### PR TITLE
build(macos): harden cpp-driver/libuv build and allow side-by-side drivers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,21 +30,51 @@ set(PHP_SCYLLADB_DRIVER_VERSION "${PROJECT_VERSION}-dev")
 # Homebrew on Apple Silicon installs to /opt/homebrew; on Intel to /usr/local.
 # Adding the prefix to CMAKE_PREFIX_PATH lets find_package / pkg-config locate
 # libraries without requiring the user to set PKG_CONFIG_PATH manually.
+#
+# Several formulae we depend on are keg-only (openssl@3, libuv, libssh2, gmp)
+# — their headers/pkgconfig live under their own prefix, not the global one —
+# so we probe each individually and add them too.
 if (APPLE)
-    execute_process(
-            COMMAND brew --prefix
-            OUTPUT_VARIABLE _brew_prefix
-            OUTPUT_STRIP_TRAILING_WHITESPACE
-            ERROR_QUIET
-            RESULT_VARIABLE _brew_rc
-    )
-    if (_brew_rc EQUAL 0 AND _brew_prefix)
-        list(PREPEND CMAKE_PREFIX_PATH "${_brew_prefix}")
-        set(ENV{PKG_CONFIG_PATH} "${_brew_prefix}/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}")
-        message(STATUS "Homebrew prefix: ${_brew_prefix}")
+    function(_scylladb_add_brew_prefix formula)
+        execute_process(
+                COMMAND brew --prefix ${formula}
+                OUTPUT_VARIABLE _p
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                ERROR_QUIET
+                RESULT_VARIABLE _rc
+        )
+        if (_rc EQUAL 0 AND _p AND IS_DIRECTORY "${_p}")
+            list(PREPEND CMAKE_PREFIX_PATH "${_p}")
+            set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH}" PARENT_SCOPE)
+            set(ENV{PKG_CONFIG_PATH} "${_p}/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}")
+            message(STATUS "Homebrew prefix [${formula}]: ${_p}")
+        endif ()
+    endfunction()
+
+    _scylladb_add_brew_prefix("")          # global brew prefix
+    _scylladb_add_brew_prefix(openssl@3)
+    _scylladb_add_brew_prefix(libuv)
+    _scylladb_add_brew_prefix(libssh2)
+    _scylladb_add_brew_prefix(gmp)
+endif ()
+
+# ── C++ driver prefix selection ──────────────────────────────────────────────
+# When the cpp-driver is installed under a non-standard location (e.g.
+# /usr/local/scylladb or /usr/local/cassandra from scripts/compile-cpp-driver.sh
+# with the per-driver layout), prepend its pkgconfig dir so FindCPPDriver picks
+# the intended one — this is also how you switch between scylladb / cassandra
+# when both are installed side by side.
+set(CPP_DRIVER_PREFIX "" CACHE PATH
+        "Install prefix where the chosen cpp-driver was installed \
+(e.g. /usr/local/scylladb or /usr/local/cassandra). \
+Its lib/pkgconfig dir is prepended to PKG_CONFIG_PATH.")
+if (CPP_DRIVER_PREFIX)
+    if (NOT IS_DIRECTORY "${CPP_DRIVER_PREFIX}")
+        message(WARNING "CPP_DRIVER_PREFIX='${CPP_DRIVER_PREFIX}' does not exist")
     endif ()
-    unset(_brew_prefix)
-    unset(_brew_rc)
+    list(PREPEND CMAKE_PREFIX_PATH "${CPP_DRIVER_PREFIX}")
+    set(ENV{PKG_CONFIG_PATH} "${CPP_DRIVER_PREFIX}/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}")
+    message(STATUS "CPP driver prefix: ${CPP_DRIVER_PREFIX}")
 endif ()
 
 # ── Library options ───────────────────────────────────────────────────────────
@@ -86,6 +116,32 @@ find_package(PHP      REQUIRED)
 include(cmake/PhpExtensionHelpers.cmake)
 
 if (ENABLE_SANITIZERS)
