### PR TITLE
fix proto for PHP 8.1

### DIFF
--- a/ext/php_driver.h
+++ b/ext/php_driver.h
@@ -56,6 +56,11 @@ typedef int pid_t;
   #endif
 #endif
 
+#ifndef ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX
+#define ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(name, return_reference, required_num_args, type, allow_null) \
+        ZEND_BEGIN_ARG_INFO_EX(name, 0, return_reference, required_num_args)
+#endif
+
 #include <ext/spl/spl_iterators.h>
 #include <ext/spl/spl_exceptions.h>
 

--- a/ext/src/Collection.c
+++ b/ext/src/Collection.c
@@ -296,6 +296,24 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO_EX(arginfo_none, 0, ZEND_RETURN_VALUE, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_current, 0, 0, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_key, 0, 0, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_next, 0, 0, IS_VOID, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_rewind, 0, 0, IS_VOID, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_valid, 0, 0, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_count, 0, 0, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
 static zend_function_entry php_driver_collection_methods[] = {
   PHP_ME(Collection, __construct, arginfo__construct, ZEND_ACC_CTOR|ZEND_ACC_PUBLIC)
   PHP_ME(Collection, type, arginfo_none, ZEND_ACC_PUBLIC)
@@ -308,13 +326,13 @@ static zend_function_entry php_driver_collection_methods[] = {
   PHP_ME(Collection, get, arginfo_index, ZEND_ACC_PUBLIC)
   PHP_ME(Collection, find, arginfo_value, ZEND_ACC_PUBLIC)
   /* Countable */
-  PHP_ME(Collection, count, arginfo_none, ZEND_ACC_PUBLIC)
+  PHP_ME(Collection, count, arginfo_count, ZEND_ACC_PUBLIC)
   /* Iterator */
-  PHP_ME(Collection, current, arginfo_none, ZEND_ACC_PUBLIC)
-  PHP_ME(Collection, key, arginfo_none, ZEND_ACC_PUBLIC)
-  PHP_ME(Collection, next, arginfo_none, ZEND_ACC_PUBLIC)
-  PHP_ME(Collection, valid, arginfo_none, ZEND_ACC_PUBLIC)
-  PHP_ME(Collection, rewind, arginfo_none, ZEND_ACC_PUBLIC)
+  PHP_ME(Collection, current, arginfo_current, ZEND_ACC_PUBLIC)
+  PHP_ME(Collection, key, arginfo_key, ZEND_ACC_PUBLIC)
+  PHP_ME(Collection, next, arginfo_next, ZEND_ACC_PUBLIC)
+  PHP_ME(Collection, valid, arginfo_valid, ZEND_ACC_PUBLIC)
+  PHP_ME(Collection, rewind, arginfo_rewind, ZEND_ACC_PUBLIC)
   PHP_ME(Collection, remove, arginfo_index, ZEND_ACC_PUBLIC)
   PHP_FE_END
 };

--- a/ext/src/Map.c
+++ b/ext/src/Map.c
@@ -426,6 +426,41 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO_EX(arginfo_none, 0, ZEND_RETURN_VALUE, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_current, 0, 0, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_key, 0, 0, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_next, 0, 0, IS_VOID, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_rewind, 0, 0, IS_VOID, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_valid, 0, 0, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_count, 0, 0, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_offsetExists, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_INFO(0, offset)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_offsetGet, 0, 1, IS_MIXED, 0)
+	ZEND_ARG_INFO(0, offset)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_offsetSet, 0, 2, IS_VOID, 0)
+	ZEND_ARG_INFO(0, offset)
+	ZEND_ARG_INFO(0, value)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_offsetUnset, 0, 1, IS_VOID, 0)
+	ZEND_ARG_INFO(0, offset)
+ZEND_END_ARG_INFO()
+
 static zend_function_entry php_driver_map_methods[] = {
   PHP_ME(Map, __construct, arginfo__construct, ZEND_ACC_CTOR|ZEND_ACC_PUBLIC)
   PHP_ME(Map, type, arginfo_none, ZEND_ACC_PUBLIC)
@@ -436,18 +471,18 @@ static zend_function_entry php_driver_map_methods[] = {
   PHP_ME(Map, remove, arginfo_one, ZEND_ACC_PUBLIC)
   PHP_ME(Map, has, arginfo_one, ZEND_ACC_PUBLIC)
   /* Countable */
-  PHP_ME(Map, count, arginfo_none, ZEND_ACC_PUBLIC)
+  PHP_ME(Map, count, arginfo_count, ZEND_ACC_PUBLIC)
   /* Iterator */
-  PHP_ME(Map, current, arginfo_none, ZEND_ACC_PUBLIC)
-  PHP_ME(Map, key, arginfo_none, ZEND_ACC_PUBLIC)
-  PHP_ME(Map, next, arginfo_none, ZEND_ACC_PUBLIC)
-  PHP_ME(Map, valid, arginfo_none, ZEND_ACC_PUBLIC)
-  PHP_ME(Map, rewind, arginfo_none, ZEND_ACC_PUBLIC)
+  PHP_ME(Map, current, arginfo_current, ZEND_ACC_PUBLIC)
+  PHP_ME(Map, key, arginfo_key, ZEND_ACC_PUBLIC)
+  PHP_ME(Map, next, arginfo_next, ZEND_ACC_PUBLIC)
+  PHP_ME(Map, valid, arginfo_valid, ZEND_ACC_PUBLIC)
+  PHP_ME(Map, rewind, arginfo_rewind, ZEND_ACC_PUBLIC)
   /* ArrayAccess */
-  PHP_ME(Map, offsetSet, arginfo_two, ZEND_ACC_PUBLIC)
-  PHP_ME(Map, offsetGet, arginfo_one, ZEND_ACC_PUBLIC)
-  PHP_ME(Map, offsetUnset, arginfo_one, ZEND_ACC_PUBLIC)
-  PHP_ME(Map, offsetExists, arginfo_one, ZEND_ACC_PUBLIC)
+  PHP_ME(Map, offsetSet, arginfo_offsetSet, ZEND_ACC_PUBLIC)
+  PHP_ME(Map, offsetGet, arginfo_offsetGet, ZEND_ACC_PUBLIC)
+  PHP_ME(Map, offsetUnset, arginfo_offsetUnset, ZEND_ACC_PUBLIC)
+  PHP_ME(Map, offsetExists, arginfo_offsetExists, ZEND_ACC_PUBLIC)
   PHP_FE_END
 };
 

--- a/ext/src/Rows.c
+++ b/ext/src/Rows.c
@@ -395,18 +395,53 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_timeout, 0, ZEND_RETURN_VALUE, 1)
 ZEND_END_ARG_INFO()
 #endif
 
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_current, 0, 0, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_key, 0, 0, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_next, 0, 0, IS_VOID, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_rewind, 0, 0, IS_VOID, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_valid, 0, 0, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_count, 0, 0, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_offsetExists, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_INFO(0, offset)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_offsetGet, 0, 1, IS_MIXED, 0)
+	ZEND_ARG_INFO(0, offset)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_offsetSet, 0, 2, IS_VOID, 0)
+	ZEND_ARG_INFO(0, offset)
+	ZEND_ARG_INFO(0, value)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_offsetUnset, 0, 1, IS_VOID, 0)
+	ZEND_ARG_INFO(0, offset)
+ZEND_END_ARG_INFO()
+
 static zend_function_entry php_driver_rows_methods[] = {
   PHP_ME(Rows, __construct,      arginfo_none,    ZEND_ACC_PUBLIC | ZEND_ACC_CTOR)
-  PHP_ME(Rows, count,            arginfo_none,    ZEND_ACC_PUBLIC)
-  PHP_ME(Rows, rewind,           arginfo_none,    ZEND_ACC_PUBLIC)
-  PHP_ME(Rows, current,          arginfo_none,    ZEND_ACC_PUBLIC)
-  PHP_ME(Rows, key,              arginfo_none,    ZEND_ACC_PUBLIC)
-  PHP_ME(Rows, next,             arginfo_none,    ZEND_ACC_PUBLIC)
-  PHP_ME(Rows, valid,            arginfo_none,    ZEND_ACC_PUBLIC)
-  PHP_ME(Rows, offsetExists,     arginfo_offset,  ZEND_ACC_PUBLIC)
-  PHP_ME(Rows, offsetGet,        arginfo_offset,  ZEND_ACC_PUBLIC)
-  PHP_ME(Rows, offsetSet,        arginfo_set,     ZEND_ACC_PUBLIC)
-  PHP_ME(Rows, offsetUnset,      arginfo_offset,  ZEND_ACC_PUBLIC)
+  PHP_ME(Rows, count,            arginfo_count,   ZEND_ACC_PUBLIC)
+  PHP_ME(Rows, rewind,           arginfo_rewind,  ZEND_ACC_PUBLIC)
+  PHP_ME(Rows, current,          arginfo_current, ZEND_ACC_PUBLIC)
+  PHP_ME(Rows, key,              arginfo_key,     ZEND_ACC_PUBLIC)
+  PHP_ME(Rows, next,             arginfo_next,    ZEND_ACC_PUBLIC)
+  PHP_ME(Rows, valid,            arginfo_valid,   ZEND_ACC_PUBLIC)
+  PHP_ME(Rows, offsetExists,     arginfo_offsetExists, ZEND_ACC_PUBLIC)
+  PHP_ME(Rows, offsetGet,        arginfo_offsetGet,    ZEND_ACC_PUBLIC)
+  PHP_ME(Rows, offsetSet,        arginfo_offsetSet,    ZEND_ACC_PUBLIC)
+  PHP_ME(Rows, offsetUnset,      arginfo_offsetUnset,  ZEND_ACC_PUBLIC)
   PHP_ME(Rows, isLastPage,       arginfo_none,    ZEND_ACC_PUBLIC)
   PHP_ME(Rows, nextPage,         arginfo_timeout, ZEND_ACC_PUBLIC)
   PHP_ME(Rows, nextPageAsync,    arginfo_none,    ZEND_ACC_PUBLIC)

--- a/ext/src/Set.c
+++ b/ext/src/Set.c
@@ -278,6 +278,24 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO_EX(arginfo_none, 0, ZEND_RETURN_VALUE, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_current, 0, 0, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_key, 0, 0, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_next, 0, 0, IS_VOID, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_rewind, 0, 0, IS_VOID, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_valid, 0, 0, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_count, 0, 0, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
 static zend_function_entry php_driver_set_methods[] = {
   PHP_ME(Set, __construct, arginfo__construct, ZEND_ACC_CTOR|ZEND_ACC_PUBLIC)
   PHP_ME(Set, type, arginfo_none, ZEND_ACC_PUBLIC)
@@ -286,13 +304,13 @@ static zend_function_entry php_driver_set_methods[] = {
   PHP_ME(Set, has, arginfo_one, ZEND_ACC_PUBLIC)
   PHP_ME(Set, remove, arginfo_one, ZEND_ACC_PUBLIC)
   /* Countable */
-  PHP_ME(Set, count, arginfo_none, ZEND_ACC_PUBLIC)
+  PHP_ME(Set, count, arginfo_count, ZEND_ACC_PUBLIC)
   /* Iterator */
-  PHP_ME(Set, current, arginfo_none, ZEND_ACC_PUBLIC)
-  PHP_ME(Set, key, arginfo_none, ZEND_ACC_PUBLIC)
-  PHP_ME(Set, next, arginfo_none, ZEND_ACC_PUBLIC)
-  PHP_ME(Set, valid, arginfo_none, ZEND_ACC_PUBLIC)
-  PHP_ME(Set, rewind, arginfo_none, ZEND_ACC_PUBLIC)
+  PHP_ME(Set, current, arginfo_current, ZEND_ACC_PUBLIC)
+  PHP_ME(Set, key, arginfo_key, ZEND_ACC_PUBLIC)
+  PHP_ME(Set, next, arginfo_next, ZEND_ACC_PUBLIC)
+  PHP_ME(Set, valid, arginfo_valid, ZEND_ACC_PUBLIC)
+  PHP_ME(Set, rewind, arginfo_rewind, ZEND_ACC_PUBLIC)
   PHP_FE_END
 };
 

--- a/ext/src/Tuple.c
+++ b/ext/src/Tuple.c
@@ -278,6 +278,23 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_index_value, 0, ZEND_RETURN_VALUE, 1)
 ZEND_END_ARG_INFO()
 #endif
 
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_current, 0, 0, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_key, 0, 0, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_next, 0, 0, IS_VOID, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_rewind, 0, 0, IS_VOID, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_valid, 0, 0, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_count, 0, 0, IS_LONG, 0)
+ZEND_END_ARG_INFO()
 
 static zend_function_entry php_driver_tuple_methods[] = {
   PHP_ME(Tuple, __construct, arginfo__construct, ZEND_ACC_CTOR|ZEND_ACC_PUBLIC)
@@ -290,13 +307,13 @@ static zend_function_entry php_driver_tuple_methods[] = {
 #endif
   PHP_ME(Tuple, get, arginfo_index, ZEND_ACC_PUBLIC)
   /* Countable */
-  PHP_ME(Tuple, count, arginfo_none, ZEND_ACC_PUBLIC)
+  PHP_ME(Tuple, count, arginfo_count, ZEND_ACC_PUBLIC)
   /* Iterator */
-  PHP_ME(Tuple, current, arginfo_none, ZEND_ACC_PUBLIC)
-  PHP_ME(Tuple, key, arginfo_none, ZEND_ACC_PUBLIC)
-  PHP_ME(Tuple, next, arginfo_none, ZEND_ACC_PUBLIC)
-  PHP_ME(Tuple, valid, arginfo_none, ZEND_ACC_PUBLIC)
-  PHP_ME(Tuple, rewind, arginfo_none, ZEND_ACC_PUBLIC)
+  PHP_ME(Tuple, current, arginfo_current, ZEND_ACC_PUBLIC)
+  PHP_ME(Tuple, key, arginfo_key, ZEND_ACC_PUBLIC)
+  PHP_ME(Tuple, next, arginfo_next, ZEND_ACC_PUBLIC)
+  PHP_ME(Tuple, valid, arginfo_valid, ZEND_ACC_PUBLIC)
+  PHP_ME(Tuple, rewind, arginfo_rewind, ZEND_ACC_PUBLIC)
   PHP_FE_END
 };
 

--- a/ext/src/UserTypeValue.c
+++ b/ext/src/UserTypeValue.c
@@ -318,6 +318,24 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO_EX(arginfo_none, 0, ZEND_RETURN_VALUE, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_current, 0, 0, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_key, 0, 0, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_next, 0, 0, IS_VOID, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_rewind, 0, 0, IS_VOID, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_valid, 0, 0, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_count, 0, 0, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
 static zend_function_entry php_driver_user_type_value_methods[] = {
   PHP_ME(UserTypeValue, __construct, arginfo__construct, ZEND_ACC_CTOR|ZEND_ACC_PUBLIC)
   PHP_ME(UserTypeValue, type, arginfo_none, ZEND_ACC_PUBLIC)
@@ -329,13 +347,13 @@ static zend_function_entry php_driver_user_type_value_methods[] = {
 #endif
   PHP_ME(UserTypeValue, get, arginfo_name, ZEND_ACC_PUBLIC)
   /* Countable */
-  PHP_ME(UserTypeValue, count, arginfo_none, ZEND_ACC_PUBLIC)
+  PHP_ME(UserTypeValue, count, arginfo_count, ZEND_ACC_PUBLIC)
   /* Iterator */
-  PHP_ME(UserTypeValue, current, arginfo_none, ZEND_ACC_PUBLIC)
-  PHP_ME(UserTypeValue, key, arginfo_none, ZEND_ACC_PUBLIC)
-  PHP_ME(UserTypeValue, next, arginfo_none, ZEND_ACC_PUBLIC)
-  PHP_ME(UserTypeValue, valid, arginfo_none, ZEND_ACC_PUBLIC)
-  PHP_ME(UserTypeValue, rewind, arginfo_none, ZEND_ACC_PUBLIC)
+  PHP_ME(UserTypeValue, current, arginfo_current, ZEND_ACC_PUBLIC)
+  PHP_ME(UserTypeValue, key, arginfo_key, ZEND_ACC_PUBLIC)
+  PHP_ME(UserTypeValue, next, arginfo_next, ZEND_ACC_PUBLIC)
+  PHP_ME(UserTypeValue, valid, arginfo_valid, ZEND_ACC_PUBLIC)
+  PHP_ME(UserTypeValue, rewind, arginfo_rewind, ZEND_ACC_PUBLIC)
   PHP_FE_END
 };
 


### PR DESCRIPTION
Without this fix:

```
Deprecated: Return type of Cassandra\Set::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0

Deprecated: Return type of Cassandra\Set::current() should either be compatible with Iterator::current(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0

Deprecated: Return type of Cassandra\Set::next() should either be compatible with Iterator::next(): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0

Deprecated: Return type of Cassandra\Set::key() should either be compatible with Iterator::key(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0

Deprecated: Return type of Cassandra\Set::valid() should either be compatible with Iterator::valid(): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0

Deprecated: Return type of Cassandra\Set::rewind() should either be compatible with Iterator::rewind(): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0

Deprecated: Return type of Cassandra\Map::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0

Deprecated: Return type of Cassandra\Map::current() should either be compatible with Iterator::current(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0

Deprecated: Return type of Cassandra\Map::next() should either be compatible with Iterator::next(): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0

Deprecated: Return type of Cassandra\Map::key() should either be compatible with Iterator::key(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0

Deprecated: Return type of Cassandra\Map::valid() should either be compatible with Iterator::valid(): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0

Deprecated: Return type of Cassandra\Map::rewind() should either be compatible with Iterator::rewind(): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0

Deprecated: Return type of Cassandra\Map::offsetExists($key) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0

Deprecated: Return type of Cassandra\Map::offsetGet($key) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0

Deprecated: Return type of Cassandra\Map::offsetSet($key, $value) should either be compatible with ArrayAccess::offsetSet(mixed $offset, mixed $value): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0

Deprecated: Return type of Cassandra\Map::offsetUnset($key) should either be compatible with ArrayAccess::offsetUnset(mixed $offset): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0

Deprecated: Return type of Cassandra\Collection::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0

Deprecated: Return type of Cassandra\Collection::current() should either be compatible with Iterator::current(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0

Deprecated: Return type of Cassandra\Collection::next() should either be compatible with Iterator::next(): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0

Deprecated: Return type of Cassandra\Collection::key() should either be compatible with Iterator::key(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0

Deprecated: Return type of Cassandra\Collection::valid() should either be compatible with Iterator::valid(): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0

Deprecated: Return type of Cassandra\Collection::rewind() should either be compatible with Iterator::rewind(): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0

Deprecated: Return type of Cassandra\Tuple::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0

Deprecated: Return type of Cassandra\Tuple::current() should either be compatible with Iterator::current(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0

Deprecated: Return type of Cassandra\Tuple::next() should either be compatible with Iterator::next(): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0

Deprecated: Return type of Cassandra\Tuple::key() should either be compatible with Iterator::key(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0

Deprecated: Return type of Cassandra\Tuple::valid() should either be compatible with Iterator::valid(): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0

Deprecated: Return type of Cassandra\Tuple::rewind() should either be compatible with Iterator::rewind(): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0

Deprecated: Return type of Cassandra\UserTypeValue::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0

Deprecated: Return type of Cassandra\UserTypeValue::current() should either be compatible with Iterator::current(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0

Deprecated: Return type of Cassandra\UserTypeValue::next() should either be compatible with Iterator::next(): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0

Deprecated: Return type of Cassandra\UserTypeValue::key() should either be compatible with Iterator::key(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0

Deprecated: Return type of Cassandra\UserTypeValue::valid() should either be compatible with Iterator::valid(): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0

Deprecated: Return type of Cassandra\UserTypeValue::rewind() should either be compatible with Iterator::rewind(): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0

Deprecated: Return type of Cassandra\Rows::current() should either be compatible with Iterator::current(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0

Deprecated: Return type of Cassandra\Rows::next() should either be compatible with Iterator::next(): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0

Deprecated: Return type of Cassandra\Rows::key() should either be compatible with Iterator::key(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0

Deprecated: Return type of Cassandra\Rows::valid() should either be compatible with Iterator::valid(): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0

Deprecated: Return type of Cassandra\Rows::rewind() should either be compatible with Iterator::rewind(): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0

Deprecated: Return type of Cassandra\Rows::offsetExists($offset) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0

Deprecated: Return type of Cassandra\Rows::offsetGet($offset) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0

Deprecated: Return type of Cassandra\Rows::offsetSet($offset, $value) should either be compatible with ArrayAccess::offsetSet(mixed $offset, mixed $value): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0

Deprecated: Return type of Cassandra\Rows::offsetUnset($offset) should either be compatible with ArrayAccess::offsetUnset(mixed $offset): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0

```