### PR TITLE
Add bounds checking to prevent overflow warnings during build.

### DIFF
--- a/util/src/inet.cpp
+++ b/util/src/inet.cpp
@@ -379,8 +379,16 @@ int php_driver_parse_ip_address(char *in, CassInet *inet) {
         int src_pos = compress_pos + move_len - i - 1;
         int dst_pos = CASS_INET_V6_LENGTH - i - 1;
 
-        address[dst_pos] = address[src_pos];
-        address[src_pos] = 0;
+        // Bounds check for src_pos and dst_pos to prevent string overflow
+        if (src_pos >= 0 && src_pos < CASS_INET_V6_LENGTH && dst_pos >= 0 && dst_pos < CASS_INET_V6_LENGTH) {
+          address[dst_pos] = address[src_pos];
+          address[src_pos] = 0;
+        } else {
+          // Throw exception if out of bounds
+          zend_throw_exception_ex(php_driver_invalid_argument_exception_ce, 0,
+                              "Index out of bounds: src_pos = %d, dst_pos = %d, array size = %d",
+                              src_pos, dst_pos, CASS_INET_V6_LENGTH);
+        }
       }
     }
 


### PR DESCRIPTION
Added bounds checking to `util/src/inet.cpp` to prevent overflow warnings during build.

Received the following warnings on Debian 12 when installing with the build command: `cmake --preset Release -DPHP_SCYLLADB_OPTIMISE_FOR_CURRENT_MACHINE=ON -DPHP_SCYLLADB_USE_LIBCASSANDRA=ON -DPHP_SCYLLADB_LIBUV_STATIC=ON && cd out/Release && sudo ninja install`

```
-- Build files have been written to: /home/dev/scylladb-php-driver/out/Release
[166/167] Linking CXX shared library cassandra.so
/home/dev/scylladb-php-driver/util/src/inet.cpp: In function ‘php_driver_parse_ip_address’:
/home/dev/scylladb-php-driver/util/src/inet.cpp:383:26: warning: writing 16 bytes into a region of size 0 [-Wstringop-overflow=]
  383 |         address[src_pos] = 0;
      |                          ^
/home/dev/scylladb-php-driver/util/src/inet.cpp:132:16: note: at offset [-2147483663, -1] into destination object ‘address’ of size 16
  132 |   cass_uint8_t address[CASS_INET_V6_LENGTH] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
      |                ^
/home/dev/scylladb-php-driver/util/src/inet.cpp:383:26: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
  383 |         address[src_pos] = 0;
      |                          ^
/home/dev/scylladb-php-driver/util/src/inet.cpp:132:16: note: at offset [-2147483648, -2] into destination object ‘address’ of size 16
  132 |   cass_uint8_t address[CASS_INET_V6_LENGTH] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
      |                ^
/home/dev/scylladb-php-driver/util/src/inet.cpp:383:26: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
  383 |         address[src_pos] = 0;
      |                          ^
/home/dev/scylladb-php-driver/util/src/inet.cpp:132:16: note: at offset [-2147483648, -3] into destination object ‘address’ of size 16
  132 |   cass_uint8_t address[CASS_INET_V6_LENGTH] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
      |                ^
/home/dev/scylladb-php-driver/util/src/inet.cpp:383:26: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
  383 |         address[src_pos] = 0;
      |                          ^
/home/dev/scylladb-php-driver/util/src/inet.cpp:132:16: note: at offset [-2147483648, -4] into destination object ‘address’ of size 16
  132 |   cass_uint8_t address[CASS_INET_V6_LENGTH] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
      |                ^
/home/dev/scylladb-php-driver/util/src/inet.cpp:383:26: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
  383 |         address[src_pos] = 0;
      |                          ^
/home/dev/scylladb-php-driver/util/src/inet.cpp:132:16: note: at offset [-2147483648, -5] into destination object ‘address’ of size 16
  132 |   cass_uint8_t address[CASS_INET_V6_LENGTH] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
      |                ^
/home/dev/scylladb-php-driver/util/src/inet.cpp:383:26: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
  383 |         address[src_pos] = 0;
      |                          ^
/home/dev/scylladb-php-driver/util/src/inet.cpp:132:16: note: at offset [-2147483648, -6] into destination object ‘address’ of size 16
  132 |   cass_uint8_t address[CASS_INET_V6_LENGTH] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
      |                ^
/home/dev/scylladb-php-driver/util/src/inet.cpp:383:26: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
  383 |         address[src_pos] = 0;
      |                          ^
/home/dev/scylladb-php-driver/util/src/inet.cpp:132:16: note: at offset [-2147483648, -1] into destination object ‘address’ of size 16
  132 |   cass_uint8_t address[CASS_INET_V6_LENGTH] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
  ```