+    set(_sanitizers_cmake_dir "${PROJECT_SOURCE_DIR}/third-party/sanitizers-cmake/cmake")
+    if (NOT EXISTS "${_sanitizers_cmake_dir}/FindSanitizers.cmake")
+        # Submodule not initialized — try to init it automatically when we're
+        # inside a git checkout; otherwise tell the user exactly what to run.
+        find_package(Git QUIET)
+        if (Git_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.gitmodules")
+            message(STATUS "Initializing third-party/sanitizers-cmake submodule")
+            execute_process(
+                COMMAND "${GIT_EXECUTABLE}" submodule update --init --recursive
+                        third-party/sanitizers-cmake
+                WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
+                RESULT_VARIABLE _sm_rc
+            )
+        else ()
+            set(_sm_rc 1)
+        endif ()
+        if (NOT EXISTS "${_sanitizers_cmake_dir}/FindSanitizers.cmake")
+            message(FATAL_ERROR
+                "ENABLE_SANITIZERS=ON but third-party/sanitizers-cmake is missing.\n"
+                "Run: git submodule update --init --recursive\n"
+                "Or disable with: -DENABLE_SANITIZERS=OFF"
+            )
+        endif ()
+        unset(_sm_rc)
+    endif ()
+    unset(_sanitizers_cmake_dir)
     find_package(Sanitizers REQUIRED)
 endif ()
 

--- a/cmake/FindCPPDriver.cmake
+++ b/cmake/FindCPPDriver.cmake
@@ -3,33 +3,56 @@ include(FindPackageHandleStandardArgs)
 
 find_package(PkgConfig REQUIRED)
 
+# Pick driver + linkage → pkg-config module name.
 if (USE_LIBCASSANDRA)
+    set(_cpp_driver_label "DataStax cassandra")
     if (PHP_DRIVER_STATIC)
-        pkg_check_modules(LIBCASSANDRA REQUIRED IMPORTED_TARGET cassandra_static)
+        set(_cpp_driver_pc "cassandra_static")
     else ()
-        pkg_check_modules(LIBCASSANDRA REQUIRED IMPORTED_TARGET cassandra)
+        set(_cpp_driver_pc "cassandra")
     endif ()
-    set(_cpp_driver_underlying PkgConfig::LIBCASSANDRA)
-    set(_cpp_driver_version    "${LIBCASSANDRA_VERSION}")
 else ()
+    set(_cpp_driver_label "ScyllaDB cpp-driver")
     if (PHP_DRIVER_STATIC)
-        pkg_check_modules(LIBSCYLLADB REQUIRED IMPORTED_TARGET scylla-cpp-driver_static)
+        set(_cpp_driver_pc "scylla-cpp-driver_static")
     else ()
-        pkg_check_modules(LIBSCYLLADB REQUIRED IMPORTED_TARGET scylla-cpp-driver)
+        set(_cpp_driver_pc "scylla-cpp-driver")
     endif ()
-    set(_cpp_driver_underlying PkgConfig::LIBSCYLLADB)
-    set(_cpp_driver_version    "${LIBSCYLLADB_VERSION}")
 endif ()
+
+pkg_check_modules(LIBCPPDRIVER QUIET IMPORTED_TARGET "${_cpp_driver_pc}")
+
+if (NOT LIBCPPDRIVER_FOUND)
+    if (USE_LIBCASSANDRA)
+        set(_install_hint "cassandra")
+    else ()
+        set(_install_hint "scylladb")
+    endif ()
+    message(FATAL_ERROR
+        "Could not find ${_cpp_driver_label} via pkg-config module '${_cpp_driver_pc}'.\n"
+        "Hints:\n"
+        "  * Install it with: scripts/compile-cpp-driver.sh --driver ${_install_hint}\n"
+        "  * Then point CMake at the install prefix with:\n"
+        "      -DCPP_DRIVER_PREFIX=<prefix>   (e.g. /usr/local/${_install_hint})\n"
+        "  * To use the DataStax driver instead, pass: -DUSE_LIBCASSANDRA=ON\n"
+        "  * To link statically, pass: -DPHP_DRIVER_STATIC=ON (expects '${_cpp_driver_pc}.pc')\n"
+        "Current PKG_CONFIG_PATH: $ENV{PKG_CONFIG_PATH}"
+    )
+endif ()
+
+set(_cpp_driver_version "${LIBCPPDRIVER_VERSION}")
 
 # ── Create CppDriver::Driver INTERFACE IMPORTED target ───────────────────────
 if (NOT TARGET CppDriver::Driver)
     add_library(CppDriver::Driver INTERFACE IMPORTED GLOBAL)
-    target_link_libraries(CppDriver::Driver INTERFACE "${_cpp_driver_underlying}")
+    target_link_libraries(CppDriver::Driver INTERFACE PkgConfig::LIBCPPDRIVER)
 endif ()
-unset(_cpp_driver_underlying)
 
 find_package_handle_standard_args(CPPDriver
         REQUIRED_VARS _cpp_driver_version
         VERSION_VAR   _cpp_driver_version
 )
+
 unset(_cpp_driver_version)
+unset(_cpp_driver_label)
+unset(_cpp_driver_pc)

--- a/scripts/compile-cpp-driver.sh
+++ b/scripts/compile-cpp-driver.sh
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 DRIVER="scylladb"
-INSTALL_PREFIX="/usr/local"
+INSTALL_PREFIX=""
+LAYOUT="per-driver"   # per-driver | flat
 BUILD_DIR=""
 KEEP_SRC=0
 BUILD_TYPE="RelWithDebInfo"
@@ -14,28 +15,46 @@ print_usage() {
 Usage: $(basename "$0") [OPTIONS]
 
 Options:
-  --driver NAME     Driver to build: scylladb (default) or cassandra
-  --prefix PATH     Install prefix (default: /usr/local)
-  --ref GIT_REF     Git branch/tag/commit to check out (default: HEAD of default branch)
-  --build-type TYPE CMake build type: Debug|Release|RelWithDebInfo (default: RelWithDebInfo)
-  --build-dir PATH  Temporary build directory (default: auto in /tmp)
-  --keep-src        Keep source directory after install
-  -h, --help        Show this help
+  --driver NAME       Driver to build: scylladb (default) or cassandra
+  --prefix PATH       Install prefix root (default: /usr/local)
+                      With --layout per-driver, the driver installs to <prefix>/<driver>
+                      so scylladb and cassandra can coexist.
+  --layout LAYOUT     per-driver (default) | flat
+                      per-driver: install to <prefix>/<driver>
+                      flat:       install directly to <prefix> (old behavior; may overwrite)
+  --ref GIT_REF       Git branch/tag/commit to check out (default: HEAD of default branch)
+  --build-type TYPE   CMake build type: Debug|Release|RelWithDebInfo (default: RelWithDebInfo)
+  --build-dir PATH    Temporary build directory (default: auto in /tmp)
+  --keep-src          Keep source directory after install
+  -h, --help          Show this help
 
 Examples:
-  $(basename "$0")                                  # scylladb driver to /usr/local
-  $(basename "$0") --driver cassandra --prefix \$HOME/.local
-  $(basename "$0") --prefix /opt/scylladb --build-type Release
+  $(basename "$0")                                          # scylladb -> /usr/local/scylladb
+  $(basename "$0") --driver cassandra                       # cassandra -> /usr/local/cassandra
+  $(basename "$0") --driver cassandra --prefix \$HOME/.local # -> ~/.local/cassandra
+  $(basename "$0") --layout flat --prefix /opt/scylladb     # legacy flat install
+
+After install, point the PHP extension at it via:
+  cmake --preset DebugPHP8.4NTS -DCPP_DRIVER_PREFIX=<prefix>/<driver>
 
 EOF
 }
 
 die() { echo "ERROR: $*" >&2; exit 1; }
 
+# sudo-if-needed wrapper for Linux package managers
+SUDO=""
+maybe_sudo() {
+    if [[ $EUID -ne 0 ]] && command -v sudo >/dev/null 2>&1; then
+        SUDO="sudo"
+    fi
+}
+
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --driver)     DRIVER="${2:?--driver requires a value}"; shift 2 ;;
         --prefix)     INSTALL_PREFIX="${2:?--prefix requires a value}"; shift 2 ;;
