### PR TITLE
Fix missing symbols from math.cpp

### DIFF
--- a/docs/Cassandra/Bigint.php
+++ b/docs/Cassandra/Bigint.php
@@ -26,7 +26,7 @@ final class Bigint implements Value, Numeric {
     /**
      * Creates a new 64bit integer.
      *
-     * @param string $value integer value as a string
+     * @param string|int|float|Bigint $value integer value
      */
     public function __construct($value) { }
 

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -9,6 +9,7 @@ target_sources(
         src/future.cpp
         src/hash.cpp
         src/inet.cpp
+        src/math.cpp
         src/ref.cpp
         src/result.cpp
         src/types.cpp

--- a/util/math.h
+++ b/util/math.h
@@ -22,6 +22,7 @@ void import_twos_complement(cass_byte_t* data, size_t size, mpz_t* number);
 cass_byte_t* export_twos_complement(mpz_t number, size_t* size);
 
 int php_driver_parse_float(char* in, int in_len, cass_float_t* number);
+int php_driver_parse_double(char* in, int in_len, cass_double_t* number);
 int php_driver_parse_int(char* in, int in_len, cass_int32_t* number);
 int php_driver_parse_bigint(char* in, int in_len, cass_int64_t* number);
 int php_driver_parse_varint(char* in, int in_len, mpz_t* number);

--- a/util/math.h
+++ b/util/math.h
@@ -22,7 +22,6 @@ void import_twos_complement(cass_byte_t* data, size_t size, mpz_t* number);
 cass_byte_t* export_twos_complement(mpz_t number, size_t* size);
 
 int php_driver_parse_float(char* in, int in_len, cass_float_t* number);
-int php_driver_parse_double(char* in, int in_len, cass_double_t* number);
 int php_driver_parse_int(char* in, int in_len, cass_int32_t* number);
 int php_driver_parse_bigint(char* in, int in_len, cass_int64_t* number);
 int php_driver_parse_varint(char* in, int in_len, mpz_t* number);

--- a/util/src/math.cpp
+++ b/util/src/math.cpp
@@ -82,32 +82,6 @@ php_driver_parse_float(char* in, int in_len, cass_float_t* number )
 }
 
 int
-php_driver_parse_double(char* in, int in_len, cass_double_t* number )
-{
-  char* end;
-  errno = 0;
-
-  *number = (cass_double_t) strtod(in, &end);
-
-  if (errno == ERANGE) {
-    zend_throw_exception_ex(php_driver_range_exception_ce, 0 , "Value is too small or too big for double: '%s'", in);
-    return 0;
-  }
-
-  if (errno || end == in) {
-    zend_throw_exception_ex(php_driver_invalid_argument_exception_ce, 0 , "Invalid double value: '%s'", in);
-    return 0;
-  }
-
-  if (end != &in[in_len]) {
-    zend_throw_exception_ex(php_driver_invalid_argument_exception_ce, 0 , "Invalid characters were found in value: '%s'", in);
-    return 0;
-  }
-
-  return 1;
-}
-
-int
 php_driver_parse_int(char* in, int in_len, cass_int32_t* number )
 {
   char* end          = NULL;

--- a/util/src/math.cpp
+++ b/util/src/math.cpp
@@ -164,7 +164,7 @@ php_driver_parse_bigint(char* in, int in_len, cass_int64_t* number )
 
   if (errno == ERANGE) {
     zend_throw_exception_ex(php_driver_range_exception_ce, 0 ,
-                            "value must be between " LL_FORMAT " and " LL_FORMAT ", %s given", INT64_MIN, INT64_MAX, in);
+                            "value must be between %" PRId64 " and %" PRId64 ", %s given", INT64_MIN, INT64_MAX, in);
     return 0;
   }
 

--- a/util/src/math.cpp
+++ b/util/src/math.cpp
@@ -572,7 +572,7 @@ export_twos_complement(mpz_t number, size_t* size)
 
     /* round to the nearest byte and add space for a leading 0 byte */
     *size    = (mpz_sizeinbase(number, 2) + 7) / 8 + 1;
-    bytes    = malloc(*size);
+    bytes    = (cass_byte_t*) malloc(*size);
     bytes[0] = 0;
     mpz_export(bytes + 1, NULL, 1, sizeof(cass_byte_t), 1, 0, number);
   }

--- a/util/src/math.cpp
+++ b/util/src/math.cpp
@@ -82,6 +82,32 @@ php_driver_parse_float(char* in, int in_len, cass_float_t* number )
 }
 
 int
+php_driver_parse_double(char* in, int in_len, cass_double_t* number )
+{
+  char* end;
+  errno = 0;
+
+  *number = (cass_double_t) strtod(in, &end);
+
+  if (errno == ERANGE) {
+    zend_throw_exception_ex(php_driver_range_exception_ce, 0 , "Value is too small or too big for double: '%s'", in);
+    return 0;
+  }
+
+  if (errno || end == in) {
+    zend_throw_exception_ex(php_driver_invalid_argument_exception_ce, 0 , "Invalid double value: '%s'", in);
+    return 0;
+  }
+
+  if (end != &in[in_len]) {
+    zend_throw_exception_ex(php_driver_invalid_argument_exception_ce, 0 , "Invalid characters were found in value: '%s'", in);
+    return 0;
+  }
+
+  return 1;
+}
+
+int
 php_driver_parse_int(char* in, int in_len, cass_int32_t* number )
 {
   char* end          = NULL;


### PR DESCRIPTION
If someone would use string for the Bigint constructer then glibc would fail to find `_Z23php_driver_parse_bigintPciPl` (`php_driver_parse_bigint(char*, int, long*)`) because math.cpp was never compiled and linked to the shared object.

That also included other users of:

* php_driver_parse_float
* php_driver_parse_bigint
* php_driver_parse_varint
* php_driver_format_integer
* php_driver_format_decimal
* import_twos_complement

for example:

* Cassandra\Bigint
* Cassandra\Decimal
* Cassandra\Float
* Cassandra\Time
* Cassandra\Varint

---

Reproducer:

```
cat > test.php << "EOF"
<?php

$foo = new \Cassandra\Bigint('0');
EOF
php test.php
```

Error output:

```
php: symbol lookup error: /usr/lib/php/20220829/cassandra.so: undefined symbol: _Z23php_driver_parse_bigintPciPl
```