### PR TITLE
Optimize builder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,14 +42,16 @@ endif ()
 
 CPMAddPackage(
         NAME libuv
-        GITHUB_REPOSITORY libuv/libuv
+        VERSION 1.44.2
+        URL https://github.com/libuv/libuv/tarball/v1.44.2
+        URL_HASH MD5=3e22e24d53aab67252907dfa004a6b53
         OPTIONS
         "BUILD_TESTING OFF"
         "BUILD_BENCHMARKS OFF"
         "LIBUV_BUILD_SHARED ${LIBUV_BUILD_SHARED}"
         "CMAKE_C_FLAGS ${CMAKE_C_FLAGS} -fPIC"
         "CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} -fPIC"
-        GIT_TAG v1.44.2
+        
 )
 
 set(LIBUV_ROOT_DIR ${libuv_BINARY_DIR})
@@ -71,7 +73,9 @@ endif ()
 
 CPMAddPackage(
         NAME libscylladb
-        GITHUB_REPOSITORY scylladb/cpp-driver
+        VERSION 2.16.2
+        URL https://github.com/scylladb/cpp-driver/tarball/2.16.2b
+        URL_HASH MD5=67e6c74cdd6c9692b2745bfc28dccdaa
         OPTIONS
         "CASS_CPP_STANDARD 17"
         "CASS_BUILD_STATIC ${CASS_BUILD_STATIC}"
@@ -84,7 +88,6 @@ CPMAddPackage(
         "CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} -fPIC"
         "LIBUV_LIBRARY ${LIBUV_LIBRARY}"
         "LIBUV_INCLUDE_DIR ${libuv_SOURCE_DIR}/include"
-        GIT_TAG 2.16.2b
 )
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,28 +12,26 @@ COPY . /ext-scylladb
 
 WORKDIR /ext-scylladb
 
-RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"  \
-    && php composer-setup.php \
-    && php -r "unlink('composer-setup.php');" \
-    && mv composer.phar /bin/composer \
-    && docker-php-source extract \
-    && apt update -y \
-    && apt install \
+RUN apt update -y \
+    && apt install -y \
         python3 \
         python3-pip \
         unzip \
         mlocate \
         build-essential \
         ninja-build \
-        git \
         libssl-dev \
         libgmp-dev \
         zlib1g-dev \
         openssl \
-        libpcre3-dev -y \
+        libpcre3-dev \
     && pip3 install cmake \
-    && install-php-extensions intl zip pcntl gmp \
-    && docker-php-source delete \
+    && install-php-extensions \
+        intl \
+        zip \
+        pcntl \
+        gmp \
+        @composer \
     && apt-get clean \
 
 FROM base as build


### PR DESCRIPTION
- Use tarball for faster download dependencies.
- Now git is not needed for building.