+        --layout)     LAYOUT="${2:?--layout requires a value}"; shift 2 ;;
         --ref)        GIT_REF="${2:?--ref requires a value}"; shift 2 ;;
         --build-type) BUILD_TYPE="${2:?--build-type requires a value}"; shift 2 ;;
         --build-dir)  BUILD_DIR="${2:?--build-dir requires a value}"; shift 2 ;;
@@ -47,31 +66,62 @@ done
 
 [[ "$DRIVER" == "scylladb" || "$DRIVER" == "cassandra" ]] \
     || die "Invalid --driver '$DRIVER'. Must be 'scylladb' or 'cassandra'."
+[[ "$LAYOUT" == "per-driver" || "$LAYOUT" == "flat" ]] \
+    || die "Invalid --layout '$LAYOUT'. Must be 'per-driver' or 'flat'."
+
+# Default prefix root
+: "${INSTALL_PREFIX:=/usr/local}"
+
+# Resolve final install path
+if [[ "$LAYOUT" == "per-driver" ]]; then
+    FINAL_PREFIX="$INSTALL_PREFIX/$DRIVER"
+else
+    FINAL_PREFIX="$INSTALL_PREFIX"
+fi
 
 command -v cmake >/dev/null 2>&1 || die "cmake not found in PATH"
 command -v git   >/dev/null 2>&1 || die "git not found in PATH"
 command -v ninja >/dev/null 2>&1 || die "ninja not found in PATH"
 
