### PR TITLE
parser_state and token_type One Definition C++ Rule warnings

### DIFF
--- a/util/src/inet.cpp
+++ b/util/src/inet.cpp
@@ -30,9 +30,9 @@
                           ip_address_describe_token(type), ((int)(in_ptr - in) - 1), in);       \
   return 0;
 
-enum token_type { TOKEN_END = 0, TOKEN_COLON, TOKEN_DOT, TOKEN_HEX, TOKEN_DEC, TOKEN_ILLEGAL };
+enum ip_address_token_type { TOKEN_END = 0, TOKEN_COLON, TOKEN_DOT, TOKEN_HEX, TOKEN_DEC, TOKEN_ILLEGAL };
 
-enum parser_state {
+enum inet_parser_state {
   STATE_START = 0,
   STATE_FIELD = 1,
   STATE_COMPRESSED = 2,
@@ -44,7 +44,7 @@ enum parser_state {
   STATE_END = 8
 };
 
-static const char *ip_address_describe_token(enum token_type type) {
+static const char *ip_address_describe_token(enum ip_address_token_type type) {
   switch (type) {
     case TOKEN_END:
       return "end of address";
@@ -63,9 +63,9 @@ static const char *ip_address_describe_token(enum token_type type) {
   }
 }
 
-static enum token_type ip_address_tokenize(char *address, char *token, int *token_len,
+static enum ip_address_token_type ip_address_tokenize(char *address, char *token, int *token_len,
                                            char **next_token) {
-  enum token_type type;
+  enum ip_address_token_type type;
 
   char ch;
   int len = 0;
@@ -123,8 +123,8 @@ int php_driver_parse_ip_address(char *in, CassInet *inet) {
   int token_len = -1;
   int prev_token_len = 0;
   char *in_ptr = in;
-  enum token_type type;
-  enum parser_state state = STATE_START;
+  enum ip_address_token_type type;
+  enum inet_parser_state state = STATE_START;
   int pos = -1;
   int compress_pos = -1;
   int ipv4_pos = -1;
@@ -430,3 +430,4 @@ void php_driver_format_address(CassInet inet, char **out) {
     spprintf(out, 0, "%d.%d.%d.%d", inet.address[0], inet.address[1], inet.address[2],
              inet.address[3]);
 }
+

--- a/util/src/types.cpp
+++ b/util/src/types.cpp
@@ -872,7 +872,7 @@ zval php_driver_type_custom(const char* name, size_t name_length) {
                           describe_token(token), ((int)(str - validator) - 1), validator);     \
   return FAILURE;
 
-enum token_type {
+enum describe_token_type {
   TOKEN_ILLEGAL = 0,
   TOKEN_PAREN_OPEN,
   TOKEN_PAREN_CLOSE,
@@ -882,9 +882,9 @@ enum token_type {
   TOKEN_END
 };
 
-enum parser_state { STATE_CLASS = 0, STATE_AFTER_CLASS, STATE_AFTER_PARENS, STATE_END };
+enum types_parser_state { STATE_CLASS = 0, STATE_AFTER_CLASS, STATE_AFTER_PARENS, STATE_END };
 
-static const char* describe_token(enum token_type token) {
+static const char* describe_token(enum describe_token_type token) {
   switch (token) {
     case TOKEN_ILLEGAL:
       return "illegal character";
@@ -907,9 +907,9 @@ static const char* describe_token(enum token_type token) {
 
 static int isletter(char ch) { return isalnum(ch) || ch == '.'; }
 
-static enum token_type next_token(const char* str, size_t len, const char** token_str,
+static enum describe_token_type next_token(const char* str, size_t len, const char** token_str,
                                   size_t* token_len, const char** str_out, size_t* len_out) {
-  enum token_type type;
+  enum describe_token_type type;
   unsigned int i = 0;
   char c = str[i];
 
@@ -994,8 +994,8 @@ static int php_driver_parse_class_name(const char* validator, size_t validator_l
   size_t len;
   const char* token_str;
   size_t token_len;
-  enum parser_state state;
-  enum token_type token;
+  enum types_parser_state state;
+  enum describe_token_type token;
   struct node_s* root;
   struct node_s* node;
   struct node_s* child;
@@ -1350,3 +1350,4 @@ int php_driver_parse_column_type(const char* validator, size_t validator_len, in
 
   return SUCCESS;
 }
+


### PR DESCRIPTION
Renamed ENUM's to surpress `C++ One Definition Rule` Warnings.

```
scylladb-php-driver/util/src/inet.cpp:33:6: warning: type ‘token_type’ violates the C++ One Definition Rule [-Wodr]
   33 | enum token_type { TOKEN_END = 0, TOKEN_COLON, TOKEN_DOT, TOKEN_HEX, TOKEN_DEC, TOKEN_ILLEGAL };
      |      ^
scylladb-php-driver/util/src/types.cpp:875:6: note: an enum with different value name is defined in another translation unit
  875 | enum token_type {
      |      ^
scylladb-php-driver/util/src/inet.cpp:33:19: note: name ‘TOKEN_END’ differs from name ‘TOKEN_ILLEGAL’ defined in another translation unit
   33 | enum token_type { TOKEN_END = 0, TOKEN_COLON, TOKEN_DOT, TOKEN_HEX, TOKEN_DEC, TOKEN_ILLEGAL };
      |                   ^
scylladb-php-driver/util/src/types.cpp:876:3: note: mismatching definition
  876 |   TOKEN_ILLEGAL = 0,
      |   ^
scylladb-php-driver/util/src/inet.cpp:35:6: warning: type ‘parser_state’ violates the C++ One Definition Rule [-Wodr]
   35 | enum parser_state {
      |      ^
scylladb-php-driver/util/src/types.cpp:885:6: note: an enum with different value name is defined in another translation unit
  885 | enum parser_state { STATE_CLASS = 0, STATE_AFTER_CLASS, STATE_AFTER_PARENS, STATE_END };
      |      ^
scylladb-php-driver/util/src/inet.cpp:36:3: note: name ‘STATE_START’ differs from name ‘STATE_CLASS’ defined in another translation unit
   36 |   STATE_START = 0,
      |   ^
scylladb-php-driver/util/src/types.cpp:885:21: note: mismatching definition
  885 | enum parser_state { STATE_CLASS = 0, STATE_AFTER_CLASS, STATE_AFTER_PARENS, STATE_END };
```