-GIT_REPO="https://github.com/${DRIVER}/cpp-driver.git"
+case "$DRIVER" in
+    scylladb)  GIT_REPO="https://github.com/scylladb/cpp-driver.git" ;;
+    cassandra) GIT_REPO="https://github.com/apache/cassandra-cpp-driver.git" ;;
+esac
+
+# Populated by install_system_deps on macOS so we can pass them to cmake.
+OPENSSL_ROOT=""
+LIBSSH2_ROOT=""
+LIBUV_ROOT=""
+ZLIB_ROOT=""
 
 install_system_deps() {
     case "$(uname -s)" in
         Darwin)
             echo "==> Installing build deps (macOS)"
             command -v brew >/dev/null 2>&1 || die "Homebrew not found. Install from https://brew.sh"
-            brew install cmake ninja pkg-config openssl
+            brew install cmake ninja pkg-config openssl@3 libssh2 libuv zlib
+
+            # Capture keg-only formula prefixes so cmake can find them.
+            OPENSSL_ROOT="$(brew --prefix openssl@3 2>/dev/null || true)"
+            LIBSSH2_ROOT="$(brew --prefix libssh2 2>/dev/null || true)"
+            LIBUV_ROOT="$(brew --prefix libuv 2>/dev/null || true)"
+            ZLIB_ROOT="$(brew --prefix zlib 2>/dev/null || true)"
             ;;
         Linux)
+            maybe_sudo
             # shellcheck source=/dev/null
             . /etc/os-release 2>/dev/null || return
             case "${ID:-}" in
                 fedora)
                     echo "==> Installing build deps (Fedora)"
-                    dnf install -y cmake pkg-config gcc ninja-build openssl-devel openssl-devel-engine
+                    $SUDO dnf install -y cmake pkg-config gcc ninja-build \
+                        openssl-devel openssl-devel-engine libssh2-devel libuv-devel zlib-devel
                     ;;
                 ubuntu|debian)
                     echo "==> Installing build deps (Ubuntu/Debian)"
-                    apt-get install -y pkg-config build-essential libssl-dev
+                    $SUDO apt-get update
+                    $SUDO apt-get install -y pkg-config build-essential cmake ninja-build \
+                        libssl-dev libssh2-1-dev libuv1-dev zlib1g-dev
                     ;;
                 *)
                     echo "WARN: Unknown distro '${ID:-}', skipping automatic dep install" >&2
@@ -110,23 +160,34 @@ fi
 
 NPROC="$(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 4)"
 
-# timerfd is Linux-only — must be OFF on macOS
+# timerfd is Linux-only — must be OFF on macOS.
 TIMERFD="ON"
 [[ "$(uname -s)" == "Darwin" ]] && TIMERFD="OFF"
 
-echo "==> Configuring (prefix=$INSTALL_PREFIX, build=$BUILD_TYPE)"
-CFLAGS="-fPIC" \
-CXXFLAGS="-fPIC -Wno-error=redundant-move" \
-LDFLAGS="-flto" \
-LIBUV_ROOT_DIR_DETECTED=""
-if command -v brew >/dev/null 2>&1; then
-    LIBUV_ROOT_DIR_DETECTED="$(brew --prefix libuv 2>/dev/null || true)"
+# Build up cmake hint args for keg-only / non-default deps.
+CMAKE_DEP_HINTS=()
+[[ -n "$OPENSSL_ROOT"  ]] && CMAKE_DEP_HINTS+=( "-DOPENSSL_ROOT_DIR=$OPENSSL_ROOT" )
+[[ -n "$LIBSSH2_ROOT"  ]] && CMAKE_DEP_HINTS+=( "-DLIBSSH2_ROOT_DIR=$LIBSSH2_ROOT" )
+[[ -n "$LIBUV_ROOT"    ]] && CMAKE_DEP_HINTS+=( "-DLIBUV_ROOT_DIR=$LIBUV_ROOT" )
+[[ -n "$ZLIB_ROOT"     ]] && CMAKE_DEP_HINTS+=( "-DZLIB_ROOT=$ZLIB_ROOT" )
+
+# Compose CMAKE_PREFIX_PATH from the keg-only roots (helps modern find_package).
+PREFIX_PATH_ENTRIES=()
+for r in "$OPENSSL_ROOT" "$LIBSSH2_ROOT" "$LIBUV_ROOT" "$ZLIB_ROOT"; do
+    [[ -n "$r" ]] && PREFIX_PATH_ENTRIES+=( "$r" )
+done
+if [[ ${#PREFIX_PATH_ENTRIES[@]} -gt 0 ]]; then
+    PREFIX_PATH_JOINED="$(IFS=';'; echo "${PREFIX_PATH_ENTRIES[*]}")"
+    CMAKE_DEP_HINTS+=( "-DCMAKE_PREFIX_PATH=$PREFIX_PATH_JOINED" )
 fi
 
+echo "==> Configuring (prefix=$FINAL_PREFIX, build=$BUILD_TYPE, layout=$LAYOUT)"
 cmake -G Ninja -B "$SRC_DIR/build" -S "$SRC_DIR" \
+    -DCMAKE_C_FLAGS="-fPIC" \
+    -DCMAKE_CXX_FLAGS="-fPIC -Wno-error=redundant-move" \
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
     -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
-    ${LIBUV_ROOT_DIR_DETECTED:+-DLIBUV_ROOT_DIR="$LIBUV_ROOT_DIR_DETECTED"} \
-    -DCMAKE_INSTALL_PREFIX="$INSTALL_PREFIX" \
+    -DCMAKE_INSTALL_PREFIX="$FINAL_PREFIX" \
     -DCASS_CPP_STANDARD=17 \
     -DCASS_BUILD_STATIC=ON \
     -DCASS_BUILD_SHARED=ON \
@@ -135,14 +196,31 @@ cmake -G Ninja -B "$SRC_DIR/build" -S "$SRC_DIR" \
     -DCASS_USE_TIMERFD="$TIMERFD" \
     -DCASS_USE_LIBSSH2=ON \
     -DCASS_USE_ZLIB=ON \
-    -DCMAKE_CXX_COMPILER_LAUNCHER="${CCACHE_DIR:+ccache}" \
+    ${CCACHE_DIR:+-DCMAKE_CXX_COMPILER_LAUNCHER=ccache} \
     -DCMAKE_EXPORT_COMPILE_COMMANDS=OFF \
-    -DCMAKE_BUILD_TYPE="$BUILD_TYPE"
+    -DCMAKE_BUILD_TYPE="$BUILD_TYPE" \
+    "${CMAKE_DEP_HINTS[@]}"
 
 echo "==> Building (jobs=$NPROC)"
 cmake --build "$SRC_DIR/build" --parallel "$NPROC"
 
-echo "==> Installing to $INSTALL_PREFIX"
-cmake --install "$SRC_DIR/build"
+# Use sudo for install if writing under /usr or /opt and we're not root.
+INSTALL_SUDO=""
+if [[ "$(uname -s)" != "Darwin" && $EUID -ne 0 ]]; then
+    case "$FINAL_PREFIX" in
+        /usr/*|/opt/*) command -v sudo >/dev/null 2>&1 && INSTALL_SUDO="sudo" ;;
+    esac
+fi
 
-echo "==> $DRIVER cpp-driver installed to $INSTALL_PREFIX"
+echo "==> Installing to $FINAL_PREFIX"
+$INSTALL_SUDO cmake --install "$SRC_DIR/build"
+
+cat <<EOF
+
+==> $DRIVER cpp-driver installed to $FINAL_PREFIX
+
+Next:
+  cmake --preset DebugPHP8.4NTS -DCPP_DRIVER_PREFIX="$FINAL_PREFIX"
+  cmake --build out/DebugPHP8.4NTS
+
+EOF

--- a/scripts/compile-libuv.sh
+++ b/scripts/compile-libuv.sh
@@ -48,16 +48,21 @@ install_system_deps() {
             brew install cmake ninja git
             ;;
         Linux)
+            local SUDO=""
+            if [[ $EUID -ne 0 ]] && command -v sudo >/dev/null 2>&1; then
+                SUDO="sudo"
+            fi
             # shellcheck source=/dev/null
             . /etc/os-release 2>/dev/null || return
             case "${ID:-}" in
                 fedora)
                     echo "==> Installing build deps (Fedora)"
-                    dnf install -y cmake git ninja-build
+                    $SUDO dnf install -y cmake git ninja-build
                     ;;
                 ubuntu|debian)
                     echo "==> Installing build deps (Ubuntu/Debian)"
-                    apt-get install -y cmake git ninja-build
+                    $SUDO apt-get update
+                    $SUDO apt-get install -y cmake git ninja-build
                     ;;
                 *)
                     echo "WARN: Unknown distro '${ID:-}', skipping automatic dep install" >&2


### PR DESCRIPTION
## Summary

Hardens the macOS local-build path for the extension and makes it possible to keep both the ScyllaDB and Apache Cassandra cpp-drivers installed at the same time, picking which one the extension links against at CMake configure time.

## What changed

**`scripts/compile-cpp-driver.sh`**
- Fixed a silent bug: `CFLAGS=... CXXFLAGS=... LDFLAGS=...` were assigned with a broken line-continuation and never reached the `cmake` invocation. They're now passed as `-DCMAKE_C_FLAGS` / `-DCMAKE_CXX_FLAGS` / `-DCMAKE_POSITION_INDEPENDENT_CODE=ON`.
- New `--layout per-driver|flat` option, defaulting to **per-driver** → installs to `<prefix>/scylladb` or `<prefix>/cassandra` so both can coexist. `--layout flat` preserves the old behavior.
- macOS deps now include `openssl@3 libssh2 libuv zlib`; their (keg-only) brew prefixes are forwarded to cmake as `OPENSSL_ROOT_DIR`, `LIBSSH2_ROOT_DIR`, `LIBUV_ROOT_DIR`, `ZLIB_ROOT`, plus a combined `CMAKE_PREFIX_PATH`.
- `--driver cassandra` now points at `https://github.com/apache/cassandra-cpp-driver.git` (the project moved to ASF; old `datastax/cpp-driver` and `cassandra/cpp-driver` URLs were dead).
- Linux installs use `sudo` when not root, and run `apt-get update` first.
- Prints the exact follow-up `cmake --preset … -DCPP_DRIVER_PREFIX=…` command on success.

**`scripts/compile-libuv.sh`**
- Same Linux `sudo` / `apt-get update` cleanup.

**`CMakeLists.txt`**
- New `CPP_DRIVER_PREFIX` cache option: prepends `<prefix>/lib/pkgconfig` to `PKG_CONFIG_PATH` so `FindCPPDriver` selects the installed driver. This is the switch between scylladb and cassandra when both are present.
- Replaced the single `brew --prefix` probe with a helper that also resolves `openssl@3`, `libuv`, `libssh2`, and `gmp` — keg-only formulae the previous code missed.
- `ENABLE_SANITIZERS=ON` now auto-inits the `third-party/sanitizers-cmake` submodule when it's missing, with an actionable error if not inside a git checkout.

**`cmake/FindCPPDriver.cmake`**
- Collapsed the duplicated scylla/cassandra × static/shared branches.
- Replaced the cryptic pkg-config failure with an actionable message pointing at `scripts/compile-cpp-driver.sh`, `-DCPP_DRIVER_PREFIX`, `-DUSE_LIBCASSANDRA`, `-DPHP_DRIVER_STATIC`, and the current `PKG_CONFIG_PATH`.

## Why

The macOS local-dev path was fragile: silent flag drops, no support for testing against both drivers, missing keg-only deps (openssl/libssh2/libuv), and unclear failures when the submodule or driver wasn't installed. The previous `cassandra/cpp-driver` URL also 404s.

## Typical workflow after this PR

```bash
./scripts/compile-cpp-driver.sh --driver scylladb  --prefix ~/.local
./scripts/compile-cpp-driver.sh --driver cassandra --prefix ~/.local

# Build extension against ScyllaDB
cmake --preset DebugPHP8.4NTS -DCPP_DRIVER_PREFIX=$HOME/.local/scylladb

# Or against Apache Cassandra
cmake --preset DebugPHP8.4NTS -DUSE_LIBCASSANDRA=ON -DCPP_DRIVER_PREFIX=$HOME/.local/cassandra
```

## Test plan

- [ ] On macOS (arm64): `scripts/compile-cpp-driver.sh --driver scylladb --prefix ~/.local` succeeds and installs to `~/.local/scylladb`.
- [ ] On macOS (arm64): same with `--driver cassandra` succeeds and installs to `~/.local/cassandra` without clobbering scylladb.
- [ ] `cmake --preset DebugPHP8.4NTS -DCPP_DRIVER_PREFIX=$HOME/.local/scylladb` configures and `cmake --build` produces `cassandra.so`.
- [ ] Same with `-DUSE_LIBCASSANDRA=ON -DCPP_DRIVER_PREFIX=$HOME/.local/cassandra`.
- [ ] With a fresh checkout where the submodule isn't initialized, `-DENABLE_SANITIZERS=ON` auto-inits it and configures successfully.
- [ ] On Linux (Ubuntu/Fedora), the scripts still install deps correctly under both root and a regular user with sudo.
- [ ] CI still passes (Linux flat-layout path is unchanged when `--layout flat` is passed, but CI uses static linkage so no behavior change is expected for the existing matrix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)