### PR TITLE
refactor: C23 modernization wave 2

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -12,7 +12,9 @@
 #     - readability-inconsistent-declaration-parameter-name (handler ABI)
 #     - misc-unused-parameters                         (Zend handler ABI)
 #     - misc-include-cleaner                           (PHP umbrella headers)
-#     - modernize-*                                    (we're moving C++ → C23, not the other way)
+#
+#   modernize-* is mostly C++-targeted. We enable the subset that helps the
+#   C++ → C23 migration: prefer C23 nullptr/true/false/enum constants.
 #
 #   False positives from third-party / Zend macros (re-enable per-module
 #   as code is ported to C23):
@@ -22,6 +24,9 @@
 #     - bugprone-exception-escape         (last C++ files; dissolves with migration)
 #     - performance-no-int-to-ptr         (uthash HASH_DEL)
 #     - cert-err33-c                      (cass_* return codes deliberately ignored on cleanup)
+#     - cert-err34-c                      (sscanf/atoi on driver-controlled inputs; noisy)
+#     - clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling
+#                                         (memcpy/memset/fprintf — Annex K _s variants aren't portable on glibc)
 #     - bugprone-easily-swappable-parameters / bugprone-macro-parentheses (Zend ABI shape)
 
 Checks: >
@@ -38,21 +43,31 @@ Checks: >
   -clang-analyzer-security.ArrayBound,
   -clang-analyzer-core.NullDereference,
   -clang-analyzer-deadcode.DeadStores,
+  -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,
   cert-*,
   -cert-err33-c,
+  -cert-err34-c,
   -cert-dcl37-c,
   -cert-dcl51-cpp,
   -cert-str34-c,
   performance-*,
   -performance-no-int-to-ptr,
   portability-*,
+  modernize-macro-to-enum,
+  modernize-use-bool-literals,
+  modernize-use-nullptr,
   readability-misleading-indentation,
   readability-redundant-declaration,
   readability-redundant-string-init,
+  readability-redundant-casting,
+  readability-redundant-inline-specifier,
   readability-non-const-parameter,
+  readability-else-after-return,
+  readability-avoid-const-params-in-decls,
   misc-redundant-expression,
   misc-misplaced-const,
-  misc-static-assert
+  misc-static-assert,
+  misc-header-include-cycle
 
 # Treat the curated set as errors — we only enabled checks we expect to pass.
 WarningsAsErrors: '*'
@@ -68,3 +83,11 @@ CheckOptions:
     value: 'true'
   - key: misc-unused-parameters.StrictMode
     value: 'false'
+  # else-after-return: don't rewrite ternaries / single-statement guards.
+  - key: readability-else-after-return.WarnOnUnfixable
+    value: 'false'
+  - key: readability-else-after-return.WarnOnConditionVariables
+    value: 'false'
+  # modernize-use-nullptr: also treat 0 as a null candidate in pointer ctx.
+  - key: modernize-use-nullptr.NullMacros
+    value: 'NULL'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -62,7 +62,6 @@ Checks: >
   readability-redundant-casting,
   readability-redundant-inline-specifier,
   readability-non-const-parameter,
-  readability-else-after-return,
   readability-avoid-const-params-in-decls,
   misc-redundant-expression,
   misc-misplaced-const,

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "third-party/sanitizers-cmake"]
-	path = third-party/sanitizers-cmake
-	url = https://github.com/arsenm/sanitizers-cmake.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,32 +123,15 @@ include(cmake/PhpExtensionHelpers.cmake)
 include(cmake/GenStubs.cmake)
 
 if (ENABLE_SANITIZERS)
-    set(_sanitizers_cmake_dir "${PROJECT_SOURCE_DIR}/third-party/sanitizers-cmake/cmake")
-    if (NOT EXISTS "${_sanitizers_cmake_dir}/FindSanitizers.cmake")
-        # Submodule not initialized — try to init it automatically when we're
-        # inside a git checkout; otherwise tell the user exactly what to run.
-        find_package(Git QUIET)
-        if (Git_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.gitmodules")
-            message(STATUS "Initializing third-party/sanitizers-cmake submodule")
-            execute_process(
-                COMMAND "${GIT_EXECUTABLE}" submodule update --init --recursive
-                        third-party/sanitizers-cmake
-                WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
-                RESULT_VARIABLE _sm_rc
-            )
-        else ()
-            set(_sm_rc 1)
-        endif ()
-        if (NOT EXISTS "${_sanitizers_cmake_dir}/FindSanitizers.cmake")
-            message(FATAL_ERROR
-                "ENABLE_SANITIZERS=ON but third-party/sanitizers-cmake is missing.\n"
-                "Run: git submodule update --init --recursive\n"
-                "Or disable with: -DENABLE_SANITIZERS=OFF"
-            )
-        endif ()
-        unset(_sm_rc)
+    # sanitizers-cmake is vendored under third-party/ (no submodule). The path
+    # is added to CMAKE_MODULE_PATH at the top of this file.
+    if (NOT EXISTS "${PROJECT_SOURCE_DIR}/third-party/sanitizers-cmake/cmake/FindSanitizers.cmake")
+        message(FATAL_ERROR
+            "ENABLE_SANITIZERS=ON but third-party/sanitizers-cmake is missing "
+            "(expected a vendored copy of arsenm/sanitizers-cmake under "
+            "third-party/sanitizers-cmake/). Re-clone the repo or "
+            "disable with: -DENABLE_SANITIZERS=OFF")
     endif ()
-    unset(_sanitizers_cmake_dir)
     find_package(Sanitizers REQUIRED)
 endif ()
 

--- a/cmake/TargetOptimizations.cmake
+++ b/cmake/TargetOptimizations.cmake
@@ -79,6 +79,9 @@ function(scylladb_php_library target)
             # _TIME_BITS/_FILE_OFFSET_BITS are glibc extensions; macOS uses 64-bit by default
             $<$<NOT:$<PLATFORM_ID:Darwin>>:_TIME_BITS=64>
             $<$<NOT:$<PLATFORM_ID:Darwin>>:_FILE_OFFSET_BITS=64>
+            # PHP's zend_memrchr inlines glibc's memrchr() when HAVE_MEMRCHR is set
+            # — that prototype is only exposed under _GNU_SOURCE on glibc.
+            $<$<NOT:$<PLATFORM_ID:Darwin>>:_GNU_SOURCE>
             $<$<CONFIG:Debug>:DEBUG>
             $<$<OR:$<CONFIG:Release>,$<CONFIG:RelWithDebInfo>>:RELEASE>
     )

--- a/include/DateTime/Date.h
+++ b/include/DateTime/Date.h
@@ -24,18 +24,19 @@ typedef struct {
 extern PHP_SCYLLADB_API zend_class_entry *php_scylladb_date_ce;
 extern PHP_SCYLLADB_API zend_class_entry *php_scylladb_time_ce;
 
-[[nodiscard]] PHP_SCYLLADB_API php_scylladb_date *php_scylladb_date_instantiate(zval *object);
-[[nodiscard]] PHP_SCYLLADB_API zend_result php_scylladb_date_initialize(php_scylladb_date *object,
+[[nodiscard, gnu::nonnull(1)]] PHP_SCYLLADB_API php_scylladb_date *php_scylladb_date_instantiate(zval *object);
+/* secondsStr is optional (use the long alternative); only `object` is required. */
+[[nodiscard, gnu::nonnull(1)]] PHP_SCYLLADB_API zend_result php_scylladb_date_initialize(php_scylladb_date *object,
                                                                         zend_string *secondsStr,
                                                                         zend_long seconds);
 
-[[nodiscard]] PHP_SCYLLADB_API php_scylladb_time *php_scylladb_time_instantiate(zval *object);
-[[nodiscard]] PHP_SCYLLADB_API zend_result php_scylladb_time_initialize(php_scylladb_time *object,
+[[nodiscard, gnu::nonnull(1)]] PHP_SCYLLADB_API php_scylladb_time *php_scylladb_time_instantiate(zval *object);
+[[nodiscard, gnu::nonnull(1)]] PHP_SCYLLADB_API zend_result php_scylladb_time_initialize(php_scylladb_time *object,
                                                                         zend_string *nanosecondsStr,
                                                                         zend_long nanoseconds);
 
-[[nodiscard]] PHP_SCYLLADB_API php_scylladb_timestamp *php_scylladb_timestamp_instantiate(zval *object);
-[[nodiscard]] PHP_SCYLLADB_API zend_result php_scylladb_timestamp_initialize(php_scylladb_timestamp *object,
+[[nodiscard, gnu::nonnull(1)]] PHP_SCYLLADB_API php_scylladb_timestamp *php_scylladb_timestamp_instantiate(zval *object);
+[[nodiscard, gnu::nonnull(1)]] PHP_SCYLLADB_API zend_result php_scylladb_timestamp_initialize(php_scylladb_timestamp *object,
                                                                              cass_int64_t seconds,
                                                                              cass_int64_t microseconds);
 

--- a/include/RetryPolicy/RetryPolicy.h
+++ b/include/RetryPolicy/RetryPolicy.h
@@ -20,10 +20,10 @@ extern PHP_SCYLLADB_API zend_class_entry *php_scylladb_retry_policy_fallthrough_
 extern PHP_SCYLLADB_API zend_class_entry *php_scylladb_retry_policy_logging_ce;
 extern PHP_SCYLLADB_API zend_class_entry *php_scylladb_retry_policy_ce;
 
-[[nodiscard]] PHP_SCYLLADB_API php_scylladb_retry_policy *php_scylladb_retry_policy_default_policy_instantiate(zval *dst);
-[[nodiscard]] PHP_SCYLLADB_API php_scylladb_retry_policy *php_scylladb_retry_policy_downgrading_consistency_instantiate(zval *dst);
-[[nodiscard]] PHP_SCYLLADB_API php_scylladb_retry_policy *php_scylladb_retry_policy_fallthrough_instantiate(zval *dst);
-[[nodiscard]] PHP_SCYLLADB_API php_scylladb_retry_policy *php_scylladb_retry_policy_logging_instantiate(zval *dst, php_scylladb_retry_policy *retry_policy);
+[[nodiscard, gnu::nonnull(1)]] PHP_SCYLLADB_API php_scylladb_retry_policy *php_scylladb_retry_policy_default_policy_instantiate(zval *dst);
+[[nodiscard, gnu::nonnull(1)]] PHP_SCYLLADB_API php_scylladb_retry_policy *php_scylladb_retry_policy_downgrading_consistency_instantiate(zval *dst);
+[[nodiscard, gnu::nonnull(1)]] PHP_SCYLLADB_API php_scylladb_retry_policy *php_scylladb_retry_policy_fallthrough_instantiate(zval *dst);
+[[nodiscard, gnu::nonnull(1, 2)]] PHP_SCYLLADB_API php_scylladb_retry_policy *php_scylladb_retry_policy_logging_instantiate(zval *dst, php_scylladb_retry_policy *retry_policy);
 
 static zend_always_inline php_scylladb_retry_policy *php_scylladb_retry_policy_from_obj(zend_object *obj) {
   return PHP_SCYLLADB_OBJ_FETCH(php_scylladb_retry_policy, obj);

--- a/include/SSLOptions/SSLOptions.h
+++ b/include/SSLOptions/SSLOptions.h
@@ -40,6 +40,6 @@ static zend_always_inline php_scylladb_ssl *php_scylladb_ssl_from_obj(zend_objec
 #define Z_SCYLLADB_SSL_P(zv) php_scylladb_ssl_from_obj(Z_OBJ_P((zv)))
 #define Z_SCYLLADB_SSL(zv) php_scylladb_ssl_from_obj(Z_OBJ((zv)))
 
-[[nodiscard]] PHP_SCYLLADB_API php_scylladb_ssl *php_scylladb_ssl_instantiate(zval *object);
+[[nodiscard, gnu::nonnull(1)]] PHP_SCYLLADB_API php_scylladb_ssl *php_scylladb_ssl_instantiate(zval *object);
 
 END_EXTERN_C()

--- a/include/php_scylladb.h
+++ b/include/php_scylladb.h
@@ -7,11 +7,6 @@
 #include <unistd.h>
 #include <version.h>
 
-#ifdef __cplusplus
-extern "C"
-{
-#endif
-
 #include <inttypes.h>
 #include <math.h>
 #include <string.h>
@@ -47,9 +42,25 @@ static zend_always_inline zend_class_entry *zend_register_internal_class_with_fl
 
 #define PHP_SCYLLADB_CORE_ME(name, arg_info, flags) PHP_ME(Cassandra, name, arg_info, flags)
 
-#define SAFE_STR(a) ((a) ? a : "")
+/* C23: typeof + statement expression avoids double-evaluation of the argument. */
+#define SAFE_STR(a) ({ typeof(a) _php_scylladb_v = (a); _php_scylladb_v ? _php_scylladb_v : ""; })
 
-#define SAFE_ZEND_STRING(a) ((a != NULL) ? ZSTR_VAL(a) : "")
+#define SAFE_ZEND_STRING(a) ({ zend_string *_php_scylladb_zs = (a); _php_scylladb_zs != nullptr ? ZSTR_VAL(_php_scylladb_zs) : ""; })
+
+/* Branch-prediction hints — gcc/clang builtins, both are C23-compatible. */
+#define PHP_SCYLLADB_LIKELY(x)   __builtin_expect(!!(x), 1)
+#define PHP_SCYLLADB_UNLIKELY(x) __builtin_expect(!!(x), 0)
+
+/* Scope-bound cleanup. The destructor must take `T **` (cleanup attribute passes
+ * a pointer to the variable). Example:
+ *
+ *     static inline void php_scylladb_zs_release(zend_string **p) {
+ *         if (*p) zend_string_release(*p);
+ *     }
+ *     PHP_SCYLLADB_CLEANUP(php_scylladb_zs_release) zend_string *s = zend_string_init(...);
+ *
+ * Fires on every exit path (return / break / goto / fall-through). */
+#define PHP_SCYLLADB_CLEANUP(fn) __attribute__((cleanup(fn)))
 
 #ifdef ZTS
 #include "TSRM.h"
@@ -65,22 +76,23 @@ static zend_always_inline zend_class_entry *zend_register_internal_class_with_fl
 
 #define CURRENT_CPP_DRIVER_VERSION CPP_DRIVER_VERSION(CASS_VERSION_MAJOR, CASS_VERSION_MINOR, CASS_VERSION_PATCH)
 
-typedef unsigned long ulong;
-
-    extern zend_module_entry php_scylladb_module_entry;
+extern zend_module_entry php_scylladb_module_entry;
 #define phpext_cassandra_ptr &php_scylladb_module_entry
 
-    PHP_MINIT_FUNCTION(php_scylladb);
-    PHP_MSHUTDOWN_FUNCTION(php_scylladb);
-    PHP_RINIT_FUNCTION(php_scylladb);
-    PHP_RSHUTDOWN_FUNCTION(php_scylladb);
-    PHP_MINFO_FUNCTION(php_scylladb);
-    PHP_INI_MH(OnUpdateLogLevel);
-    PHP_INI_MH(OnUpdateLog);
+PHP_MINIT_FUNCTION(php_scylladb);
+PHP_MSHUTDOWN_FUNCTION(php_scylladb);
+PHP_RINIT_FUNCTION(php_scylladb);
+PHP_RSHUTDOWN_FUNCTION(php_scylladb);
+PHP_MINFO_FUNCTION(php_scylladb);
+PHP_INI_MH(OnUpdateLogLevel);
+PHP_INI_MH(OnUpdateLog);
 
-    zend_class_entry *exception_class(CassError rc);
+/* The error → exception_ce mapping is a closed lookup with no side effects
+ * and no memory reads beyond its argument — `const` is exact. */
+[[gnu::const]] zend_class_entry *exception_class(CassError rc);
 
-    void throw_invalid_argument(const zval *object, const char *object_name, const char *expected_type);
+[[gnu::nonnull(1, 2, 3)]]
+void throw_invalid_argument(const zval *object, const char *object_name, const char *expected_type);
 
 #define INVALID_ARGUMENT(object, expected)                                                                             \
     do                                                                                                                 \
@@ -110,12 +122,9 @@ typedef unsigned long ulong;
 
 #define ASSERT_SUCCESS_VALUE(rc, value) ASSERT_SUCCESS_BLOCK(rc, return value;)
 
-#define PHP_SCYLLADB_DEFAULT_CONSISTENCY CASS_CONSISTENCY_LOCAL_ONE
+/* C23 constexpr — value, not preprocessor identity. Cannot be used in #if. */
+static constexpr CassConsistency PHP_SCYLLADB_DEFAULT_CONSISTENCY = CASS_CONSISTENCY_LOCAL_ONE;
 
+/* String-literal concatenation forces these to stay as #define. */
 #define PHP_SCYLLADB_DEFAULT_LOG PHP_SCYLLADB_NAME ".log"
 #define PHP_SCYLLADB_DEFAULT_LOG_LEVEL "ERROR"
-
-
-#ifdef __cplusplus
-}
-#endif

--- a/include/php_scylladb.h
+++ b/include/php_scylladb.h
@@ -122,8 +122,10 @@ void throw_invalid_argument(const zval *object, const char *object_name, const c
 
 #define ASSERT_SUCCESS_VALUE(rc, value) ASSERT_SUCCESS_BLOCK(rc, return value;)
 
-/* C23 constexpr — value, not preprocessor identity. Cannot be used in #if. */
-static constexpr CassConsistency PHP_SCYLLADB_DEFAULT_CONSISTENCY = CASS_CONSISTENCY_LOCAL_ONE;
+/* Kept as #define: clang-tidy on CI runs without -std=c23 and chokes on
+ * `constexpr` despite the build compiler supporting it. Revisit once the
+ * lint job inherits the build's compilation database flags. */
+#define PHP_SCYLLADB_DEFAULT_CONSISTENCY CASS_CONSISTENCY_LOCAL_ONE
 
 /* String-literal concatenation forces these to stay as #define. */
 #define PHP_SCYLLADB_DEFAULT_LOG PHP_SCYLLADB_NAME ".log"

--- a/include/php_scylladb.h
+++ b/include/php_scylladb.h
@@ -42,10 +42,20 @@ static zend_always_inline zend_class_entry *zend_register_internal_class_with_fl
 
 #define PHP_SCYLLADB_CORE_ME(name, arg_info, flags) PHP_ME(Cassandra, name, arg_info, flags)
 
-/* C23: typeof + statement expression avoids double-evaluation of the argument. */
-#define SAFE_STR(a) ({ typeof(a) _php_scylladb_v = (a); _php_scylladb_v ? _php_scylladb_v : ""; })
+/* Inline functions give us single-evaluation of the argument without the
+ * GNU statement-expression extension that -Wpedantic complains about. */
+[[gnu::const]]
+static inline const char *php_scylladb_safe_str(const char *s) {
+    return s ? s : "";
+}
 
-#define SAFE_ZEND_STRING(a) ({ zend_string *_php_scylladb_zs = (a); _php_scylladb_zs != nullptr ? ZSTR_VAL(_php_scylladb_zs) : ""; })
+[[gnu::pure]]
+static inline const char *php_scylladb_safe_zend_string(const zend_string *s) {
+    return s != nullptr ? ZSTR_VAL(s) : "";
+}
+
+#define SAFE_STR(a)         php_scylladb_safe_str(a)
+#define SAFE_ZEND_STRING(a) php_scylladb_safe_zend_string(a)
 
 /* Branch-prediction hints — gcc/clang builtins, both are C23-compatible. */
 #define PHP_SCYLLADB_LIKELY(x)   __builtin_expect(!!(x), 1)

--- a/include/php_scylladb_cache_key.h
+++ b/include/php_scylladb_cache_key.h
@@ -26,17 +26,20 @@
  * needs.
  */
 
-#define PHP_SCYLLADB_FNV1A_OFFSET 0xcbf29ce484222325ULL
-#define PHP_SCYLLADB_FNV1A_PRIME  0x100000001b3ULL
+static constexpr zend_ulong PHP_SCYLLADB_FNV1A_OFFSET = 0xcbf29ce484222325ULL;
+static constexpr zend_ulong PHP_SCYLLADB_FNV1A_PRIME  = 0x100000001b3ULL;
 
+[[gnu::const]]
 static zend_always_inline zend_ulong php_scylladb_cache_key_init(void) {
     return PHP_SCYLLADB_FNV1A_OFFSET;
 }
 
+[[gnu::const]]
 static zend_always_inline zend_ulong php_scylladb_cache_key_mix_byte(zend_ulong h, uint8_t b) {
     return (h ^ b) * PHP_SCYLLADB_FNV1A_PRIME;
 }
 
+[[gnu::pure]]
 static zend_always_inline zend_ulong php_scylladb_cache_key_mix_bytes(zend_ulong h, const void *buf, size_t len) {
     const uint8_t *p = (const uint8_t *)buf;
     for (size_t i = 0; i < len; i++) {
@@ -45,31 +48,38 @@ static zend_always_inline zend_ulong php_scylladb_cache_key_mix_bytes(zend_ulong
     return h;
 }
 
+/* `pure` rather than `const`: the inlined body takes &v (a local) and
+ * dereferences it through mix_bytes — `const` forbids any indirection. */
+[[gnu::pure]]
 static zend_always_inline zend_ulong php_scylladb_cache_key_mix_long(zend_ulong h, zend_long v) {
     return php_scylladb_cache_key_mix_bytes(h, &v, sizeof(v));
 }
 
+[[gnu::pure]]
 static zend_always_inline zend_ulong php_scylladb_cache_key_mix_int(zend_ulong h, int v) {
     return php_scylladb_cache_key_mix_bytes(h, &v, sizeof(v));
 }
 
+[[gnu::pure]]
 static zend_always_inline zend_ulong php_scylladb_cache_key_mix_ulong(zend_ulong h, zend_ulong v) {
     return php_scylladb_cache_key_mix_bytes(h, &v, sizeof(v));
 }
 
 /* Mix a zend_string, including a separator byte so adjacent fields can't
-   alias (e.g. ("ab", "c") vs ("a", "bc")). NULL becomes a single 0 byte. */
+   alias (e.g. ("ab", "c") vs ("a", "bc")). nullptr becomes a single 0 byte. */
+[[gnu::pure]]
 static zend_always_inline zend_ulong php_scylladb_cache_key_mix_zstr(zend_ulong h, const zend_string *s) {
-    if (s == NULL) {
+    if (s == nullptr) {
         return php_scylladb_cache_key_mix_byte(h, 0);
     }
     h = php_scylladb_cache_key_mix_bytes(h, ZSTR_VAL(s), ZSTR_LEN(s));
     return php_scylladb_cache_key_mix_byte(h, 0);  /* separator */
 }
 
-/* Mix a C string (NUL-terminated or NULL). */
+/* Mix a C string (NUL-terminated or nullptr). */
+[[gnu::pure]]
 static zend_always_inline zend_ulong php_scylladb_cache_key_mix_cstr(zend_ulong h, const char *s) {
-    if (s == NULL) {
+    if (s == nullptr) {
         return php_scylladb_cache_key_mix_byte(h, 0);
     }
     while (*s) {

--- a/include/php_scylladb_cache_key.h
+++ b/include/php_scylladb_cache_key.h
@@ -26,8 +26,10 @@
  * needs.
  */
 
-static constexpr zend_ulong PHP_SCYLLADB_FNV1A_OFFSET = 0xcbf29ce484222325ULL;
-static constexpr zend_ulong PHP_SCYLLADB_FNV1A_PRIME  = 0x100000001b3ULL;
+/* Kept as #define for clang-tidy compatibility (lint job doesn't pick up
+ * the build's -std=c23 yet). */
+#define PHP_SCYLLADB_FNV1A_OFFSET 0xcbf29ce484222325ULL
+#define PHP_SCYLLADB_FNV1A_PRIME  0x100000001b3ULL
 
 [[gnu::const]]
 static zend_always_inline zend_ulong php_scylladb_cache_key_init(void) {

--- a/src/BatchStatement.c
+++ b/src/BatchStatement.c
@@ -35,7 +35,7 @@ void php_scylladb_batch_statement_entry_dtor(zval* dest)
 ZEND_METHOD(Cassandra_BatchStatement, __construct)
 {
     zend_long type = CASS_BATCH_TYPE_LOGGED;
-    php_scylladb_statement *self = NULL;
+    php_scylladb_statement *self = nullptr;
 
     ZEND_PARSE_PARAMETERS_START(0, 1)
         Z_PARAM_OPTIONAL
@@ -61,10 +61,10 @@ ZEND_METHOD(Cassandra_BatchStatement, __construct)
 
 ZEND_METHOD(Cassandra_BatchStatement, add)
 {
-    zval *statement = NULL;
-    zval *arguments = NULL;
-    php_scylladb_batch_statement_entry *batch_statement_entry = NULL;
-    php_scylladb_statement *self = NULL;
+    zval *statement = nullptr;
+    zval *arguments = nullptr;
+    php_scylladb_batch_statement_entry *batch_statement_entry = nullptr;
+    php_scylladb_statement *self = nullptr;
     zval entry;
 
     ZEND_PARSE_PARAMETERS_START(1, 2)
@@ -117,7 +117,7 @@ int php_scylladb_batch_statement_compare(zval *obj1, zval *obj2)
 
 void php_scylladb_batch_statement_free(zend_object *object)
 {
-    php_scylladb_statement *self = php_scylladb_statement_object_fetch(object);
+    auto self = php_scylladb_statement_object_fetch(object);
 
     zend_hash_destroy(&self->data.batch.statements);
 
@@ -126,13 +126,11 @@ void php_scylladb_batch_statement_free(zend_object *object)
 
 zend_object* php_scylladb_batch_statement_new(zend_class_entry *ce)
 {
-    php_scylladb_statement *self = (php_scylladb_statement *)ecalloc(1, sizeof(php_scylladb_statement) + zend_object_properties_size(ce));
+    php_scylladb_statement *self =
+        PHP_SCYLLADB_OBJ_ALLOCATE(php_scylladb_statement, ce, &php_scylladb_batch_statement_handlers);
 
     self->type = PHP_SCYLLADB_BATCH_STATEMENT;
     self->data.batch.type = CASS_BATCH_TYPE_LOGGED;
-    zend_hash_init(&self->data.batch.statements, 0, NULL, (dtor_func_t)php_scylladb_batch_statement_entry_dtor, 0);
-
-    zend_object_std_init(&self->zendObject, ce);
-    self->zendObject.handlers = &php_scylladb_batch_statement_handlers;
+    zend_hash_init(&self->data.batch.statements, 0, nullptr, (dtor_func_t)php_scylladb_batch_statement_entry_dtor, 0);
     return &self->zendObject;
 }

--- a/src/BatchStatement.stub.php
+++ b/src/BatchStatement.stub.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 namespace Cassandra {
     /**
      * @strict-properties
+     * @not-serializable
  * @scylladb-struct php_scylladb_statement
  */    final class BatchStatement implements Statement {
         public function __construct(int $type = \Cassandra::BATCH_LOGGED) {}

--- a/src/Blob.c
+++ b/src/Blob.c
@@ -53,7 +53,7 @@ void php_scylladb_blob_init(INTERNAL_FUNCTION_PARAMETERS) {
   // clang-format on
 
   if (ZEND_THIS && instanceof_function(Z_OBJCE_P(ZEND_THIS), php_scylladb_blob_ce)) {
-    php_scylladb_blob *self = PHP_SCYLLADB_GET_BLOB(ZEND_THIS);
+    auto self = PHP_SCYLLADB_GET_BLOB(ZEND_THIS);
     if (self->data) {
       efree(self->data);
     }
@@ -62,7 +62,7 @@ void php_scylladb_blob_init(INTERNAL_FUNCTION_PARAMETERS) {
     memcpy(self->data, string, string_len);
   } else {
     object_init_ex(return_value, php_scylladb_blob_ce);
-    php_scylladb_blob *self = PHP_SCYLLADB_GET_BLOB(return_value);
+    auto self = PHP_SCYLLADB_GET_BLOB(return_value);
     self->data = (cass_byte_t *)emalloc(string_len * sizeof(cass_byte_t));
     self->size = string_len;
     memcpy(self->data, string, string_len);
@@ -79,7 +79,7 @@ ZEND_METHOD(Cassandra_Blob, __construct) {
   ZEND_PARSE_PARAMETERS_END();
   // clang-format on
 
-  php_scylladb_blob *self = PHP_SCYLLADB_GET_BLOB(ZEND_THIS);
+  auto self = PHP_SCYLLADB_GET_BLOB(ZEND_THIS);
 
   self->data = (cass_byte_t *)emalloc(ZSTR_LEN(bytes) * sizeof(cass_byte_t));
   self->size = ZSTR_LEN(bytes);
@@ -89,7 +89,7 @@ ZEND_METHOD(Cassandra_Blob, __construct) {
 
 /* {{{ Blob::__toString() */
 ZEND_METHOD(Cassandra_Blob, __toString) {
-  php_scylladb_blob *self = PHP_SCYLLADB_GET_BLOB(ZEND_THIS);
+  auto self = PHP_SCYLLADB_GET_BLOB(ZEND_THIS);
   char *hex;
   size_t hex_len;
   php_scylladb_bytes_to_hex((const char *)self->data, self->size, &hex, &hex_len);
@@ -108,7 +108,7 @@ ZEND_METHOD(Cassandra_Blob, type) {
 
 /* {{{ Blob::bytes() */
 ZEND_METHOD(Cassandra_Blob, bytes) {
-  php_scylladb_blob *self = PHP_SCYLLADB_GET_BLOB(ZEND_THIS);
+  auto self = PHP_SCYLLADB_GET_BLOB(ZEND_THIS);
   char *hex;
   size_t hex_len;
   php_scylladb_bytes_to_hex((const char *)self->data, self->size, &hex, &hex_len);
@@ -120,7 +120,7 @@ ZEND_METHOD(Cassandra_Blob, bytes) {
 
 /* {{{ Blob::toBinaryString() */
 ZEND_METHOD(Cassandra_Blob, toBinaryString) {
-  php_scylladb_blob *blob = PHP_SCYLLADB_GET_BLOB(ZEND_THIS);
+  auto blob = PHP_SCYLLADB_GET_BLOB(ZEND_THIS);
 
   RETVAL_STRINGL((const char *)blob->data, blob->size);
 }
@@ -128,9 +128,9 @@ ZEND_METHOD(Cassandra_Blob, toBinaryString) {
 
 
 HashTable *php_scylladb_blob_gc(zend_object *object, zval** table, int *n) {
-  *table = NULL;
+  *table = nullptr;
   *n = 0;
-  return NULL;
+  return nullptr;
 }
 
 HashTable *php_scylladb_blob_properties(zend_object *object) {
@@ -139,7 +139,7 @@ HashTable *php_scylladb_blob_properties(zend_object *object) {
   zval type;
   zval bytes;
 
-  php_scylladb_blob *self = php_scylladb_blob_object_fetch(object);
+  auto self = php_scylladb_blob_object_fetch(object);
   if (object->properties) {
     zend_array_release(object->properties);
   }
@@ -160,8 +160,8 @@ HashTable *php_scylladb_blob_properties(zend_object *object) {
 
 int php_scylladb_blob_compare(zval *obj1, zval *obj2) {
   ZEND_COMPARE_OBJECTS_FALLBACK(obj1, obj2);
-  php_scylladb_blob *blob1 = NULL;
-  php_scylladb_blob *blob2 = NULL;
+  php_scylladb_blob *blob1 = nullptr;
+  php_scylladb_blob *blob2 = nullptr;
 
   if (Z_OBJCE_P(obj1) != Z_OBJCE_P(obj2)) return strcmp(ZSTR_VAL(Z_OBJCE_P(obj1)->name), ZSTR_VAL(Z_OBJCE_P(obj2)->name)); /* different classes */
 
@@ -179,12 +179,12 @@ int php_scylladb_blob_compare(zval *obj1, zval *obj2) {
 }
 
 unsigned php_scylladb_blob_hash_value(zval *obj) {
-  php_scylladb_blob *self = PHP_SCYLLADB_GET_BLOB(obj);
+  auto self = PHP_SCYLLADB_GET_BLOB(obj);
   return zend_inline_hash_func((const char *)self->data, self->size);
 }
 
 void php_scylladb_blob_free(zend_object *object) {
-  php_scylladb_blob *self = php_scylladb_blob_object_fetch(object);
+  auto self = php_scylladb_blob_object_fetch(object);
 
   if (self->data) {
     efree(self->data);
@@ -194,16 +194,13 @@ void php_scylladb_blob_free(zend_object *object) {
 }
 
 zend_object* php_scylladb_blob_new(zend_class_entry *ce) {
-  php_scylladb_blob *self = (php_scylladb_blob *)ecalloc(1, sizeof(php_scylladb_blob) + zend_object_properties_size(ce));
-
-  zend_object_std_init(&self->zendObject, ce);
-  self->zendObject.handlers = (zend_object_handlers *)&php_scylladb_blob_handlers;
+  php_scylladb_blob *self =
+      PHP_SCYLLADB_OBJ_ALLOCATE(php_scylladb_blob, ce, &php_scylladb_blob_handlers);
   return &self->zendObject;
 }
 
 
-void php_scylladb_blob_post_register(zend_class_entry *ce)
+void php_scylladb_blob_post_register([[maybe_unused]] zend_class_entry *ce)
 {
-    (void)ce;
     php_scylladb_blob_handlers.std.offset = XtOffsetOf(php_scylladb_blob, zendObject);
 }

--- a/src/Cassandra.stub.php
+++ b/src/Cassandra.stub.php
@@ -11,39 +11,65 @@ namespace {
  */
 final class Cassandra
 {
-    /* CassConsistency — matches values in cassandra.h */
-    public const int CONSISTENCY_ANY          = 0x0000;
-    public const int CONSISTENCY_ONE          = 0x0001;
-    public const int CONSISTENCY_TWO          = 0x0002;
-    public const int CONSISTENCY_THREE        = 0x0003;
-    public const int CONSISTENCY_QUORUM       = 0x0004;
-    public const int CONSISTENCY_ALL          = 0x0005;
-    public const int CONSISTENCY_LOCAL_QUORUM = 0x0006;
-    public const int CONSISTENCY_EACH_QUORUM  = 0x0007;
-    public const int CONSISTENCY_SERIAL       = 0x0008;
-    public const int CONSISTENCY_LOCAL_SERIAL = 0x0009;
-    public const int CONSISTENCY_LOCAL_ONE    = 0x000A;
+    /* CassConsistency — values bound to cassandra.h via @cvalue. */
+
+    /** @cvalue CASS_CONSISTENCY_ANY */
+    public const int CONSISTENCY_ANY = UNKNOWN;
+    /** @cvalue CASS_CONSISTENCY_ONE */
+    public const int CONSISTENCY_ONE = UNKNOWN;
+    /** @cvalue CASS_CONSISTENCY_TWO */
+    public const int CONSISTENCY_TWO = UNKNOWN;
+    /** @cvalue CASS_CONSISTENCY_THREE */
+    public const int CONSISTENCY_THREE = UNKNOWN;
+    /** @cvalue CASS_CONSISTENCY_QUORUM */
+    public const int CONSISTENCY_QUORUM = UNKNOWN;
+    /** @cvalue CASS_CONSISTENCY_ALL */
+    public const int CONSISTENCY_ALL = UNKNOWN;
+    /** @cvalue CASS_CONSISTENCY_LOCAL_QUORUM */
+    public const int CONSISTENCY_LOCAL_QUORUM = UNKNOWN;
+    /** @cvalue CASS_CONSISTENCY_EACH_QUORUM */
+    public const int CONSISTENCY_EACH_QUORUM = UNKNOWN;
+    /** @cvalue CASS_CONSISTENCY_SERIAL */
+    public const int CONSISTENCY_SERIAL = UNKNOWN;
+    /** @cvalue CASS_CONSISTENCY_LOCAL_SERIAL */
+    public const int CONSISTENCY_LOCAL_SERIAL = UNKNOWN;
+    /** @cvalue CASS_CONSISTENCY_LOCAL_ONE */
+    public const int CONSISTENCY_LOCAL_ONE = UNKNOWN;
 
     /* CassSslVerifyFlags */
-    public const int VERIFY_NONE          = 0x00;
-    public const int VERIFY_PEER_CERT     = 0x01;
-    public const int VERIFY_PEER_IDENTITY = 0x02;
+    /** @cvalue CASS_SSL_VERIFY_NONE */
+    public const int VERIFY_NONE = UNKNOWN;
+    /** @cvalue CASS_SSL_VERIFY_PEER_CERT */
+    public const int VERIFY_PEER_CERT = UNKNOWN;
+    /** @cvalue CASS_SSL_VERIFY_PEER_IDENTITY */
+    public const int VERIFY_PEER_IDENTITY = UNKNOWN;
 
     /* CassBatchType */
-    public const int BATCH_LOGGED   = 0x00;
-    public const int BATCH_UNLOGGED = 0x01;
-    public const int BATCH_COUNTER  = 0x02;
+    /** @cvalue CASS_BATCH_TYPE_LOGGED */
+    public const int BATCH_LOGGED = UNKNOWN;
+    /** @cvalue CASS_BATCH_TYPE_UNLOGGED */
+    public const int BATCH_UNLOGGED = UNKNOWN;
+    /** @cvalue CASS_BATCH_TYPE_COUNTER */
+    public const int BATCH_COUNTER = UNKNOWN;
 
     /* CassLogLevel */
-    public const int LOG_DISABLED = 0;
-    public const int LOG_CRITICAL = 1;
-    public const int LOG_ERROR    = 2;
-    public const int LOG_WARN     = 3;
-    public const int LOG_INFO     = 4;
-    public const int LOG_DEBUG    = 5;
-    public const int LOG_TRACE    = 6;
+    /** @cvalue CASS_LOG_DISABLED */
+    public const int LOG_DISABLED = UNKNOWN;
+    /** @cvalue CASS_LOG_CRITICAL */
+    public const int LOG_CRITICAL = UNKNOWN;
+    /** @cvalue CASS_LOG_ERROR */
+    public const int LOG_ERROR = UNKNOWN;
+    /** @cvalue CASS_LOG_WARN */
+    public const int LOG_WARN = UNKNOWN;
+    /** @cvalue CASS_LOG_INFO */
+    public const int LOG_INFO = UNKNOWN;
+    /** @cvalue CASS_LOG_DEBUG */
+    public const int LOG_DEBUG = UNKNOWN;
+    /** @cvalue CASS_LOG_TRACE */
+    public const int LOG_TRACE = UNKNOWN;
 
-    /* CQL primitive type name constants (used by Type\Scalar) */
+    /* CQL primitive type name constants (used by Type\Scalar).
+       These are the canonical wire names; no C-side identifier to bind to. */
     public const string TYPE_TEXT      = "text";
     public const string TYPE_ASCII     = "ascii";
     public const string TYPE_VARCHAR   = "varchar";
@@ -63,11 +89,12 @@ final class Cassandra
     public const string TYPE_TIMEUUID  = "timeuuid";
     public const string TYPE_INET      = "inet";
 
-    /* VERSION and CPP_DRIVER_VERSION are populated at MINIT
-       (CPP_DRIVER_VERSION is runtime-computed from the linked libcassandra
-       or libscylla-cpp-driver). The literals here are placeholders
-       overridden by src/Core.cpp before any user code runs. */
-    public const string VERSION            = "0.0.0";
+    /** Driver version. @cvalue resolves to the PHP_SCYLLADB_VERSION macro. */
+    /** @cvalue PHP_SCYLLADB_VERSION */
+    public const string VERSION = UNKNOWN;
+
+    /** Linked Cassandra C/C++ driver version. Runtime-computed; the stub
+        placeholder is overridden in src/Core.c#php_scylladb_core_post_register. */
     public const string CPP_DRIVER_VERSION = "0.0.0";
 
     public static function cluster(): \Cassandra\Cluster\Builder {}

--- a/src/Cluster/Builder.c
+++ b/src/Cluster/Builder.c
@@ -111,10 +111,10 @@ ZEND_METHOD(Cassandra_Cluster_Builder, build)
 #ifndef PHP_SCYLLADB_BACKEND_SCYLLA_RUST
     CassError rc;
 #endif
-    php_scylladb_cluster_builder *self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
+    auto self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
 
     object_init_ex(return_value, php_scylladb_default_cluster_ce);
-    php_scylladb_cluster *cluster = PHP_SCYLLADB_GET_CLUSTER(return_value);
+    auto cluster = PHP_SCYLLADB_GET_CLUSTER(return_value);
 
     cluster->persist = self->persist;
     cluster->default_consistency = self->default_consistency;
@@ -160,7 +160,7 @@ ZEND_METHOD(Cassandra_Cluster_Builder, build)
         cluster->cache_key = h;
 
         zval *le = zend_hash_index_find(&EG(persistent_list), h);
-        if (le != NULL && Z_TYPE_P(le) == IS_RESOURCE &&
+        if (le != nullptr && Z_TYPE_P(le) == IS_RESOURCE &&
             Z_RES_P(le)->type == php_le_php_scylladb_cluster())
         {
             cluster->cluster = (CassCluster *)Z_RES_P(le)->ptr;
@@ -294,7 +294,7 @@ ZEND_METHOD(Cassandra_Cluster_Builder, withDefaultConsistency)
         return;
     }
 
-    php_scylladb_cluster_builder *self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
+    auto self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
     self->default_consistency = consistency;
 
     RETURN_ZVAL(getThis(), 1, 0);
@@ -315,14 +315,14 @@ ZEND_METHOD(Cassandra_Cluster_Builder, withDefaultPageSize)
         return;
     }
 
-    php_scylladb_cluster_builder *self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
+    auto self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
     self->default_page_size = (int)pageSize;
     RETURN_ZVAL(getThis(), 1, 0);
 }
 ZEND_METHOD(Cassandra_Cluster_Builder, withDefaultTimeout)
 {
     double timeout = 0.0;
-    php_scylladb_cluster_builder *self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
+    auto self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
 
     ZEND_PARSE_PARAMETERS_START(1, 1)
     Z_PARAM_DOUBLE(timeout)
@@ -348,7 +348,7 @@ ZEND_METHOD(Cassandra_Cluster_Builder, withDefaultTimeout)
 }
 ZEND_METHOD(Cassandra_Cluster_Builder, withContactPoints)
 {
-    php_scylladb_cluster_builder *self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
+    auto self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
     php_scylladb_parse_hosts(INTERNAL_FUNCTION_PARAM_PASSTHRU, &self->contact_points);
 }
 ZEND_METHOD(Cassandra_Cluster_Builder, withPort)
@@ -367,7 +367,7 @@ ZEND_METHOD(Cassandra_Cluster_Builder, withPort)
         return;
     }
 
-    php_scylladb_cluster_builder *self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
+    auto self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
     self->port = (int)port;
     RETURN_ZVAL(getThis(), 1, 0);
 }
@@ -375,7 +375,7 @@ ZEND_METHOD(Cassandra_Cluster_Builder, withRoundRobinLoadBalancingPolicy)
 {
     ZEND_PARSE_PARAMETERS_NONE();
 
-    php_scylladb_cluster_builder *self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
+    auto self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
 
     if (self->local_dc)
     {
@@ -399,7 +399,7 @@ ZEND_METHOD(Cassandra_Cluster_Builder, withDatacenterAwareRoundRobinLoadBalancin
     Z_PARAM_BOOL(allow_remote_dcs_for_local_cl)
     ZEND_PARSE_PARAMETERS_END();
 
-    php_scylladb_cluster_builder *self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
+    auto self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
 
     if (hostPerRemoteDatacenter < 0)
     {
@@ -424,22 +424,22 @@ ZEND_METHOD(Cassandra_Cluster_Builder, withDatacenterAwareRoundRobinLoadBalancin
 }
 ZEND_METHOD(Cassandra_Cluster_Builder, withBlackListHosts)
 {
-    php_scylladb_cluster_builder *self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
+    auto self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
     php_scylladb_parse_hosts(INTERNAL_FUNCTION_PARAM_PASSTHRU, &self->blacklist_hosts);
 }
 ZEND_METHOD(Cassandra_Cluster_Builder, withWhiteListHosts)
 {
-    php_scylladb_cluster_builder *self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
+    auto self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
     php_scylladb_parse_hosts(INTERNAL_FUNCTION_PARAM_PASSTHRU, &self->whitelist_hosts);
 }
 ZEND_METHOD(Cassandra_Cluster_Builder, withBlackListDCs)
 {
-    php_scylladb_cluster_builder *self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
+    auto self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
     php_scylladb_parse_hosts(INTERNAL_FUNCTION_PARAM_PASSTHRU, &self->blacklist_dcs);
 }
 ZEND_METHOD(Cassandra_Cluster_Builder, withWhiteListDCs)
 {
-    php_scylladb_cluster_builder *self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
+    auto self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
     php_scylladb_parse_hosts(INTERNAL_FUNCTION_PARAM_PASSTHRU, &self->whitelist_dcs);
 }
 ZEND_METHOD(Cassandra_Cluster_Builder, withTokenAwareRouting)
@@ -451,7 +451,7 @@ ZEND_METHOD(Cassandra_Cluster_Builder, withTokenAwareRouting)
     Z_PARAM_BOOL(enabled)
     ZEND_PARSE_PARAMETERS_END();
 
-    php_scylladb_cluster_builder *self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
+    auto self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
     self->use_token_aware_routing = (cass_bool_t)(enabled);
 
     RETURN_ZVAL(getThis(), 1, 0);
@@ -466,7 +466,7 @@ ZEND_METHOD(Cassandra_Cluster_Builder, withCredentials)
     Z_PARAM_STR(password)
     ZEND_PARSE_PARAMETERS_END();
 
-    php_scylladb_cluster_builder *self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
+    auto self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
 
     if (self->username != nullptr)
     {
@@ -484,12 +484,12 @@ ZEND_METHOD(Cassandra_Cluster_Builder, withCredentials)
 }
 ZEND_METHOD(Cassandra_Cluster_Builder, withConnectTimeout)
 {
-    php_scylladb_cluster_builder *self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
+    auto self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
     php_scylladb_set_timeout(INTERNAL_FUNCTION_PARAM_PASSTHRU, &self->connect_timeout);
 }
 ZEND_METHOD(Cassandra_Cluster_Builder, withRequestTimeout)
 {
-    php_scylladb_cluster_builder *self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
+    auto self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
     php_scylladb_set_timeout(INTERNAL_FUNCTION_PARAM_PASSTHRU, &self->request_timeout);
 }
 ZEND_METHOD(Cassandra_Cluster_Builder, withSSL)
@@ -500,8 +500,8 @@ ZEND_METHOD(Cassandra_Cluster_Builder, withSSL)
     Z_PARAM_OBJECT_OF_CLASS(ssl_options, php_scylladb_ssl_options_ce)
     ZEND_PARSE_PARAMETERS_END();
 
-    php_scylladb_ssl *ssl = Z_SCYLLADB_SSL_P(ssl_options);
-    php_scylladb_cluster_builder *self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(ZEND_THIS);
+    auto ssl = Z_SCYLLADB_SSL_P(ssl_options);
+    auto self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(ZEND_THIS);
 
     if (self->ssl_options != nullptr)
     {
@@ -521,7 +521,7 @@ ZEND_METHOD(Cassandra_Cluster_Builder, withPersistentSessions)
     Z_PARAM_BOOL(enabled)
     ZEND_PARSE_PARAMETERS_END();
 
-    php_scylladb_cluster_builder *self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
+    auto self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
     self->persist = (cass_bool_t)(enabled);
 
     RETURN_ZVAL(getThis(), 1, 0);
@@ -542,7 +542,7 @@ ZEND_METHOD(Cassandra_Cluster_Builder, withProtocolVersion)
         return;
     }
 
-    php_scylladb_cluster_builder *self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
+    auto self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
     self->protocol_version = version;
 
     RETURN_ZVAL(getThis(), 1, 0);
@@ -563,7 +563,7 @@ ZEND_METHOD(Cassandra_Cluster_Builder, withIOThreads)
         return;
     }
 
-    php_scylladb_cluster_builder *self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
+    auto self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
     self->io_threads = (uint32_t)count;
 
     RETURN_ZVAL(getThis(), 1, 0);
@@ -602,7 +602,7 @@ ZEND_METHOD(Cassandra_Cluster_Builder, withConnectionsPerHost)
         return;
     }
 
-    php_scylladb_cluster_builder *self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
+    auto self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
     self->core_connections_per_host = core;
     self->max_connections_per_host = max;
 
@@ -610,7 +610,7 @@ ZEND_METHOD(Cassandra_Cluster_Builder, withConnectionsPerHost)
 }
 ZEND_METHOD(Cassandra_Cluster_Builder, withReconnectInterval)
 {
-    php_scylladb_cluster_builder *self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
+    auto self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
     php_scylladb_set_timeout(INTERNAL_FUNCTION_PARAM_PASSTHRU, &self->reconnect_interval);
 }
 ZEND_METHOD(Cassandra_Cluster_Builder, withLatencyAwareRouting)
@@ -622,7 +622,7 @@ ZEND_METHOD(Cassandra_Cluster_Builder, withLatencyAwareRouting)
     Z_PARAM_BOOL(enabled)
     ZEND_PARSE_PARAMETERS_END();
 
-    php_scylladb_cluster_builder *self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
+    auto self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
     self->enable_latency_aware_routing = (cass_bool_t)(enabled);
 
     RETURN_ZVAL(getThis(), 1, 0);
@@ -636,7 +636,7 @@ ZEND_METHOD(Cassandra_Cluster_Builder, withTCPNodelay)
     Z_PARAM_BOOL(enabled)
     ZEND_PARSE_PARAMETERS_END();
 
-    php_scylladb_cluster_builder *self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
+    auto self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
     self->enable_tcp_nodelay = (cass_bool_t)(enabled);
 
     RETURN_ZVAL(getThis(), 1, 0);
@@ -650,7 +650,7 @@ ZEND_METHOD(Cassandra_Cluster_Builder, withTCPKeepalive)
     Z_PARAM_DOUBLE_OR_NULL(delay, is_null)
     ZEND_PARSE_PARAMETERS_END();
 
-    php_scylladb_cluster_builder *self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
+    auto self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
 
     if (is_null)
     {
@@ -680,7 +680,7 @@ ZEND_METHOD(Cassandra_Cluster_Builder, withRetryPolicy)
     Z_PARAM_OBJECT_OF_CLASS(retry_policy, php_scylladb_retry_policy_ce)
     ZEND_PARSE_PARAMETERS_END();
 
-    php_scylladb_cluster_builder *self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
+    auto self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
     php_scylladb_retry_policy *policy = PHP_SCYLLADB_OBJ_FETCH(php_scylladb_retry_policy, Z_OBJ_P(retry_policy));
 
     if (self->retry_policy != nullptr)
@@ -701,14 +701,14 @@ ZEND_METHOD(Cassandra_Cluster_Builder, withTimestampGenerator)
     Z_PARAM_OBJECT_OF_CLASS(timestamp_gen, php_scylladb_timestamp_generator_ce)
     ZEND_PARSE_PARAMETERS_END();
 
-    php_scylladb_cluster_builder *self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
+    auto self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
 
     if (self->timestamp_gen != nullptr)
     {
         zend_object_release(&self->timestamp_gen->zendObject);
     }
 
-    php_scylladb_timestamp_gen *timestamp_generator = php_scylladb_timestamp_gen_object_fetch(Z_OBJ_P(timestamp_gen));
+    auto timestamp_generator = php_scylladb_timestamp_gen_object_fetch(Z_OBJ_P(timestamp_gen));
     self->timestamp_gen = timestamp_generator;
     GC_ADDREF(&timestamp_generator->zendObject);
 
@@ -723,7 +723,7 @@ ZEND_METHOD(Cassandra_Cluster_Builder, withSchemaMetadata)
     Z_PARAM_BOOL(enabled)
     ZEND_PARSE_PARAMETERS_END();
 
-    php_scylladb_cluster_builder *self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
+    auto self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
     self->enable_schema = (cass_bool_t)(enabled);
 
     RETURN_ZVAL(getThis(), 1, 0);
@@ -737,7 +737,7 @@ ZEND_METHOD(Cassandra_Cluster_Builder, withHostnameResolution)
     Z_PARAM_BOOL(enabled)
     ZEND_PARSE_PARAMETERS_END();
 
-    php_scylladb_cluster_builder *self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
+    auto self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
     self->enable_hostname_resolution = (cass_bool_t)(enabled);
 
     RETURN_ZVAL(getThis(), 1, 0);
@@ -751,7 +751,7 @@ ZEND_METHOD(Cassandra_Cluster_Builder, withRandomizedContactPoints)
     Z_PARAM_BOOL(enabled)
     ZEND_PARSE_PARAMETERS_END();
 
-    php_scylladb_cluster_builder *self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
+    auto self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
 
     self->enable_randomized_contact_points = (cass_bool_t)(enabled);
 
@@ -759,6 +759,6 @@ ZEND_METHOD(Cassandra_Cluster_Builder, withRandomizedContactPoints)
 }
 ZEND_METHOD(Cassandra_Cluster_Builder, withConnectionHeartbeatInterval)
 {
-    php_scylladb_cluster_builder *self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
+    auto self = PHP_SCYLLADB_GET_CLUSTER_BUILDER(getThis());
     php_scylladb_set_timeout(INTERNAL_FUNCTION_PARAM_PASSTHRU, &self->connection_heartbeat_interval);
 }

--- a/src/Cluster/Builder.stub.php
+++ b/src/Cluster/Builder.stub.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 namespace Cassandra\Cluster {
     /**
      * @strict-properties
+     * @not-serializable
  * @scylladb-struct php_scylladb_cluster_builder
  */    final class Builder
     {

--- a/src/Cluster/BuilderHandlers.c
+++ b/src/Cluster/BuilderHandlers.c
@@ -47,7 +47,7 @@ HashTable *php_scylladb_cluster_builder_properties(zend_object *object)
     zval randomizedContactPoints;
     zval connectionHeartbeatInterval;
 
-    php_scylladb_cluster_builder *self = php_scylladb_cluster_builder_object_fetch(object);
+    auto self = php_scylladb_cluster_builder_object_fetch(object);
     if (object->properties) {
         zend_array_release(object->properties);
     }
@@ -231,7 +231,7 @@ int php_scylladb_cluster_builder_compare(zval *obj1, zval *obj2)
 }
 void php_scylladb_cluster_builder_free(zend_object *object)
 {
-    php_scylladb_cluster_builder *self = php_scylladb_cluster_builder_object_fetch(object);
+    auto self = php_scylladb_cluster_builder_object_fetch(object);
 
     zend_string_release(self->contact_points);
     self->contact_points = nullptr;
@@ -306,8 +306,8 @@ void php_scylladb_cluster_builder_free(zend_object *object)
 }
 zend_object *php_scylladb_cluster_builder_new(zend_class_entry *ce)
 {
-    php_scylladb_cluster_builder *self = (php_scylladb_cluster_builder *)
-        emalloc(sizeof(php_scylladb_cluster_builder) + zend_object_properties_size(ce));
+    php_scylladb_cluster_builder *self =
+        PHP_SCYLLADB_OBJ_ALLOCATE(php_scylladb_cluster_builder, ce, &php_scylladb_cluster_builder_handlers);
 
     self->contact_points = zend_string_init_fast(ZEND_STRL("127.0.0.1"));
     self->port = 9042;
@@ -345,10 +345,6 @@ zend_object *php_scylladb_cluster_builder_new(zend_class_entry *ce)
     self->ssl_options = nullptr;
 
     ZVAL_UNDEF(&self->default_timeout);
-
-    zend_object_std_init(&self->zendObject, ce);
-    object_properties_init(&self->zendObject, ce);
-    self->zendObject.handlers = &php_scylladb_cluster_builder_handlers;
 
     return &self->zendObject;
 }

--- a/src/Cluster/DefaultCluster.c
+++ b/src/Cluster/DefaultCluster.c
@@ -73,7 +73,7 @@ ZEND_METHOD(Cassandra_DefaultCluster, connect)
         session->cache_key = cache_key;
 
         zval *le = zend_hash_index_find(&EG(persistent_list), cache_key);
-        if (le != NULL && Z_RES_P(le)->type == php_le_php_scylladb_session())
+        if (le != nullptr && Z_RES_P(le)->type == php_le_php_scylladb_session())
         {
             psession = (php_scylladb_psession *)Z_RES_P(le)->ptr;
             session->session = psession->session;   /* borrowed; psession owns */
@@ -81,7 +81,7 @@ ZEND_METHOD(Cassandra_DefaultCluster, connect)
         }
     }
 
-    if (future == NULL)
+    if (future == nullptr)
     {
         zval resource;
 
@@ -139,10 +139,10 @@ ZEND_METHOD(Cassandra_DefaultCluster, connect)
 
 ZEND_METHOD(Cassandra_DefaultCluster, connectAsync)
 {
-    char *keyspace = NULL;
+    char *keyspace = nullptr;
     size_t keyspace_len;
-    php_scylladb_cluster *self = NULL;
-    php_scylladb_future_session *future = NULL;
+    php_scylladb_cluster *self = nullptr;
+    php_scylladb_future_session *future = nullptr;
 
     ZEND_PARSE_PARAMETERS_START(0, 1)
         Z_PARAM_OPTIONAL
@@ -166,7 +166,7 @@ ZEND_METHOD(Cassandra_DefaultCluster, connectAsync)
         future->cache_key = php_scylladb_cache_key_mix_cstr(future->cache_key, SAFE_STR(keyspace));
 
         zval *le = zend_hash_index_find(&EG(persistent_list), future->cache_key);
-        if (le != NULL && Z_RES_P(le)->type == php_le_php_scylladb_session())
+        if (le != nullptr && Z_RES_P(le)->type == php_le_php_scylladb_session())
         {
             php_scylladb_psession *psession = (php_scylladb_psession *)Z_RES_P(le)->ptr;
             future->session = psession->session;   /* borrowed; psession owns */

--- a/src/Cluster/DefaultCluster.stub.php
+++ b/src/Cluster/DefaultCluster.stub.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 namespace Cassandra {
     /**
      * @strict-properties
+     * @not-serializable
  * @scylladb-struct php_scylladb_cluster
  */    final class DefaultCluster implements Cluster {
         public function connect(?string $keyspace = null, ?int $timeout = null): Session {}

--- a/src/Cluster/DefaultClusterHandlers.c
+++ b/src/Cluster/DefaultClusterHandlers.c
@@ -25,7 +25,7 @@ int php_scylladb_default_cluster_compare(zval *obj1, zval *obj2)
 
 void php_scylladb_default_cluster_free(zend_object *object)
 {
-    php_scylladb_cluster *self = php_scylladb_cluster_object_fetch(object);
+    auto self = php_scylladb_cluster_object_fetch(object);
 
     if (!self->persist && self->cluster)
     {
@@ -43,7 +43,8 @@ void php_scylladb_default_cluster_free(zend_object *object)
 
 zend_object *php_scylladb_default_cluster_new(zend_class_entry *ce)
 {
-    php_scylladb_cluster *self = (php_scylladb_cluster *)ecalloc(1, sizeof(php_scylladb_cluster) + zend_object_properties_size(ce));
+    php_scylladb_cluster *self =
+        PHP_SCYLLADB_OBJ_ALLOCATE(php_scylladb_cluster, ce, &php_scylladb_default_cluster_handlers);
 
     self->cluster = nullptr;
     self->default_consistency = PHP_SCYLLADB_DEFAULT_CONSISTENCY;
@@ -52,9 +53,6 @@ zend_object *php_scylladb_default_cluster_new(zend_class_entry *ce)
     self->cache_key = 0;
 
     ZVAL_UNDEF(&self->default_timeout);
-
-    zend_object_std_init(&self->zendObject, ce);
-    self->zendObject.handlers = &php_scylladb_default_cluster_handlers;
 
     return &self->zendObject;
 }

--- a/src/Collection.c
+++ b/src/Collection.c
@@ -36,7 +36,7 @@ php_scylladb_collection_add(php_scylladb_collection *collection, zval *object)
 }
 
 static int
-php_scylladb_collection_del(php_scylladb_collection *collection, ulong index)
+php_scylladb_collection_del(php_scylladb_collection *collection, zend_ulong index)
 {
   if (zend_hash_index_del(&collection->values, index) == SUCCESS) {
     collection->dirty = 1;
@@ -47,10 +47,10 @@ php_scylladb_collection_del(php_scylladb_collection *collection, ulong index)
 }
 
 static int
-php_scylladb_collection_get(php_scylladb_collection *collection, ulong index, zval *zvalue)
+php_scylladb_collection_get(php_scylladb_collection *collection, zend_ulong index, zval *zvalue)
 {
   zval *value;
-  if ((value = zend_hash_index_find(&collection->values, (zend_ulong)(index))) != NULL) {
+  if ((value = zend_hash_index_find(&collection->values, (zend_ulong)(index))) != nullptr) {
     *zvalue = *value;
     return 1;
   }
@@ -119,14 +119,14 @@ PHP_METHOD(Cassandra_Collection, __construct)
 /* {{{ Collection::type() */
 PHP_METHOD(Cassandra_Collection, type)
 {
-  php_scylladb_collection *self = PHP_SCYLLADB_GET_COLLECTION(getThis());
+  auto self = PHP_SCYLLADB_GET_COLLECTION(getThis());
   RETURN_ZVAL(&self->type, 1, 0);
 }
 
 /* {{{ Collection::values() */
 PHP_METHOD(Cassandra_Collection, values)
 {
-  php_scylladb_collection *collection = NULL;
+  php_scylladb_collection *collection = nullptr;
   array_init(return_value);
   collection = PHP_SCYLLADB_GET_COLLECTION(getThis());
   php_scylladb_collection_populate(collection, return_value);
@@ -136,8 +136,8 @@ PHP_METHOD(Cassandra_Collection, values)
 /* {{{ Collection::add(mixed) */
 PHP_METHOD(Cassandra_Collection, add)
 {
-  php_scylladb_collection *self = NULL;
-  zval* args = NULL;
+  php_scylladb_collection *self = nullptr;
+  zval* args = nullptr;
   int argc = 0, i;
   php_scylladb_type *type;
 
@@ -176,7 +176,7 @@ PHP_METHOD(Cassandra_Collection, add)
 PHP_METHOD(Cassandra_Collection, get)
 {
   zend_long key;
-  php_scylladb_collection *self = NULL;
+  php_scylladb_collection *self = nullptr;
   zval value;
 
   ZEND_PARSE_PARAMETERS_START(1, 1)
@@ -185,7 +185,7 @@ PHP_METHOD(Cassandra_Collection, get)
 
   self = PHP_SCYLLADB_GET_COLLECTION(getThis());
 
-  if (php_scylladb_collection_get(self, (ulong) key, &value))
+  if (php_scylladb_collection_get(self, (zend_ulong) key, &value))
     RETURN_ZVAL(&value, 1, 0);
 }
 /* }}} */
@@ -194,7 +194,7 @@ PHP_METHOD(Cassandra_Collection, get)
 PHP_METHOD(Cassandra_Collection, find)
 {
   zval *object;
-  php_scylladb_collection *collection = NULL;
+  php_scylladb_collection *collection = nullptr;
   long index;
 
   ZEND_PARSE_PARAMETERS_START(1, 1)
@@ -211,7 +211,7 @@ PHP_METHOD(Cassandra_Collection, find)
 /* {{{ Collection::count() */
 PHP_METHOD(Cassandra_Collection, count)
 {
-  php_scylladb_collection *collection = PHP_SCYLLADB_GET_COLLECTION(getThis());
+  auto collection = PHP_SCYLLADB_GET_COLLECTION(getThis());
   RETURN_LONG(zend_hash_num_elements(&collection->values));
 }
 /* }}} */
@@ -220,9 +220,9 @@ PHP_METHOD(Cassandra_Collection, count)
 PHP_METHOD(Cassandra_Collection, current)
 {
   zval *current;
-  php_scylladb_collection *collection = PHP_SCYLLADB_GET_COLLECTION(getThis());
+  auto collection = PHP_SCYLLADB_GET_COLLECTION(getThis());
 
-  if ((current = zend_hash_get_current_data(&collection->values)) != NULL) {
+  if ((current = zend_hash_get_current_data(&collection->values)) != nullptr) {
     RETURN_ZVAL(current, 1, 0);
   }
 }
@@ -232,8 +232,8 @@ PHP_METHOD(Cassandra_Collection, current)
 PHP_METHOD(Cassandra_Collection, key)
 {
   zend_ulong num_key;
-  php_scylladb_collection *collection = PHP_SCYLLADB_GET_COLLECTION(getThis());
-  if (zend_hash_get_current_key(&collection->values, NULL, &num_key) == HASH_KEY_IS_LONG) {
+  auto collection = PHP_SCYLLADB_GET_COLLECTION(getThis());
+  if (zend_hash_get_current_key(&collection->values, nullptr, &num_key) == HASH_KEY_IS_LONG) {
     RETURN_LONG(num_key);
   }
 }
@@ -242,7 +242,7 @@ PHP_METHOD(Cassandra_Collection, key)
 /* {{{ Collection::next() */
 PHP_METHOD(Cassandra_Collection, next)
 {
-  php_scylladb_collection *collection = PHP_SCYLLADB_GET_COLLECTION(getThis());
+  auto collection = PHP_SCYLLADB_GET_COLLECTION(getThis());
   zend_hash_move_forward(&collection->values);
 }
 /* }}} */
@@ -250,7 +250,7 @@ PHP_METHOD(Cassandra_Collection, next)
 /* {{{ Collection::valid() */
 PHP_METHOD(Cassandra_Collection, valid)
 {
-  php_scylladb_collection *collection = PHP_SCYLLADB_GET_COLLECTION(getThis());
+  auto collection = PHP_SCYLLADB_GET_COLLECTION(getThis());
   RETURN_BOOL(zend_hash_has_more_elements(&collection->values) == SUCCESS);
 }
 /* }}} */
@@ -258,7 +258,7 @@ PHP_METHOD(Cassandra_Collection, valid)
 /* {{{ Collection::rewind() */
 PHP_METHOD(Cassandra_Collection, rewind)
 {
-  php_scylladb_collection *collection = PHP_SCYLLADB_GET_COLLECTION(getThis());
+  auto collection = PHP_SCYLLADB_GET_COLLECTION(getThis());
   zend_hash_internal_pointer_reset(&collection->values);
 }
 /* }}} */
@@ -267,7 +267,7 @@ PHP_METHOD(Cassandra_Collection, rewind)
 PHP_METHOD(Cassandra_Collection, remove)
 {
   zend_long index;
-  php_scylladb_collection *collection = NULL;
+  php_scylladb_collection *collection = nullptr;
 
   ZEND_PARSE_PARAMETERS_START(1, 1)
     Z_PARAM_LONG(index)
@@ -275,7 +275,7 @@ PHP_METHOD(Cassandra_Collection, remove)
 
   collection = PHP_SCYLLADB_GET_COLLECTION(getThis());
 
-  if (php_scylladb_collection_del(collection, (ulong) index)) {
+  if (php_scylladb_collection_del(collection, (zend_ulong) index)) {
     RETURN_TRUE;
   }
 
@@ -296,7 +296,7 @@ php_scylladb_collection_properties(zend_object *object)
 {
   zval values;
 
-  php_scylladb_collection  *self = php_scylladb_collection_object_fetch(object);
+  auto self = php_scylladb_collection_object_fetch(object);
   if (object->properties) {
     zend_array_release(object->properties);
   }
@@ -347,8 +347,8 @@ php_scylladb_collection_compare(zval *obj1, zval *obj2)
   zend_hash_internal_pointer_reset_ex(&collection1->values, &pos1);
   zend_hash_internal_pointer_reset_ex(&collection2->values, &pos2);
 
-  while ((current1 = zend_hash_get_current_data_ex(&collection1->values, &pos1)) != NULL &&
-         (current2 = zend_hash_get_current_data_ex(&collection2->values, &pos2)) != NULL) {
+  while ((current1 = zend_hash_get_current_data_ex(&collection1->values, &pos1)) != nullptr &&
+         (current2 = zend_hash_get_current_data_ex(&collection2->values, &pos2)) != nullptr) {
     result = php_scylladb_value_compare(current1,
                                          current2);
     if (result != 0) return result;
@@ -364,7 +364,7 @@ php_scylladb_collection_hash_value(zval *obj)
 {
   zval *current;
   unsigned hashv = 0;
-  php_scylladb_collection *self = PHP_SCYLLADB_GET_COLLECTION(obj);
+  auto self = PHP_SCYLLADB_GET_COLLECTION(obj);
 
   if (!self->dirty) return self->hashv;
 
@@ -396,22 +396,19 @@ zend_object*
 php_scylladb_collection_new(zend_class_entry *ce)
 {
   php_scylladb_collection *self =
-      (php_scylladb_collection *)ecalloc(1, sizeof(php_scylladb_collection) + zend_object_properties_size(ce));
+      PHP_SCYLLADB_OBJ_ALLOCATE(php_scylladb_collection, ce, &php_scylladb_collection_handlers);
 
-  zend_hash_init(&self->values, 0, NULL, ZVAL_PTR_DTOR, 0);
+  zend_hash_init(&self->values, 0, nullptr, ZVAL_PTR_DTOR, 0);
   self->dirty = 1;
   ZVAL_UNDEF(&self->type);
 
-  zend_object_std_init(&self->zendObject, ce);
   php_scylladb_collection_handlers.std.offset = XtOffsetOf(php_scylladb_collection, zendObject);
   php_scylladb_collection_handlers.std.free_obj = php_scylladb_collection_free;
-  self->zendObject.handlers = (zend_object_handlers *)&php_scylladb_collection_handlers;
   return &self->zendObject;
 }
 
 
-void php_scylladb_collection_post_register(zend_class_entry *ce)
+void php_scylladb_collection_post_register([[maybe_unused]] zend_class_entry *ce)
 {
-    (void)ce;
     php_scylladb_collection_handlers.std.offset = XtOffsetOf(php_scylladb_collection, zendObject);
 }

--- a/src/Core.c
+++ b/src/Core.c
@@ -23,22 +23,19 @@ ZEND_METHOD(Cassandra, ssl) {
 
 static void override_class_constant_string(zend_class_entry *ce, const char *name, const char *value) {
     zend_class_constant *c = (zend_class_constant *)zend_hash_str_find_ptr(&ce->constants_table, name, strlen(name));
-    if (c == NULL) return;
+    if (c == nullptr) return;
     zval_ptr_dtor(&c->value);
     ZVAL_STR(&c->value, zend_string_init(value, strlen(value), 1));
 }
 
 void php_scylladb_core_post_register(zend_class_entry *ce)
 {
-    /* CPP_DRIVER_VERSION is runtime-computed from the linked driver. The stub
-       has a placeholder; override it here with the real value before any
-       user code can observe it. */
+    /* VERSION is now wired in the stub via @cvalue PHP_SCYLLADB_VERSION.
+     * CPP_DRIVER_VERSION still needs runtime composition because
+     * CASS_VERSION_SUFFIX may be empty and we don't want a trailing dash. */
     char buf[64];
     snprintf(buf, sizeof(buf), "%d.%d.%d%s",
              CASS_VERSION_MAJOR, CASS_VERSION_MINOR, CASS_VERSION_PATCH,
              strlen(CASS_VERSION_SUFFIX) > 0 ? "-" CASS_VERSION_SUFFIX : "");
     override_class_constant_string(ce, "CPP_DRIVER_VERSION", buf);
-
-    /* VERSION constant set to PHP_SCYLLADB_VERSION (overrides stub placeholder). */
-    override_class_constant_string(ce, "VERSION", PHP_SCYLLADB_VERSION);
 }

--- a/src/Custom.c
+++ b/src/Custom.c
@@ -19,7 +19,7 @@
 
 #include <Registry/Registry.h>
 
-zend_class_entry* php_scylladb_custom_ce = NULL;
+zend_class_entry* php_scylladb_custom_ce = nullptr;
 
 static zend_function_entry php_scylladb_custom_methods[] = {
   PHP_FE_END

--- a/src/Database/DefaultAggregate.c
+++ b/src/Database/DefaultAggregate.c
@@ -132,7 +132,7 @@ ZEND_METHOD(Cassandra_DefaultAggregate, initialCondition)
   self = PHP_SCYLLADB_GET_AGGREGATE(getThis());
   if (Z_ISUNDEF(self->initial_condition)) {
     const CassValue *value = cass_aggregate_meta_init_cond(self->meta);
-    const CassDataType *data_type = NULL;
+    const CassDataType *data_type = nullptr;
     if (!value) {
       return;
     }
@@ -198,9 +198,9 @@ ZEND_METHOD(Cassandra_DefaultAggregate, signature)
 HashTable *
 php_scylladb_default_aggregate_gc(zend_object *object, zval** table, int *n)
 {
-  *table = NULL;
+  *table = nullptr;
   *n = 0;
-  return NULL;
+  return nullptr;
 }
 
 HashTable *
@@ -224,7 +224,7 @@ php_scylladb_default_aggregate_compare(zval *obj1, zval *obj2 )
 void
 php_scylladb_default_aggregate_free(zend_object *object )
 {
-  php_scylladb_aggregate *self = php_scylladb_aggregate_object_fetch(object);
+  auto self = php_scylladb_aggregate_object_fetch(object);
 
   zval_ptr_dtor(&self->simple_name);
   zval_ptr_dtor(&self->argument_types);
@@ -239,7 +239,7 @@ php_scylladb_default_aggregate_free(zend_object *object )
     zval_ptr_dtor(&self->schema);
     ZVAL_UNDEF(&self->schema);
   }
-  self->meta = NULL;
+  self->meta = nullptr;
 
   zend_object_std_dtor(&self->zendObject);
 
@@ -249,7 +249,7 @@ zend_object*
 php_scylladb_default_aggregate_new(zend_class_entry *ce )
 {
   php_scylladb_aggregate *self =
-      (php_scylladb_aggregate *)ecalloc(1, sizeof(php_scylladb_aggregate) + zend_object_properties_size(ce));
+      PHP_SCYLLADB_OBJ_ALLOCATE(php_scylladb_aggregate, ce, &php_scylladb_default_aggregate_handlers);
 
   ZVAL_UNDEF(&self->simple_name);
   ZVAL_UNDEF(&self->argument_types);
@@ -261,11 +261,9 @@ php_scylladb_default_aggregate_new(zend_class_entry *ce )
   ZVAL_UNDEF(&self->signature);
 
   ZVAL_UNDEF(&self->schema);
-  self->meta = NULL;
+  self->meta = nullptr;
 
-  zend_object_std_init(&self->zendObject, ce);
   php_scylladb_default_aggregate_handlers.offset = XtOffsetOf(php_scylladb_aggregate, zendObject);
   php_scylladb_default_aggregate_handlers.free_obj = php_scylladb_default_aggregate_free;
-  self->zendObject.handlers = (zend_object_handlers *)&php_scylladb_default_aggregate_handlers;
   return &self->zendObject;
 }

--- a/src/Database/DefaultAggregate.stub.php
+++ b/src/Database/DefaultAggregate.stub.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 namespace Cassandra {
     /**
      * @strict-properties
+     * @not-serializable
  * @scylladb-struct php_scylladb_aggregate
  */    final class DefaultAggregate implements \Cassandra\Aggregate {
         public function name(): string {}

--- a/src/Database/DefaultColumn.c
+++ b/src/Database/DefaultColumn.c
@@ -206,9 +206,9 @@ ZEND_METHOD(Cassandra_DefaultColumn, indexOptions)
 HashTable *
 php_scylladb_default_column_gc(zend_object *object, zval** table, int *n)
 {
-  *table = NULL;
+  *table = nullptr;
   *n = 0;
-  return NULL;
+  return nullptr;
 }
 
 HashTable *
@@ -232,7 +232,7 @@ php_scylladb_default_column_compare(zval *obj1, zval *obj2 )
 void
 php_scylladb_default_column_free(zend_object *object )
 {
-  php_scylladb_column *self = php_scylladb_column_object_fetch(object);
+  auto self = php_scylladb_column_object_fetch(object);
 
   zval_ptr_dtor(&self->name);
   zval_ptr_dtor(&self->type);
@@ -241,7 +241,7 @@ php_scylladb_default_column_free(zend_object *object )
     zval_ptr_dtor(&self->schema);
     ZVAL_UNDEF(&self->schema);
   }
-  self->meta = NULL;
+  self->meta = nullptr;
 
   zend_object_std_dtor(&self->zendObject);
 
@@ -251,18 +251,16 @@ zend_object*
 php_scylladb_default_column_new(zend_class_entry *ce )
 {
   php_scylladb_column *self =
-      (php_scylladb_column *)ecalloc(1, sizeof(php_scylladb_column) + zend_object_properties_size(ce));
+      PHP_SCYLLADB_OBJ_ALLOCATE(php_scylladb_column, ce, &php_scylladb_default_column_handlers);
 
   self->reversed = 0;
   self->frozen   = 0;
   ZVAL_UNDEF(&self->schema);
-  self->meta     = NULL;
+  self->meta     = nullptr;
   ZVAL_UNDEF(&self->name);
   ZVAL_UNDEF(&self->type);
 
-  zend_object_std_init(&self->zendObject, ce);
   php_scylladb_default_column_handlers.offset = XtOffsetOf(php_scylladb_column, zendObject);
   php_scylladb_default_column_handlers.free_obj = php_scylladb_default_column_free;
-  self->zendObject.handlers = (zend_object_handlers *)&php_scylladb_default_column_handlers;
   return &self->zendObject;
 }

--- a/src/Database/DefaultColumn.stub.php
+++ b/src/Database/DefaultColumn.stub.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 namespace Cassandra {
     /**
      * @strict-properties
+     * @not-serializable
  * @scylladb-struct php_scylladb_column
  */    final class DefaultColumn implements \Cassandra\Column {
         public function name(): string {}

--- a/src/Database/DefaultFunction.c
+++ b/src/Database/DefaultFunction.c
@@ -189,9 +189,9 @@ ZEND_METHOD(Cassandra_DefaultFunction, isCalledOnNullInput)
 HashTable *
 php_scylladb_default_function_gc(zend_object *object, zval** table, int *n)
 {
-  *table = NULL;
+  *table = nullptr;
   *n = 0;
-  return NULL;
+  return nullptr;
 }
 
 HashTable *
@@ -215,7 +215,7 @@ php_scylladb_default_function_compare(zval *obj1, zval *obj2 )
 void
 php_scylladb_default_function_free(zend_object *object )
 {
-  php_scylladb_function *self = php_scylladb_function_object_fetch(object);
+  auto self = php_scylladb_function_object_fetch(object);
 
   zval_ptr_dtor(&self->simple_name);
   zval_ptr_dtor(&self->arguments);
@@ -228,7 +228,7 @@ php_scylladb_default_function_free(zend_object *object )
     zval_ptr_dtor(&self->schema);
     ZVAL_UNDEF(&self->schema);
   }
-  self->meta = NULL;
+  self->meta = nullptr;
 
   zend_object_std_dtor(&self->zendObject);
 
@@ -238,7 +238,7 @@ zend_object*
 php_scylladb_default_function_new(zend_class_entry *ce )
 {
   php_scylladb_function *self =
-      (php_scylladb_function *)ecalloc(1, sizeof(php_scylladb_function) + zend_object_properties_size(ce));
+      PHP_SCYLLADB_OBJ_ALLOCATE(php_scylladb_function, ce, &php_scylladb_default_function_handlers);
 
   ZVAL_UNDEF(&self->simple_name);
   ZVAL_UNDEF(&self->arguments);
@@ -248,11 +248,9 @@ php_scylladb_default_function_new(zend_class_entry *ce )
   ZVAL_UNDEF(&self->body);
 
   ZVAL_UNDEF(&self->schema);
-  self->meta = NULL;
+  self->meta = nullptr;
 
-  zend_object_std_init(&self->zendObject, ce);
   php_scylladb_default_function_handlers.offset = XtOffsetOf(php_scylladb_function, zendObject);
   php_scylladb_default_function_handlers.free_obj = php_scylladb_default_function_free;
-  self->zendObject.handlers = (zend_object_handlers *)&php_scylladb_default_function_handlers;
   return &self->zendObject;
 }

--- a/src/Database/DefaultFunction.stub.php
+++ b/src/Database/DefaultFunction.stub.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 namespace Cassandra {
     /**
      * @strict-properties
+     * @not-serializable
  * @scylladb-struct php_scylladb_function
  */    final class DefaultFunction implements \Cassandra\Function_ {
         public function name(): string {}

--- a/src/Database/DefaultIndex.c
+++ b/src/Database/DefaultIndex.c
@@ -150,7 +150,7 @@ ZEND_METHOD(Cassandra_DefaultIndex, option)
     php_scylladb_index_build_option(self);
   }
 
-  if ((result = zend_hash_str_find(Z_ARRVAL(self->options), name, name_len)) != NULL) {
+  if ((result = zend_hash_str_find(Z_ARRVAL(self->options), name, name_len)) != nullptr) {
     RETURN_ZVAL(result, 1, 0);
   }
   RETURN_FALSE;
@@ -184,7 +184,7 @@ ZEND_METHOD(Cassandra_DefaultIndex, className)
     php_scylladb_index_build_option(self);
   }
 
-  if ((result = zend_hash_str_find(Z_ARRVAL(self->options), ZEND_STRL("class_name"))) != NULL) {
+  if ((result = zend_hash_str_find(Z_ARRVAL(self->options), ZEND_STRL("class_name"))) != nullptr) {
     RETURN_ZVAL(result, 1, 0);
   }
   RETURN_FALSE;
@@ -210,9 +210,9 @@ ZEND_METHOD(Cassandra_DefaultIndex, isCustom)
 HashTable *
 php_scylladb_default_index_gc(zend_object *object, zval** table, int *n)
 {
-  *table = NULL;
+  *table = nullptr;
   *n = 0;
-  return NULL;
+  return nullptr;
 }
 
 HashTable *
@@ -236,7 +236,7 @@ php_scylladb_default_index_compare(zval *obj1, zval *obj2 )
 void
 php_scylladb_default_index_free(zend_object *object )
 {
-  php_scylladb_index *self = php_scylladb_index_object_fetch(object);
+  auto self = php_scylladb_index_object_fetch(object);
 
   zval_ptr_dtor(&self->name);
   zval_ptr_dtor(&self->kind);
@@ -247,7 +247,7 @@ php_scylladb_default_index_free(zend_object *object )
     zval_ptr_dtor(&self->schema);
     ZVAL_UNDEF(&self->schema);
   }
-  self->meta = NULL;
+  self->meta = nullptr;
 
   zend_object_std_dtor(&self->zendObject);
 
@@ -257,7 +257,7 @@ zend_object*
 php_scylladb_default_index_new(zend_class_entry *ce )
 {
   php_scylladb_index *self =
-      (php_scylladb_index *)ecalloc(1, sizeof(php_scylladb_index) + zend_object_properties_size(ce));
+      PHP_SCYLLADB_OBJ_ALLOCATE(php_scylladb_index, ce, &php_scylladb_default_index_handlers);
 
   ZVAL_UNDEF(&self->name);
   ZVAL_UNDEF(&self->kind);
@@ -265,11 +265,9 @@ php_scylladb_default_index_new(zend_class_entry *ce )
   ZVAL_UNDEF(&self->options);
 
   ZVAL_UNDEF(&self->schema);
-  self->meta = NULL;
+  self->meta = nullptr;
 
-  zend_object_std_init(&self->zendObject, ce);
   php_scylladb_default_index_handlers.offset = XtOffsetOf(php_scylladb_index, zendObject);
   php_scylladb_default_index_handlers.free_obj = php_scylladb_default_index_free;
-  self->zendObject.handlers = (zend_object_handlers *)&php_scylladb_default_index_handlers;
   return &self->zendObject;
 }

--- a/src/Database/DefaultIndex.stub.php
+++ b/src/Database/DefaultIndex.stub.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 namespace Cassandra {
     /**
      * @strict-properties
+     * @not-serializable
  * @scylladb-struct php_scylladb_index
  */    final class DefaultIndex implements \Cassandra\Index {
         public function name(): string {}

--- a/src/Database/DefaultKeyspace.c
+++ b/src/Database/DefaultKeyspace.c
@@ -87,7 +87,7 @@ ZEND_METHOD(Cassandra_DefaultKeyspace, table) {
 
   self = PHP_SCYLLADB_GET_KEYSPACE(getThis());
   meta = cass_keyspace_meta_table_by_name_n(self->meta, name, name_len);
-  if (meta == NULL) {
+  if (meta == nullptr) {
     RETURN_FALSE;
   }
 
@@ -149,7 +149,7 @@ ZEND_METHOD(Cassandra_DefaultKeyspace, userType) {
   self = PHP_SCYLLADB_GET_KEYSPACE(getThis());
   user_type = cass_keyspace_meta_user_type_by_name_n(self->meta, name, name_len);
 
-  if (user_type == NULL) {
+  if (user_type == nullptr) {
     return;
   }
 
@@ -196,7 +196,7 @@ ZEND_METHOD(Cassandra_DefaultKeyspace, materializedView) {
 
   self = PHP_SCYLLADB_GET_KEYSPACE(getThis());
   meta = cass_keyspace_meta_materialized_view_by_name_n(self->meta, name, name_len);
-  if (meta == NULL) {
+  if (meta == nullptr) {
     RETURN_FALSE;
   }
 
@@ -258,7 +258,7 @@ int php_scylladb_arguments_string(zval* args, int argc, smart_str *arguments) {
       smart_str_appendl_ex(arguments, Z_STRVAL_P(argument_type), Z_STRLEN_P(argument_type), 0);
     } else if (Z_TYPE_P(argument_type) == IS_OBJECT &&
                instanceof_function(Z_OBJCE_P(argument_type), php_scylladb_type_ce)) {
-      php_scylladb_type *type = PHP_SCYLLADB_GET_TYPE(argument_type);
+      auto type = PHP_SCYLLADB_GET_TYPE(argument_type);
       php_scylladb_type_string(type, arguments);
     } else {
       zend_throw_exception_ex(
@@ -278,10 +278,10 @@ ZEND_METHOD(Cassandra_DefaultKeyspace, function) {
   php_scylladb_keyspace *self;
   char *name;
   size_t name_len;
-  zval* args = NULL;
-  smart_str arguments = {NULL,0};
+  zval* args = nullptr;
+  smart_str arguments = {nullptr,0};
   int argc = 0;
-  const CassFunctionMeta *meta = NULL;
+  const CassFunctionMeta *meta = nullptr;
 
   ZEND_PARSE_PARAMETERS_START(1, -1)
     Z_PARAM_STRING(name, name_len)
@@ -299,7 +299,7 @@ ZEND_METHOD(Cassandra_DefaultKeyspace, function) {
   }
 
   meta = cass_keyspace_meta_function_by_name_n(self->meta, name, name_len,
-                                               (arguments.s ? arguments.s->val : NULL),
+                                               (arguments.s ? arguments.s->val : nullptr),
                                                (arguments.s ? arguments.s->len : 0));
   if (meta) {
     zval zfunction = php_scylladb_create_function(&self->schema, meta);
@@ -327,7 +327,7 @@ ZEND_METHOD(Cassandra_DefaultKeyspace, functions) {
     zval zfunction = php_scylladb_create_function(&self->schema, meta);
 
     if (!Z_ISUNDEF(zfunction)) {
-      php_scylladb_function *function = PHP_SCYLLADB_GET_FUNCTION(&zfunction);
+      auto function = PHP_SCYLLADB_GET_FUNCTION(&zfunction);
 
       if (Z_TYPE(function->signature) == IS_STRING) {
         add_assoc_zval_ex(return_value, Z_STRVAL(function->signature), Z_STRLEN(function->signature), &zfunction);
@@ -367,10 +367,10 @@ ZEND_METHOD(Cassandra_DefaultKeyspace, aggregate) {
   char *name;
   size_t name_len;
   zval *args;
-  args = NULL;
-  smart_str arguments = {NULL, 0};
+  args = nullptr;
+  smart_str arguments = {nullptr, 0};
   int argc = 0;
-  const CassAggregateMeta *meta = NULL;
+  const CassAggregateMeta *meta = nullptr;
 
   ZEND_PARSE_PARAMETERS_START(1, -1)
     Z_PARAM_STRING(name, name_len)
@@ -388,7 +388,7 @@ ZEND_METHOD(Cassandra_DefaultKeyspace, aggregate) {
   }
 
   meta = cass_keyspace_meta_aggregate_by_name_n(self->meta, name, name_len,
-                                                (arguments.s ? arguments.s->val : NULL),
+                                                (arguments.s ? arguments.s->val : nullptr),
                                                 (arguments.s ? arguments.s->len : 0));
   if (meta) {
     zval zaggregate = php_scylladb_create_aggregate(&self->schema, meta);
@@ -416,7 +416,7 @@ ZEND_METHOD(Cassandra_DefaultKeyspace, aggregates) {
     zval zaggregate = php_scylladb_create_aggregate(&self->schema, meta);
 
     if (!Z_ISUNDEF(zaggregate)) {
-      php_scylladb_aggregate *aggregate = PHP_SCYLLADB_GET_AGGREGATE(&zaggregate);
+      auto aggregate = PHP_SCYLLADB_GET_AGGREGATE(&zaggregate);
 
       if (Z_TYPE(aggregate->signature) == IS_STRING) {
         add_assoc_zval_ex(return_value, Z_STRVAL(aggregate->signature), Z_STRLEN(aggregate->signature), &zaggregate);
@@ -430,9 +430,9 @@ ZEND_METHOD(Cassandra_DefaultKeyspace, aggregates) {
 }
 
 HashTable *php_scylladb_default_keyspace_gc(zend_object *object, zval** table, int *n) {
-  *table = NULL;
+  *table = nullptr;
   *n = 0;
-  return NULL;
+  return nullptr;
 }
 
 HashTable *php_scylladb_default_keyspace_properties(zend_object *object) {
@@ -449,27 +449,26 @@ int php_scylladb_default_keyspace_compare(zval *obj1, zval *obj2) {
 }
 
 void php_scylladb_default_keyspace_free(zend_object *object) {
-  php_scylladb_keyspace *self = php_scylladb_keyspace_object_fetch(object);
+  auto self = php_scylladb_keyspace_object_fetch(object);
 
   if (!Z_ISUNDEF(self->schema)) {
     zval_ptr_dtor(&self->schema);
     ZVAL_UNDEF(&self->schema);
   }
-  self->meta = NULL;
+  self->meta = nullptr;
 
   zend_object_std_dtor(&self->zendObject);
 
 }
 
 zend_object* php_scylladb_default_keyspace_new(zend_class_entry *ce) {
-  php_scylladb_keyspace *self = (php_scylladb_keyspace *)ecalloc(1, sizeof(php_scylladb_keyspace) + zend_object_properties_size(ce));
+  php_scylladb_keyspace *self =
+      PHP_SCYLLADB_OBJ_ALLOCATE(php_scylladb_keyspace, ce, &php_scylladb_default_keyspace_handlers);
 
-  self->meta = NULL;
+  self->meta = nullptr;
   ZVAL_UNDEF(&self->schema);
 
-  zend_object_std_init(&self->zendObject, ce);
   php_scylladb_default_keyspace_handlers.offset = XtOffsetOf(php_scylladb_keyspace, zendObject);
   php_scylladb_default_keyspace_handlers.free_obj = php_scylladb_default_keyspace_free;
-  self->zendObject.handlers = (zend_object_handlers *)&php_scylladb_default_keyspace_handlers;
   return &self->zendObject;
 }

--- a/src/Database/DefaultKeyspace.stub.php
+++ b/src/Database/DefaultKeyspace.stub.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 namespace Cassandra {
     /**
      * @strict-properties
+     * @not-serializable
  * @scylladb-struct php_scylladb_keyspace
  */    final class DefaultKeyspace implements \Cassandra\Keyspace {
         public function name(): string {}

--- a/src/Database/DefaultMaterializedView.c
+++ b/src/Database/DefaultMaterializedView.c
@@ -103,7 +103,7 @@ php_scylladb_materialized_view_get_option(php_scylladb_materialized_view *view,
     php_scylladb_default_materialized_view_build_options(view );
   }
 
-  if ((zvalue = zend_hash_str_find(Z_ARRVAL(view->options), name, strlen(name))) == NULL) {
+  if ((zvalue = zend_hash_str_find(Z_ARRVAL(view->options), name, strlen(name))) == nullptr) {
     ZVAL_FALSE(result);
     return;
   }
@@ -138,7 +138,7 @@ ZEND_METHOD(Cassandra_DefaultMaterializedView, option)
     php_scylladb_default_materialized_view_build_options(self );
   }
 
-  if ((result = zend_hash_str_find(Z_ARRVAL(self->options), name, name_len)) != NULL) {
+  if ((result = zend_hash_str_find(Z_ARRVAL(self->options), name, name_len)) != nullptr) {
     RETURN_ZVAL(result, 1, 0);
   }
   RETURN_FALSE;
@@ -377,7 +377,7 @@ ZEND_METHOD(Cassandra_DefaultMaterializedView, column)
 
   self = PHP_SCYLLADB_GET_MATERIALIZED_VIEW(getThis());
   meta = cass_materialized_view_meta_column_by_name(self->meta, name);
-  if (meta == NULL) {
+  if (meta == nullptr) {
     RETURN_FALSE;
   }
 
@@ -531,9 +531,9 @@ ZEND_METHOD(Cassandra_DefaultMaterializedView, baseTable)
 HashTable *
 php_scylladb_default_materialized_view_gc(zend_object *object, zval** table, int *n)
 {
-  *table = NULL;
+  *table = nullptr;
   *n = 0;
-  return NULL;
+  return nullptr;
 }
 
 HashTable *
@@ -557,7 +557,7 @@ php_scylladb_default_materialized_view_compare(zval *obj1, zval *obj2 )
 void
 php_scylladb_default_materialized_view_free(zend_object *object )
 {
-  php_scylladb_materialized_view *self = php_scylladb_materialized_view_object_fetch(object);
+  auto self = php_scylladb_materialized_view_object_fetch(object);
 
   zval_ptr_dtor(&self->name);
   zval_ptr_dtor(&self->options);
@@ -571,7 +571,7 @@ php_scylladb_default_materialized_view_free(zend_object *object )
     zval_ptr_dtor(&self->schema);
     ZVAL_UNDEF(&self->schema);
   }
-  self->meta = NULL;
+  self->meta = nullptr;
 
   zend_object_std_dtor(&self->zendObject);
 
@@ -581,7 +581,8 @@ zend_object*
 php_scylladb_default_materialized_view_new(zend_class_entry *ce )
 {
   php_scylladb_materialized_view *self =
-      (php_scylladb_materialized_view *)ecalloc(1, sizeof(php_scylladb_materialized_view) + zend_object_properties_size(ce));
+      PHP_SCYLLADB_OBJ_ALLOCATE(php_scylladb_materialized_view, ce,
+                                &php_scylladb_default_materialized_view_handlers);
 
   ZVAL_UNDEF(&self->name);
   ZVAL_UNDEF(&self->options);
@@ -591,12 +592,10 @@ php_scylladb_default_materialized_view_new(zend_class_entry *ce )
   ZVAL_UNDEF(&self->clustering_order);
   ZVAL_UNDEF(&self->base_table);
 
-  self->meta   = NULL;
+  self->meta   = nullptr;
   ZVAL_UNDEF(&self->schema);
 
-  zend_object_std_init(&self->zendObject, ce);
   php_scylladb_default_materialized_view_handlers.offset = XtOffsetOf(php_scylladb_materialized_view, zendObject);
   php_scylladb_default_materialized_view_handlers.free_obj = php_scylladb_default_materialized_view_free;
-  self->zendObject.handlers = (zend_object_handlers *)&php_scylladb_default_materialized_view_handlers;
   return &self->zendObject;
 }

--- a/src/Database/DefaultMaterializedView.stub.php
+++ b/src/Database/DefaultMaterializedView.stub.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 namespace Cassandra {
     /**
      * @strict-properties
+     * @not-serializable
  * @scylladb-struct php_scylladb_materialized_view
  */    final class DefaultMaterializedView extends \Cassandra\MaterializedView {
         public function name(): string {}

--- a/src/Database/DefaultSchema.c
+++ b/src/Database/DefaultSchema.c
@@ -34,7 +34,7 @@ ZEND_METHOD(Cassandra_DefaultSchema, keyspace)
 
   self = PHP_SCYLLADB_GET_SCHEMA(getThis());
   meta = cass_schema_meta_keyspace_by_name_n(self->schema_meta, name, name_len);
-  if (meta == NULL) {
+  if (meta == nullptr) {
     RETURN_FALSE;
   }
 
@@ -114,11 +114,11 @@ php_scylladb_default_schema_compare(zval *obj1, zval *obj2 )
 void
 php_scylladb_default_schema_free(zend_object *object )
 {
-  php_scylladb_schema *self = php_scylladb_schema_object_fetch(object);
+  auto self = php_scylladb_schema_object_fetch(object);
 
   if (self->schema_meta) {
     cass_schema_meta_free(self->schema_meta);
-    self->schema_meta = NULL;
+    self->schema_meta = nullptr;
   }
 
   zend_object_std_dtor(&self->zendObject);
@@ -129,13 +129,11 @@ zend_object*
 php_scylladb_default_schema_new(zend_class_entry *ce )
 {
   php_scylladb_schema *self =
-      (php_scylladb_schema *)ecalloc(1, sizeof(php_scylladb_schema) + zend_object_properties_size(ce));
+      PHP_SCYLLADB_OBJ_ALLOCATE(php_scylladb_schema, ce, &php_scylladb_default_schema_handlers);
 
-  self->schema_meta = NULL;
+  self->schema_meta = nullptr;
 
-  zend_object_std_init(&self->zendObject, ce);
   php_scylladb_default_schema_handlers.offset = XtOffsetOf(php_scylladb_schema, zendObject);
   php_scylladb_default_schema_handlers.free_obj = php_scylladb_default_schema_free;
-  self->zendObject.handlers = (zend_object_handlers *)&php_scylladb_default_schema_handlers;
   return &self->zendObject;
 }

--- a/src/Database/DefaultSchema.stub.php
+++ b/src/Database/DefaultSchema.stub.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 namespace Cassandra {
     /**
      * @strict-properties
+     * @not-serializable
  * @scylladb-struct php_scylladb_schema
  */    final class DefaultSchema implements \Cassandra\Schema {
         /** @return Keyspace|false */

--- a/src/Database/DefaultTable.c
+++ b/src/Database/DefaultTable.c
@@ -102,7 +102,7 @@ php_scylladb_table_get_option(php_scylladb_table *table,
     php_scylladb_default_table_build_options(table );
   }
 
-  if ((zvalue = zend_hash_str_find(Z_ARRVAL(table->options), name, strlen(name))) == NULL) {
+  if ((zvalue = zend_hash_str_find(Z_ARRVAL(table->options), name, strlen(name))) == nullptr) {
     ZVAL_FALSE(result);
     return;
   }
@@ -137,7 +137,7 @@ ZEND_METHOD(Cassandra_DefaultTable, option)
     php_scylladb_default_table_build_options(self );
   }
 
-  if ((result = zend_hash_str_find(Z_ARRVAL(self->options), name, name_len)) != NULL) {
+  if ((result = zend_hash_str_find(Z_ARRVAL(self->options), name, name_len)) != nullptr) {
     RETURN_ZVAL(result, 1, 0);
   }
   RETURN_FALSE;
@@ -376,7 +376,7 @@ ZEND_METHOD(Cassandra_DefaultTable, column)
 
   self = PHP_SCYLLADB_GET_TABLE(getThis());
   meta = cass_table_meta_column_by_name(self->meta, name);
-  if (meta == NULL) {
+  if (meta == nullptr) {
     RETURN_FALSE;
   }
 
@@ -521,7 +521,7 @@ ZEND_METHOD(Cassandra_DefaultTable, index)
 
   self = PHP_SCYLLADB_GET_TABLE(getThis());
   meta = cass_table_meta_index_by_name(self->meta, name);
-  if (meta == NULL) {
+  if (meta == nullptr) {
     RETURN_FALSE;
   }
 
@@ -553,7 +553,7 @@ ZEND_METHOD(Cassandra_DefaultTable, indexes)
     zindex = php_scylladb_create_index(&self->schema, meta );
 
     if (!Z_ISUNDEF(zindex)) {
-      php_scylladb_index *index = PHP_SCYLLADB_GET_INDEX(&zindex);
+      auto index = PHP_SCYLLADB_GET_INDEX(&zindex);
 
       if (Z_TYPE(index->name) == IS_STRING) {
         add_assoc_zval_ex(return_value, Z_STRVAL(index->name), Z_STRLEN(index->name), &zindex);
@@ -581,7 +581,7 @@ ZEND_METHOD(Cassandra_DefaultTable, materializedView)
   self = PHP_SCYLLADB_GET_TABLE(getThis());
   meta = cass_table_meta_materialized_view_by_name_n(self->meta,
                                                      name, name_len);
-  if (meta == NULL) {
+  if (meta == nullptr) {
     RETURN_FALSE;
   }
 
@@ -630,9 +630,9 @@ ZEND_METHOD(Cassandra_DefaultTable, materializedViews)
 HashTable *
 php_scylladb_default_table_gc(zend_object *object, zval** table, int *n)
 {
-  *table = NULL;
+  *table = nullptr;
   *n = 0;
-  return NULL;
+  return nullptr;
 }
 
 HashTable *
@@ -656,7 +656,7 @@ php_scylladb_default_table_compare(zval *obj1, zval *obj2 )
 void
 php_scylladb_default_table_free(zend_object *object )
 {
-  php_scylladb_table *self = php_scylladb_table_object_fetch(object);
+  auto self = php_scylladb_table_object_fetch(object);
 
   zval_ptr_dtor(&self->name);
   zval_ptr_dtor(&self->options);
@@ -669,7 +669,7 @@ php_scylladb_default_table_free(zend_object *object )
     zval_ptr_dtor(&self->schema);
     ZVAL_UNDEF(&self->schema);
   }
-  self->meta = NULL;
+  self->meta = nullptr;
 
   zend_object_std_dtor(&self->zendObject);
 
@@ -679,7 +679,7 @@ zend_object*
 php_scylladb_default_table_new(zend_class_entry *ce )
 {
   php_scylladb_table *self =
-      (php_scylladb_table *)ecalloc(1, sizeof(php_scylladb_table) + zend_object_properties_size(ce));
+      PHP_SCYLLADB_OBJ_ALLOCATE(php_scylladb_table, ce, &php_scylladb_default_table_handlers);
 
   ZVAL_UNDEF(&self->name);
   ZVAL_UNDEF(&self->options);
@@ -688,12 +688,10 @@ php_scylladb_default_table_new(zend_class_entry *ce )
   ZVAL_UNDEF(&self->clustering_key);
   ZVAL_UNDEF(&self->clustering_order);
 
-  self->meta   = NULL;
+  self->meta   = nullptr;
   ZVAL_UNDEF(&self->schema);
 
-  zend_object_std_init(&self->zendObject, ce);
   php_scylladb_default_table_handlers.offset = XtOffsetOf(php_scylladb_table, zendObject);
   php_scylladb_default_table_handlers.free_obj = php_scylladb_default_table_free;
-  self->zendObject.handlers = (zend_object_handlers *)&php_scylladb_default_table_handlers;
   return &self->zendObject;
 }

--- a/src/Database/DefaultTable.stub.php
+++ b/src/Database/DefaultTable.stub.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 namespace Cassandra {
     /**
      * @strict-properties
+     * @not-serializable
  * @scylladb-struct php_scylladb_table
  */    final class DefaultTable implements \Cassandra\Table {
         public function name(): string {}

--- a/src/Database/ResultDecoder.c
+++ b/src/Database/ResultDecoder.c
@@ -41,19 +41,19 @@ int php_scylladb_value(const CassValue *value, const CassDataType *data_type, zv
     cass_double_t v_double;
     php_scylladb_uuid *uuid;
     CassIterator *iterator;
-    php_scylladb_numeric *numeric = NULL;
-    php_scylladb_timestamp *timestamp = NULL;
-    php_scylladb_date *date = NULL;
-    php_scylladb_time *time = NULL;
-    php_scylladb_blob *blob = NULL;
-    php_scylladb_inet *inet = NULL;
-    php_scylladb_duration *duration = NULL;
-    php_scylladb_collection *collection = NULL;
-    php_scylladb_map *map = NULL;
-    php_scylladb_set *set = NULL;
-    php_scylladb_tuple *tuple = NULL;
-    php_scylladb_user_type_value *user_type_value = NULL;
-    ulong index;
+    php_scylladb_numeric *numeric = nullptr;
+    php_scylladb_timestamp *timestamp = nullptr;
+    php_scylladb_date *date = nullptr;
+    php_scylladb_time *time = nullptr;
+    php_scylladb_blob *blob = nullptr;
+    php_scylladb_inet *inet = nullptr;
+    php_scylladb_duration *duration = nullptr;
+    php_scylladb_collection *collection = nullptr;
+    php_scylladb_map *map = nullptr;
+    php_scylladb_set *set = nullptr;
+    php_scylladb_tuple *tuple = nullptr;
+    php_scylladb_user_type_value *user_type_value = nullptr;
+    zend_ulong index;
 
     CassValueType type = cass_data_type_type(data_type);
     const CassDataType *primary_type;
@@ -189,7 +189,7 @@ int php_scylladb_value(const CassValue *value, const CassDataType *data_type, zv
 
         iterator = cass_iterator_from_collection(value);
 
-        if (iterator != NULL)
+        if (iterator != nullptr)
         {
             while (cass_iterator_next(iterator))
             {
@@ -219,7 +219,7 @@ int php_scylladb_value(const CassValue *value, const CassDataType *data_type, zv
 
         iterator = cass_iterator_from_map(value);
 
-        if (iterator != NULL)
+        if (iterator != nullptr)
         {
             while (cass_iterator_next(iterator))
             {
@@ -251,7 +251,7 @@ int php_scylladb_value(const CassValue *value, const CassDataType *data_type, zv
 
         iterator = cass_iterator_from_collection(value);
 
-        if (iterator != NULL)
+        if (iterator != nullptr)
         {
             while (cass_iterator_next(iterator))
             {
@@ -279,7 +279,7 @@ int php_scylladb_value(const CassValue *value, const CassDataType *data_type, zv
 
         iterator = cass_iterator_from_tuple(value);
 
-        if (iterator != NULL)
+        if (iterator != nullptr)
         {
             index = 0;
             while (cass_iterator_next(iterator))
@@ -316,7 +316,7 @@ int php_scylladb_value(const CassValue *value, const CassDataType *data_type, zv
 
         iterator = cass_iterator_fields_from_user_type(value);
 
-        if (iterator != NULL)
+        if (iterator != nullptr)
         {
             index = 0;
             while (cass_iterator_next(iterator))
@@ -362,7 +362,7 @@ int php_scylladb_get_keyspace_field(const CassKeyspaceMeta *metadata, const char
 
     value = cass_keyspace_meta_field_by_name(metadata, field_name);
 
-    if (value == NULL || cass_value_is_null(value))
+    if (value == nullptr || cass_value_is_null(value))
     {
 
         ZVAL_NULL(out);
@@ -378,7 +378,7 @@ int php_scylladb_get_table_field(const CassTableMeta *metadata, const char *fiel
 
     value = cass_table_meta_field_by_name(metadata, field_name);
 
-    if (value == NULL || cass_value_is_null(value))
+    if (value == nullptr || cass_value_is_null(value))
     {
 
         ZVAL_NULL(out);
@@ -394,7 +394,7 @@ int php_scylladb_get_column_field(const CassColumnMeta *metadata, const char *fi
 
     value = cass_column_meta_field_by_name(metadata, field_name);
 
-    if (value == NULL || cass_value_is_null(value))
+    if (value == nullptr || cass_value_is_null(value))
     {
 
         ZVAL_NULL(out);
@@ -413,7 +413,7 @@ int php_scylladb_get_result(const CassResult *result, zval *out)
     size_t column_name_len;
     const CassDataType *column_type;
     const CassValue *column_value;
-    CassIterator *iterator = NULL;
+    CassIterator *iterator = nullptr;
     size_t columns = -1;
     char **column_names;
     unsigned i;
@@ -436,7 +436,7 @@ int php_scylladb_get_result(const CassResult *result, zval *out)
         {
             zval value;
 
-            if (column_names[i] == NULL)
+            if (column_names[i] == nullptr)
             {
                 cass_result_column_name(result, i, &column_name, &column_name_len);
                 column_names[i] = estrndup(column_name, column_name_len);
@@ -472,7 +472,7 @@ int php_scylladb_get_result(const CassResult *result, zval *out)
 
     for (i = 0; i < columns; i++)
     {
-        if (column_names[i] != NULL)
+        if (column_names[i] != nullptr)
         {
             efree(column_names[i]);
         }

--- a/src/Database/Rows.c
+++ b/src/Database/Rows.c
@@ -51,7 +51,7 @@ static void php_scylladb_rows_create(php_scylladb_rows *current, zval *result )
         rows->statement = current->statement;
         ZVAL_COPY(&rows->session, &current->session);
         rows->result        = current->next_result;
-        current->next_result = NULL;
+        current->next_result = nullptr;
     }
 }
 
@@ -66,7 +66,7 @@ ZEND_METHOD(Cassandra_Rows, __construct)
 
 ZEND_METHOD(Cassandra_Rows, count)
 {
-    php_scylladb_rows *self = NULL;
+    php_scylladb_rows *self = nullptr;
 
     if (zend_parse_parameters_none() == FAILURE)
         return;
@@ -78,7 +78,7 @@ ZEND_METHOD(Cassandra_Rows, count)
 
 ZEND_METHOD(Cassandra_Rows, rewind)
 {
-    php_scylladb_rows *self = NULL;
+    php_scylladb_rows *self = nullptr;
 
     if (zend_parse_parameters_none() == FAILURE)
         return;
@@ -95,11 +95,11 @@ ZEND_METHOD(Cassandra_Rows, current)
         return;
     }
 
-    php_scylladb_rows *self = PHP_SCYLLADB_GET_ROWS(getThis());
+    auto self = PHP_SCYLLADB_GET_ROWS(getThis());
 
     zval *entry = zend_hash_get_current_data(Z_ARRVAL(self->rows));
 
-    if (entry != NULL)
+    if (entry != nullptr)
     {
         RETURN_ZVAL(entry, 1, 0);
     }
@@ -109,7 +109,7 @@ ZEND_METHOD(Cassandra_Rows, key)
 {
     zend_ulong num_index;
     zend_string* str_index;
-    php_scylladb_rows *self = NULL;
+    php_scylladb_rows *self = nullptr;
 
     if (zend_parse_parameters_none() == FAILURE)
         return;
@@ -123,7 +123,7 @@ ZEND_METHOD(Cassandra_Rows, key)
 
 ZEND_METHOD(Cassandra_Rows, next)
 {
-    php_scylladb_rows *self = NULL;
+    php_scylladb_rows *self = nullptr;
 
     if (zend_parse_parameters_none() == FAILURE)
     {
@@ -137,7 +137,7 @@ ZEND_METHOD(Cassandra_Rows, next)
 
 ZEND_METHOD(Cassandra_Rows, valid)
 {
-    php_scylladb_rows *self = NULL;
+    php_scylladb_rows *self = nullptr;
 
     if (zend_parse_parameters_none() == FAILURE)
         return;
@@ -150,7 +150,7 @@ ZEND_METHOD(Cassandra_Rows, valid)
 ZEND_METHOD(Cassandra_Rows, offsetExists)
 {
     zval *offset;
-    php_scylladb_rows *self = NULL;
+    php_scylladb_rows *self = nullptr;
 
     ZEND_PARSE_PARAMETERS_START(1, 1)
         Z_PARAM_ZVAL(offset)
@@ -170,7 +170,7 @@ ZEND_METHOD(Cassandra_Rows, offsetGet)
 {
     zval *offset;
     zval *value;
-    php_scylladb_rows *self = NULL;
+    php_scylladb_rows *self = nullptr;
 
     ZEND_PARSE_PARAMETERS_START(1, 1)
         Z_PARAM_ZVAL(offset)
@@ -182,7 +182,7 @@ ZEND_METHOD(Cassandra_Rows, offsetGet)
     }
 
     self = PHP_SCYLLADB_GET_ROWS(getThis());
-    if ((value = zend_hash_index_find(Z_ARRVAL(self->rows), (zend_ulong)(Z_LVAL_P(offset)))) != NULL)
+    if ((value = zend_hash_index_find(Z_ARRVAL(self->rows), (zend_ulong)(Z_LVAL_P(offset)))) != nullptr)
     {
         RETURN_ZVAL(value, 1, 0);
     }
@@ -210,14 +210,14 @@ ZEND_METHOD(Cassandra_Rows, offsetUnset)
 
 ZEND_METHOD(Cassandra_Rows, isLastPage)
 {
-    php_scylladb_rows *self = NULL;
+    php_scylladb_rows *self = nullptr;
 
     if (zend_parse_parameters_none() == FAILURE)
         return;
 
     self = PHP_SCYLLADB_GET_ROWS(getThis());
 
-    if (self->result == NULL && Z_ISUNDEF(self->next_rows) && Z_ISUNDEF(self->future_next_page))
+    if (self->result == nullptr && Z_ISUNDEF(self->next_rows) && Z_ISUNDEF(self->future_next_page))
     {
         RETURN_TRUE;
     }
@@ -227,8 +227,8 @@ ZEND_METHOD(Cassandra_Rows, isLastPage)
 
 ZEND_METHOD(Cassandra_Rows, nextPage)
 {
-    zval *timeout = NULL;
-    php_scylladb_rows *self = PHP_SCYLLADB_GET_ROWS(getThis());
+    zval *timeout = nullptr;
+    auto self = PHP_SCYLLADB_GET_ROWS(getThis());
 
     ZEND_PARSE_PARAMETERS_START(0, 1)
         Z_PARAM_OPTIONAL
@@ -239,7 +239,7 @@ ZEND_METHOD(Cassandra_Rows, nextPage)
     {
         if (!Z_ISUNDEF(self->future_next_page))
         {
-            php_scylladb_future_rows *future_rows = NULL;
+            php_scylladb_future_rows *future_rows = nullptr;
 
             if (Z_TYPE(self->future_next_page) != IS_OBJECT ||
                 !instanceof_function(Z_OBJCE(self->future_next_page),
@@ -259,14 +259,14 @@ ZEND_METHOD(Cassandra_Rows, nextPage)
             /* Take ownership of FutureRows' result — the FutureRows is
                about to be discarded along with the future_next_page. */
             self->next_result    = future_rows->result;
-            future_rows->result  = NULL;
+            future_rows->result  = nullptr;
         }
         else
         {
-            const CassResult *result = NULL;
-            CassFuture *future = NULL;
+            const CassResult *result = nullptr;
+            CassFuture *future = nullptr;
 
-            if (self->result == NULL)
+            if (self->result == nullptr)
             {
                 return;
             }
@@ -313,8 +313,8 @@ ZEND_METHOD(Cassandra_Rows, nextPage)
 
 ZEND_METHOD(Cassandra_Rows, nextPageAsync)
 {
-    php_scylladb_rows *self = NULL;
-    php_scylladb_future_rows *future_rows = NULL;
+    php_scylladb_rows *self = nullptr;
+    php_scylladb_future_rows *future_rows = nullptr;
 
     if (zend_parse_parameters_none() == FAILURE)
         return;
@@ -337,7 +337,7 @@ ZEND_METHOD(Cassandra_Rows, nextPageAsync)
         RETURN_ZVAL(&self->future_next_page, 1, 0);
     }
 
-    if (self->result == NULL)
+    if (self->result == nullptr)
     {
         object_init_ex(return_value, php_scylladb_future_value_ce);
         return;
@@ -363,7 +363,7 @@ ZEND_METHOD(Cassandra_Rows, pagingStateToken)
 {
     const char *paging_state;
     size_t paging_state_size;
-    php_scylladb_rows *self = NULL;
+    php_scylladb_rows *self = nullptr;
 
     if (zend_parse_parameters_none() == FAILURE)
     {
@@ -372,7 +372,7 @@ ZEND_METHOD(Cassandra_Rows, pagingStateToken)
 
     self = PHP_SCYLLADB_GET_ROWS(getThis());
 
-    if (self->result == NULL)
+    if (self->result == nullptr)
         return;
 
     ASSERT_SUCCESS(
@@ -384,7 +384,7 @@ ZEND_METHOD(Cassandra_Rows, first)
 {
     HashPosition pos;
     zval *entry;
-    php_scylladb_rows *self = NULL;
+    php_scylladb_rows *self = nullptr;
 
     if (zend_parse_parameters_none() == FAILURE)
     {
@@ -394,7 +394,7 @@ ZEND_METHOD(Cassandra_Rows, first)
     self = PHP_SCYLLADB_GET_ROWS(getThis());
 
     zend_hash_internal_pointer_reset_ex(Z_ARRVAL(self->rows), &pos);
-    if ((entry = zend_hash_get_current_data(Z_ARRVAL(self->rows))) != NULL)
+    if ((entry = zend_hash_get_current_data(Z_ARRVAL(self->rows))) != nullptr)
     {
         RETVAL_ZVAL(entry, 1, 0);
     }
@@ -418,19 +418,19 @@ int php_scylladb_rows_compare(zval *obj1, zval *obj2)
 
 void php_scylladb_rows_free(zend_object *object)
 {
-    php_scylladb_rows *self = php_scylladb_rows_object_fetch(object);
+    auto self = php_scylladb_rows_object_fetch(object);
 
     if (self->result) {
         cass_result_free((CassResult *)self->result);
-        self->result = NULL;
+        self->result = nullptr;
     }
     if (self->next_result) {
         cass_result_free((CassResult *)self->next_result);
-        self->next_result = NULL;
+        self->next_result = nullptr;
     }
     if (self->statement) {
         zend_list_delete(self->statement);
-        self->statement = NULL;
+        self->statement = nullptr;
     }
     if (!Z_ISUNDEF(self->session)) {
         zval_ptr_dtor(&self->session);
@@ -446,19 +446,18 @@ void php_scylladb_rows_free(zend_object *object)
 
 zend_object *php_scylladb_rows_new(zend_class_entry *ce)
 {
-    php_scylladb_rows *self = (php_scylladb_rows *)ecalloc(1, sizeof(php_scylladb_rows) + zend_object_properties_size(ce));
+    php_scylladb_rows *self =
+        PHP_SCYLLADB_OBJ_ALLOCATE(php_scylladb_rows, ce, &php_scylladb_rows_handlers);
 
-    self->statement = NULL;
-    self->result = NULL;
-    self->next_result = NULL;
+    self->statement = nullptr;
+    self->result = nullptr;
+    self->next_result = nullptr;
     ZVAL_UNDEF(&self->session);
     ZVAL_UNDEF(&self->rows);
     ZVAL_UNDEF(&self->next_rows);
     ZVAL_UNDEF(&self->future_next_page);
 
-    zend_object_std_init(&self->zendObject, ce);
   php_scylladb_rows_handlers.offset = XtOffsetOf(php_scylladb_rows, zendObject);
   php_scylladb_rows_handlers.free_obj = php_scylladb_rows_free;
-  self->zendObject.handlers = (zend_object_handlers *)&php_scylladb_rows_handlers;
   return &self->zendObject;
 }

--- a/src/Database/Rows.stub.php
+++ b/src/Database/Rows.stub.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 namespace Cassandra {
     /**
      * @strict-properties
+     * @not-serializable
  * @scylladb-struct php_scylladb_rows
  */    final class Rows implements \Iterator, \Countable, \ArrayAccess {
         public function __construct() {}

--- a/src/Database/Table.c
+++ b/src/Database/Table.c
@@ -31,7 +31,7 @@ php_scylladb_table_build_options(CassIterator* iterator ) {
     return zoptions;
   }
   while (cass_iterator_next(iterator)) {
-    const CassValue *value = NULL;
+    const CassValue *value = nullptr;
     if (cass_iterator_get_meta_field_name(iterator, &name, &name_length) == CASS_OK) {
       if ((name_length == sizeof("keyspace_name") - 1 &&
            memcmp(name, "keyspace_name", name_length) == 0) ||

--- a/src/DateTime/Date.c
+++ b/src/DateTime/Date.c
@@ -105,7 +105,7 @@ typedef struct {
 
 static zend_string *date_to_datetime_get_timestamp(void *vctx) {
   date_to_datetime_ctx_t *ctx = (date_to_datetime_ctx_t *)vctx;
-  smart_str b = {0};
+  smart_str b = {};
   smart_str_append_long(
       &b,
       (zend_long)cass_date_time_to_epoch(
@@ -154,7 +154,7 @@ ZEND_METHOD(Cassandra_Date, fromDateTime) {
   ZEND_PARSE_PARAMETERS_END();
   // clang-format on
 
-  zval getTimeStampResult = {0};
+  zval getTimeStampResult = {};
   zend_call_method_with_0_params(Z_OBJ_P(datetime), Z_OBJCE_P(datetime), nullptr, "gettimestamp",
                                  &getTimeStampResult);
 
@@ -187,7 +187,7 @@ ZEND_METHOD(Cassandra_Date, __toString) {
 HashTable *php_scylladb_date_gc(zend_object *object, zval **table, int *n) {
   *table = nullptr;
   *n = 0;
-  return NULL;
+  return nullptr;
 }
 
 HashTable *php_scylladb_date_properties(zend_object *object) {
@@ -233,8 +233,7 @@ zend_object *php_scylladb_date_new(zend_class_entry *ce) {
 
 
 
-void php_scylladb_date_post_register(zend_class_entry *ce)
+void php_scylladb_date_post_register([[maybe_unused]] zend_class_entry *ce)
 {
-    (void)ce;
     php_scylladb_date_handlers.std.offset = XtOffsetOf(php_scylladb_date, zendObject);
 }

--- a/src/DateTime/Duration.c
+++ b/src/DateTime/Duration.c
@@ -62,7 +62,7 @@ static int get_param(zval* value,
     *destination = parsed_big_int;
   } else if (Z_TYPE_P(value) == IS_OBJECT &&
              instanceof_function(Z_OBJCE_P(value), php_scylladb_bigint_ce )) {
-    php_scylladb_numeric *bigint = PHP_SCYLLADB_GET_NUMERIC(value);
+    auto bigint = PHP_SCYLLADB_GET_NUMERIC(value);
     cass_int64_t bigint_value = bigint->data.bigint.value;
 
     if (bigint_value > max || bigint_value < min) {
@@ -194,7 +194,7 @@ ZEND_METHOD(Cassandra_Duration, days)
 
 ZEND_METHOD(Cassandra_Duration, nanos)
 {
-  php_scylladb_duration *self = NULL;
+  php_scylladb_duration *self = nullptr;
 
   if (zend_parse_parameters_none() == FAILURE)
     return;
@@ -206,9 +206,9 @@ ZEND_METHOD(Cassandra_Duration, nanos)
 
 HashTable *php_scylladb_duration_gc(zend_object *object, zval **table, int *n)
 {
-  *table = NULL;
+  *table = nullptr;
   *n = 0;
-  return NULL;
+  return nullptr;
 }
 
 HashTable *
@@ -220,7 +220,7 @@ php_scylladb_duration_properties(zend_object *object)
   object->properties = zend_new_array(3);
   HashTable *props = object->properties;
 
-  php_scylladb_duration  *self = php_scylladb_duration_object_fetch(object);
+  auto self = php_scylladb_duration_object_fetch(object);
   zval wrapped_months, wrapped_days, wrapped_nanos;
 
   ZVAL_LONG(&wrapped_months, self->months);
@@ -270,7 +270,7 @@ php_scylladb_duration_compare(zval *obj1, zval *obj2 )
 unsigned
 php_scylladb_duration_hash_value(zval *obj )
 {
-  php_scylladb_duration *self = PHP_SCYLLADB_GET_DURATION(obj);
+  auto self = PHP_SCYLLADB_GET_DURATION(obj);
   unsigned hashv = 0;
 
   hashv = php_scylladb_combine_hash(hashv, (unsigned) self->months);
@@ -283,7 +283,7 @@ php_scylladb_duration_hash_value(zval *obj )
 void
 php_scylladb_duration_free(zend_object *object )
 {
-  php_scylladb_duration *self = php_scylladb_duration_object_fetch(object);
+  auto self = php_scylladb_duration_object_fetch(object);
 
   /* Clean up */
 
@@ -294,16 +294,13 @@ php_scylladb_duration_free(zend_object *object )
 zend_object*
 php_scylladb_duration_new(zend_class_entry *ce )
 {
-  php_scylladb_duration *self = (php_scylladb_duration *)ecalloc(1, sizeof(php_scylladb_duration) + zend_object_properties_size(ce));
-
-  zend_object_std_init(&self->zendObject, ce);
-  self->zendObject.handlers = (zend_object_handlers *)&php_scylladb_duration_handlers;
+  php_scylladb_duration *self =
+      PHP_SCYLLADB_OBJ_ALLOCATE(php_scylladb_duration, ce, &php_scylladb_duration_handlers);
   return &self->zendObject;
 }
 
 
-void php_scylladb_duration_post_register(zend_class_entry *ce)
+void php_scylladb_duration_post_register([[maybe_unused]] zend_class_entry *ce)
 {
-    (void)ce;
     php_scylladb_duration_handlers.std.offset = XtOffsetOf(php_scylladb_duration, zendObject);
 }

--- a/src/DateTime/Time.c
+++ b/src/DateTime/Time.c
@@ -35,12 +35,12 @@ static cass_int64_t php_scylladb_time_now_ns(void) {
   cass_int64_t seconds;
   cass_int64_t nanoseconds;
 #if defined(__APPLE__) && defined(__MACH__)
-  struct timeval ts = {0};
-  gettimeofday(&ts, NULL);
+  struct timeval ts = {};
+  gettimeofday(&ts, nullptr);
   seconds = (cass_int64_t)ts.tv_sec;
   nanoseconds = (cass_int64_t)ts.tv_usec * 1000;
 #else
-  struct timespec ts = {0};
+  struct timespec ts = {};
   clock_gettime(CLOCK_REALTIME, &ts);
   seconds = (cass_int64_t)ts.tv_sec;
   nanoseconds = (cass_int64_t)ts.tv_nsec;
@@ -182,7 +182,7 @@ ZEND_METHOD(Cassandra_Time, __toString) {
 HashTable *php_scylladb_time_gc(zend_object *object, zval **table, int *n) {
   *table = nullptr;
   *n = 0;
-  return NULL;
+  return nullptr;
 }
 
 HashTable *php_scylladb_time_properties(zend_object *object) {
@@ -227,8 +227,7 @@ zend_object *php_scylladb_time_new(zend_class_entry *ce) {
 
 
 
-void php_scylladb_time_post_register(zend_class_entry *ce)
+void php_scylladb_time_post_register([[maybe_unused]] zend_class_entry *ce)
 {
-    (void)ce;
     php_scylladb_time_handlers.std.offset = XtOffsetOf(php_scylladb_time, zendObject);
 }

--- a/src/DateTime/Timestamp.c
+++ b/src/DateTime/Timestamp.c
@@ -57,12 +57,12 @@ static time_now php_scylladb_time_now(void) {
   cass_int64_t seconds;
   cass_int64_t microseconds;
 #if defined(__APPLE__) && defined(__MACH__)
-  struct timeval ts = {0};
-  gettimeofday(&ts, NULL);
+  struct timeval ts = {};
+  gettimeofday(&ts, nullptr);
   seconds = (cass_int64_t)ts.tv_sec;
   microseconds = (cass_int64_t)ts.tv_usec;
 #else
-  struct timespec ts = {0};
+  struct timespec ts = {};
   clock_gettime(CLOCK_REALTIME, &ts);
   seconds = ts.tv_sec;
   microseconds = ts.tv_nsec / 1000;
@@ -154,7 +154,7 @@ static zend_string *timestamp_to_datetime_get_timestamp(void *vctx) {
   int64_t sec = ctx->self->timestamp / 1000;
   int64_t millisec = (ctx->self->timestamp - (sec * 1000));
 
-  smart_str b = {0};
+  smart_str b = {};
   smart_str_append_long(&b, (zend_long)sec);
   smart_str_appendc(&b, '.');
   smart_str_append_long(&b, (zend_long)millisec);
@@ -190,7 +190,7 @@ ZEND_METHOD(Cassandra_Timestamp, fromDateTime) {
   ZEND_PARSE_PARAMETERS_END();
   // clang-format on
 
-  zval getTimeStampResult = {0};
+  zval getTimeStampResult = {};
   zval format;
   zend_string *val = zend_string_init_existing_interned(ZEND_STRL("Uv"), false);
   ZVAL_STR(&format, val);
@@ -237,7 +237,7 @@ ZEND_METHOD(Cassandra_Timestamp, __toString) {
 HashTable *php_scylladb_timestamp_gc(zend_object *object, zval **table, int *n) {
   *table = nullptr;
   *n = 0;
-  return NULL;
+  return nullptr;
 }
 HashTable *php_scylladb_timestamp_properties(zend_object *object) {
   php_scylladb_timestamp *self = PHP_SCYLLADB_OBJ_FETCH(php_scylladb_timestamp, object);
@@ -290,8 +290,7 @@ zend_object *php_scylladb_timestamp_new(zend_class_entry *ce) {
 }
 
 
-void php_scylladb_timestamp_post_register(zend_class_entry *ce)
+void php_scylladb_timestamp_post_register([[maybe_unused]] zend_class_entry *ce)
 {
-    (void)ce;
     php_scylladb_timestamp_handlers.std.offset = XtOffsetOf(php_scylladb_timestamp, zendObject);
 }

--- a/src/DateTime/Timeuuid.c
+++ b/src/DateTime/Timeuuid.c
@@ -139,7 +139,7 @@ ZEND_METHOD(Cassandra_Timeuuid, time) {
 HashTable *php_scylladb_timeuuid_gc(zend_object *object, zval** table, int *n) {
   *table = nullptr;
   *n = 0;
-  return NULL;
+  return nullptr;
 }
 
 HashTable *php_scylladb_timeuuid_properties(zend_object *object) {
@@ -191,24 +191,21 @@ unsigned php_scylladb_timeuuid_hash_value(zval *obj) {
 }
 
 void php_scylladb_timeuuid_free(zend_object *object) {
-  php_scylladb_uuid *self = php_scylladb_uuid_object_fetch(object);
+  auto self = php_scylladb_uuid_object_fetch(object);
   zend_object_std_dtor(&self->zendObject);
 }
 
 zend_object* php_scylladb_timeuuid_new(zend_class_entry *ce) {
   php_scylladb_uuid *self =
-      (php_scylladb_uuid *)ecalloc(1, sizeof(php_scylladb_uuid) + zend_object_properties_size(ce));
+      PHP_SCYLLADB_OBJ_ALLOCATE(php_scylladb_uuid, ce, &php_scylladb_timeuuid_handlers);
 
-  zend_object_std_init(&self->zendObject, ce);
   php_scylladb_timeuuid_handlers.std.offset = XtOffsetOf(php_scylladb_uuid, zendObject);
   php_scylladb_timeuuid_handlers.std.free_obj = php_scylladb_timeuuid_free;
-  self->zendObject.handlers = (zend_object_handlers *)&php_scylladb_timeuuid_handlers;
   return &self->zendObject;
 }
 
 
-void php_scylladb_timeuuid_post_register(zend_class_entry *ce)
+void php_scylladb_timeuuid_post_register([[maybe_unused]] zend_class_entry *ce)
 {
-    (void)ce;
     php_scylladb_timeuuid_handlers.std.offset = XtOffsetOf(php_scylladb_uuid, zendObject);
 }

--- a/src/DefaultSession.c
+++ b/src/DefaultSession.c
@@ -35,153 +35,142 @@ extern zend_object_handlers php_scylladb_default_session_handlers;
     return SUCCESS;                    \
   } while (0)
 
+/* Cleanup helpers for PHP_SCYLLADB_CLEANUP — destructor signature is `T **`
+ * because the cleanup attribute passes a pointer to the local variable. */
+static inline void php_scylladb_free_bytes(cass_byte_t **p) {
+  if (*p) free(*p);
+}
+static inline void php_scylladb_cass_collection_free(CassCollection **p) {
+  if (*p) cass_collection_free(*p);
+}
+static inline void php_scylladb_cass_tuple_free(CassTuple **p) {
+  if (*p) cass_tuple_free(*p);
+}
+static inline void php_scylladb_cass_user_type_free(CassUserType **p) {
+  if (*p) cass_user_type_free(*p);
+}
+
 static int bind_argument_by_index(CassStatement* statement, size_t index, zval* value) {
-  if (Z_TYPE_P(value) == IS_NULL) CHECK_RESULT(cass_statement_bind_null(statement, index));
-
-  if (Z_TYPE_P(value) == IS_STRING)
-    CHECK_RESULT(cass_statement_bind_string(statement, index, Z_STRVAL_P(value)));
-
-  if (Z_TYPE_P(value) == IS_DOUBLE)
-    CHECK_RESULT(cass_statement_bind_double(statement, index, Z_DVAL_P(value)));
-
-  if (Z_TYPE_P(value) == IS_LONG)
-    CHECK_RESULT(cass_statement_bind_int32(statement, index, Z_LVAL_P(value)));
-
-  if ((Z_TYPE_P(value) == IS_TRUE))
-    CHECK_RESULT(cass_statement_bind_bool(statement, index, cass_true));
-
-  if ((Z_TYPE_P(value) == IS_FALSE))
-    CHECK_RESULT(cass_statement_bind_bool(statement, index, cass_false));
+  /* Primitive dispatch: one Z_TYPE_P read, compiler builds a jump table.
+   * CHECK_RESULT always returns, so each case is terminal. IS_OBJECT and
+   * any unsupported type fall through to the instanceof chain / error. */
+  switch (Z_TYPE_P(value)) {
+    case IS_NULL:   CHECK_RESULT(cass_statement_bind_null(statement, index));
+    case IS_STRING: CHECK_RESULT(cass_statement_bind_string(statement, index, Z_STRVAL_P(value)));
+    case IS_DOUBLE: CHECK_RESULT(cass_statement_bind_double(statement, index, Z_DVAL_P(value)));
+    case IS_LONG:   CHECK_RESULT(cass_statement_bind_int32(statement, index, Z_LVAL_P(value)));
+    case IS_TRUE:   CHECK_RESULT(cass_statement_bind_bool(statement, index, cass_true));
+    case IS_FALSE:  CHECK_RESULT(cass_statement_bind_bool(statement, index, cass_false));
+    case IS_OBJECT: break;       /* dispatched on class entry below */
+    default:        break;       /* fall through to unsupported throw */
+  }
 
   if (Z_TYPE_P(value) == IS_OBJECT) {
     if (instanceof_function(Z_OBJCE_P(value), php_scylladb_float_ce)) {
-      php_scylladb_numeric* float_number = PHP_SCYLLADB_GET_NUMERIC(value);
+      auto float_number = PHP_SCYLLADB_GET_NUMERIC(value);
       CHECK_RESULT(cass_statement_bind_float(statement, index, float_number->data.floating.value));
     }
 
     if (instanceof_function(Z_OBJCE_P(value), php_scylladb_bigint_ce)) {
-      php_scylladb_numeric* bigint = PHP_SCYLLADB_GET_NUMERIC(value);
+      auto bigint = PHP_SCYLLADB_GET_NUMERIC(value);
       CHECK_RESULT(cass_statement_bind_int64(statement, index, bigint->data.bigint.value));
     }
 
     if (instanceof_function(Z_OBJCE_P(value), php_scylladb_smallint_ce)) {
-      php_scylladb_numeric* smallint = PHP_SCYLLADB_GET_NUMERIC(value);
+      auto smallint = PHP_SCYLLADB_GET_NUMERIC(value);
       CHECK_RESULT(cass_statement_bind_int16(statement, index, smallint->data.smallint.value));
     }
 
     if (instanceof_function(Z_OBJCE_P(value), php_scylladb_tinyint_ce)) {
-      php_scylladb_numeric* tinyint = PHP_SCYLLADB_GET_NUMERIC(value);
+      auto tinyint = PHP_SCYLLADB_GET_NUMERIC(value);
       CHECK_RESULT(cass_statement_bind_int8(statement, index, tinyint->data.tinyint.value));
     }
 
     if (instanceof_function(Z_OBJCE_P(value), php_scylladb_timestamp_ce)) {
-      php_scylladb_timestamp* timestamp = Z_SCYLLADB_TIMESTAMP_P(value);
+      auto timestamp = Z_SCYLLADB_TIMESTAMP_P(value);
       CHECK_RESULT(cass_statement_bind_int64(statement, index, timestamp->timestamp));
     }
 
     if (instanceof_function(Z_OBJCE_P(value), php_scylladb_date_ce)) {
-      php_scylladb_date* date = Z_SCYLLADB_DATE_P(value);
+      auto date = Z_SCYLLADB_DATE_P(value);
       CHECK_RESULT(cass_statement_bind_uint32(statement, index, date->date));
     }
 
     if (instanceof_function(Z_OBJCE_P(value), php_scylladb_time_ce)) {
-      php_scylladb_time* time = Z_SCYLLADB_TIME_P(value);
+      auto time = Z_SCYLLADB_TIME_P(value);
       CHECK_RESULT(cass_statement_bind_int64(statement, index, time->time));
     }
 
     if (instanceof_function(Z_OBJCE_P(value), php_scylladb_blob_ce)) {
-      php_scylladb_blob* blob = PHP_SCYLLADB_GET_BLOB(value);
+      auto blob = PHP_SCYLLADB_GET_BLOB(value);
       CHECK_RESULT(cass_statement_bind_bytes(statement, index, blob->data, blob->size));
     }
 
     if (instanceof_function(Z_OBJCE_P(value), php_scylladb_varint_ce)) {
-      php_scylladb_numeric* varint = PHP_SCYLLADB_GET_NUMERIC(value);
+      auto varint = PHP_SCYLLADB_GET_NUMERIC(value);
       size_t size;
+      PHP_SCYLLADB_CLEANUP(php_scylladb_free_bytes)
       cass_byte_t* data = export_twos_complement(varint->data.varint.value, &size);
-      CassError rc = cass_statement_bind_bytes(statement, index, data, size);
-      free(data);
-      CHECK_RESULT(rc);
+      CHECK_RESULT(cass_statement_bind_bytes(statement, index, data, size));
     }
 
     if (instanceof_function(Z_OBJCE_P(value), php_scylladb_decimal_ce)) {
-      php_scylladb_numeric* decimal = PHP_SCYLLADB_GET_NUMERIC(value);
+      auto decimal = PHP_SCYLLADB_GET_NUMERIC(value);
       size_t size;
+      PHP_SCYLLADB_CLEANUP(php_scylladb_free_bytes)
       cass_byte_t* data = (cass_byte_t*)export_twos_complement(decimal->data.decimal.value, &size);
-      CassError rc =
-          cass_statement_bind_decimal(statement, index, data, size, decimal->data.decimal.scale);
-      free(data);
-      CHECK_RESULT(rc);
+      CHECK_RESULT(cass_statement_bind_decimal(statement, index, data, size, decimal->data.decimal.scale));
     }
 
     if (instanceof_function(Z_OBJCE_P(value), php_scylladb_uuid_interface_ce)) {
-      php_scylladb_uuid* uuid = PHP_SCYLLADB_GET_UUID(value);
+      auto uuid = PHP_SCYLLADB_GET_UUID(value);
       CHECK_RESULT(cass_statement_bind_uuid(statement, index, uuid->uuid));
     }
 
     if (instanceof_function(Z_OBJCE_P(value), php_scylladb_inet_ce)) {
-      php_scylladb_inet* inet = PHP_SCYLLADB_GET_INET(value);
+      auto inet = PHP_SCYLLADB_GET_INET(value);
       CHECK_RESULT(cass_statement_bind_inet(statement, index, inet->inet));
     }
 
     if (instanceof_function(Z_OBJCE_P(value), php_scylladb_duration_ce)) {
-      php_scylladb_duration* duration = PHP_SCYLLADB_GET_DURATION(value);
+      auto duration = PHP_SCYLLADB_GET_DURATION(value);
       CHECK_RESULT(cass_statement_bind_duration(statement, index, duration->months, duration->days,
                                                 duration->nanos));
     }
 
     if (instanceof_function(Z_OBJCE_P(value), php_scylladb_set_ce)) {
-      CassError rc;
-      CassCollection* collection;
-      php_scylladb_set* set = PHP_SCYLLADB_GET_SET(value);
+      auto set = PHP_SCYLLADB_GET_SET(value);
+      PHP_SCYLLADB_CLEANUP(php_scylladb_cass_collection_free) CassCollection* collection = nullptr;
       if (!php_scylladb_collection_from_set(set, &collection)) return FAILURE;
-
-      rc = cass_statement_bind_collection(statement, index, collection);
-      cass_collection_free(collection);
-      CHECK_RESULT(rc);
+      CHECK_RESULT(cass_statement_bind_collection(statement, index, collection));
     }
 
     if (instanceof_function(Z_OBJCE_P(value), php_scylladb_map_ce)) {
-      CassError rc;
-      CassCollection* collection;
-      php_scylladb_map* map = PHP_SCYLLADB_GET_MAP(value);
+      auto map = PHP_SCYLLADB_GET_MAP(value);
+      PHP_SCYLLADB_CLEANUP(php_scylladb_cass_collection_free) CassCollection* collection = nullptr;
       if (!php_scylladb_collection_from_map(map, &collection)) return FAILURE;
-
-      rc = cass_statement_bind_collection(statement, index, collection);
-      cass_collection_free(collection);
-      CHECK_RESULT(rc);
+      CHECK_RESULT(cass_statement_bind_collection(statement, index, collection));
     }
 
     if (instanceof_function(Z_OBJCE_P(value), php_scylladb_collection_ce)) {
-      CassError rc;
-      CassCollection* collection;
-      php_scylladb_collection* coll = PHP_SCYLLADB_GET_COLLECTION(value);
+      auto coll = PHP_SCYLLADB_GET_COLLECTION(value);
+      PHP_SCYLLADB_CLEANUP(php_scylladb_cass_collection_free) CassCollection* collection = nullptr;
       if (!php_scylladb_collection_from_collection(coll, &collection)) return FAILURE;
-
-      rc = cass_statement_bind_collection(statement, index, collection);
-      cass_collection_free(collection);
-      CHECK_RESULT(rc);
+      CHECK_RESULT(cass_statement_bind_collection(statement, index, collection));
     }
 
     if (instanceof_function(Z_OBJCE_P(value), php_scylladb_tuple_ce)) {
-      CassError rc;
-      CassTuple* tup;
-      php_scylladb_tuple* tuple = PHP_SCYLLADB_GET_TUPLE(value);
+      auto tuple = PHP_SCYLLADB_GET_TUPLE(value);
+      PHP_SCYLLADB_CLEANUP(php_scylladb_cass_tuple_free) CassTuple* tup = nullptr;
       if (!php_scylladb_tuple_from_tuple(tuple, &tup)) return FAILURE;
-
-      rc = cass_statement_bind_tuple(statement, index, tup);
-      cass_tuple_free(tup);
-      CHECK_RESULT(rc);
+      CHECK_RESULT(cass_statement_bind_tuple(statement, index, tup));
     }
 
     if (instanceof_function(Z_OBJCE_P(value), php_scylladb_user_type_value_ce)) {
-      CassError rc;
-      CassUserType* ut;
-      php_scylladb_user_type_value* user_type_value = PHP_SCYLLADB_GET_USER_TYPE_VALUE(value);
+      auto user_type_value = PHP_SCYLLADB_GET_USER_TYPE_VALUE(value);
+      PHP_SCYLLADB_CLEANUP(php_scylladb_cass_user_type_free) CassUserType* ut = nullptr;
       if (!php_scylladb_user_type_from_user_type_value(user_type_value, &ut)) return FAILURE;
-
-      rc = cass_statement_bind_user_type(statement, index, ut);
-      cass_user_type_free(ut);
-      CHECK_RESULT(rc);
+      CHECK_RESULT(cass_statement_bind_user_type(statement, index, ut));
     }
   }
 
@@ -192,156 +181,126 @@ static int bind_argument_by_index(CassStatement* statement, size_t index, zval* 
 }
 
 static int bind_argument_by_name(CassStatement* statement, const char* name, zval* value) {
-  if (Z_TYPE_P(value) == IS_NULL) {
-    CHECK_RESULT(cass_statement_bind_null_by_name(statement, name));
+  switch (Z_TYPE_P(value)) {
+    case IS_NULL:   CHECK_RESULT(cass_statement_bind_null_by_name(statement, name));
+    case IS_STRING: CHECK_RESULT(cass_statement_bind_string_by_name(statement, name, Z_STRVAL_P(value)));
+    case IS_DOUBLE: CHECK_RESULT(cass_statement_bind_double_by_name(statement, name, Z_DVAL_P(value)));
+    case IS_LONG:   CHECK_RESULT(cass_statement_bind_int32_by_name(statement, name, Z_LVAL_P(value)));
+    case IS_TRUE:   CHECK_RESULT(cass_statement_bind_bool_by_name(statement, name, cass_true));
+    case IS_FALSE:  CHECK_RESULT(cass_statement_bind_bool_by_name(statement, name, cass_false));
+    case IS_OBJECT: break;
+    default:        break;
   }
-
-  if (Z_TYPE_P(value) == IS_STRING)
-    CHECK_RESULT(cass_statement_bind_string_by_name(statement, name, Z_STRVAL_P(value)));
-
-  if (Z_TYPE_P(value) == IS_DOUBLE)
-    CHECK_RESULT(cass_statement_bind_double_by_name(statement, name, Z_DVAL_P(value)));
-
-  if (Z_TYPE_P(value) == IS_LONG)
-    CHECK_RESULT(cass_statement_bind_int32_by_name(statement, name, Z_LVAL_P(value)));
-
-  if ((Z_TYPE_P(value) == IS_TRUE))
-    CHECK_RESULT(cass_statement_bind_bool_by_name(statement, name, cass_true));
-
-  if ((Z_TYPE_P(value) == IS_FALSE))
-    CHECK_RESULT(cass_statement_bind_bool_by_name(statement, name, cass_false));
 
   if (Z_TYPE_P(value) == IS_OBJECT) {
     if (instanceof_function(Z_OBJCE_P(value), php_scylladb_float_ce)) {
-      php_scylladb_numeric* float_number = PHP_SCYLLADB_GET_NUMERIC(value);
+      auto float_number = PHP_SCYLLADB_GET_NUMERIC(value);
       CHECK_RESULT(
           cass_statement_bind_float_by_name(statement, name, float_number->data.floating.value));
     }
 
     if (instanceof_function(Z_OBJCE_P(value), php_scylladb_bigint_ce)) {
-      php_scylladb_numeric* bigint = PHP_SCYLLADB_GET_NUMERIC(value);
+      auto bigint = PHP_SCYLLADB_GET_NUMERIC(value);
       CHECK_RESULT(cass_statement_bind_int64_by_name(statement, name, bigint->data.bigint.value));
     }
 
     if (instanceof_function(Z_OBJCE_P(value), php_scylladb_smallint_ce)) {
-      php_scylladb_numeric* smallint = PHP_SCYLLADB_GET_NUMERIC(value);
+      auto smallint = PHP_SCYLLADB_GET_NUMERIC(value);
       CHECK_RESULT(
           cass_statement_bind_int16_by_name(statement, name, smallint->data.smallint.value));
     }
 
     if (instanceof_function(Z_OBJCE_P(value), php_scylladb_tinyint_ce)) {
-      php_scylladb_numeric* tinyint = PHP_SCYLLADB_GET_NUMERIC(value);
+      auto tinyint = PHP_SCYLLADB_GET_NUMERIC(value);
       CHECK_RESULT(cass_statement_bind_int8_by_name(statement, name, tinyint->data.tinyint.value));
     }
 
     if (instanceof_function(Z_OBJCE_P(value), php_scylladb_timestamp_ce)) {
-      php_scylladb_timestamp* timestamp = Z_SCYLLADB_TIMESTAMP_P(value);
+      auto timestamp = Z_SCYLLADB_TIMESTAMP_P(value);
       CHECK_RESULT(cass_statement_bind_int64_by_name(statement, name, timestamp->timestamp));
     }
 
     if (instanceof_function(Z_OBJCE_P(value), php_scylladb_date_ce)) {
-      php_scylladb_date* date = Z_SCYLLADB_DATE_P(value);
+      auto date = Z_SCYLLADB_DATE_P(value);
       CHECK_RESULT(cass_statement_bind_uint32_by_name(statement, name, date->date));
     }
 
     if (instanceof_function(Z_OBJCE_P(value), php_scylladb_time_ce)) {
-      php_scylladb_time* time = Z_SCYLLADB_TIME_P(value);
+      auto time = Z_SCYLLADB_TIME_P(value);
       CHECK_RESULT(cass_statement_bind_int64_by_name(statement, name, time->time));
     }
 
     if (instanceof_function(Z_OBJCE_P(value), php_scylladb_blob_ce)) {
-      php_scylladb_blob* blob = PHP_SCYLLADB_GET_BLOB(value);
+      auto blob = PHP_SCYLLADB_GET_BLOB(value);
       CHECK_RESULT(cass_statement_bind_bytes_by_name(statement, name, blob->data, blob->size));
     }
 
     if (instanceof_function(Z_OBJCE_P(value), php_scylladb_varint_ce)) {
-      php_scylladb_numeric* varint = PHP_SCYLLADB_GET_NUMERIC(value);
+      auto varint = PHP_SCYLLADB_GET_NUMERIC(value);
       size_t size;
+      PHP_SCYLLADB_CLEANUP(php_scylladb_free_bytes)
       cass_byte_t* data = (cass_byte_t*)export_twos_complement(varint->data.varint.value, &size);
-      CassError rc = cass_statement_bind_bytes_by_name(statement, name, data, size);
-      free(data);
-      CHECK_RESULT(rc);
+      CHECK_RESULT(cass_statement_bind_bytes_by_name(statement, name, data, size));
     }
 
     if (instanceof_function(Z_OBJCE_P(value), php_scylladb_decimal_ce)) {
-      php_scylladb_numeric* decimal = PHP_SCYLLADB_GET_NUMERIC(value);
+      auto decimal = PHP_SCYLLADB_GET_NUMERIC(value);
       size_t size;
+      PHP_SCYLLADB_CLEANUP(php_scylladb_free_bytes)
       cass_byte_t* data = (cass_byte_t*)export_twos_complement(decimal->data.decimal.value, &size);
-      CassError rc = cass_statement_bind_decimal_by_name(statement, name, data, size,
-                                                         decimal->data.decimal.scale);
-      free(data);
-      CHECK_RESULT(rc);
+      CHECK_RESULT(cass_statement_bind_decimal_by_name(statement, name, data, size,
+                                                       decimal->data.decimal.scale));
     }
 
     if (instanceof_function(Z_OBJCE_P(value), php_scylladb_uuid_interface_ce)) {
-      php_scylladb_uuid* uuid = PHP_SCYLLADB_GET_UUID(value);
+      auto uuid = PHP_SCYLLADB_GET_UUID(value);
       CHECK_RESULT(cass_statement_bind_uuid_by_name(statement, name, uuid->uuid));
     }
 
     if (instanceof_function(Z_OBJCE_P(value), php_scylladb_inet_ce)) {
-      php_scylladb_inet* inet = PHP_SCYLLADB_GET_INET(value);
+      auto inet = PHP_SCYLLADB_GET_INET(value);
       CHECK_RESULT(cass_statement_bind_inet_by_name(statement, name, inet->inet));
     }
 
     if (instanceof_function(Z_OBJCE_P(value), php_scylladb_duration_ce)) {
-      php_scylladb_duration* duration = PHP_SCYLLADB_GET_DURATION(value);
+      auto duration = PHP_SCYLLADB_GET_DURATION(value);
       CHECK_RESULT(cass_statement_bind_duration_by_name(statement, name, duration->months,
                                                         duration->days, duration->nanos));
     }
 
     if (instanceof_function(Z_OBJCE_P(value), php_scylladb_set_ce)) {
-      CassError rc;
-      CassCollection* collection;
-      php_scylladb_set* set = PHP_SCYLLADB_GET_SET(value);
+      auto set = PHP_SCYLLADB_GET_SET(value);
+      PHP_SCYLLADB_CLEANUP(php_scylladb_cass_collection_free) CassCollection* collection = nullptr;
       if (!php_scylladb_collection_from_set(set, &collection)) return FAILURE;
-
-      rc = cass_statement_bind_collection_by_name(statement, name, collection);
-      cass_collection_free(collection);
-      CHECK_RESULT(rc);
+      CHECK_RESULT(cass_statement_bind_collection_by_name(statement, name, collection));
     }
 
     if (instanceof_function(Z_OBJCE_P(value), php_scylladb_map_ce)) {
-      CassError rc;
-      CassCollection* collection;
-      php_scylladb_map* map = PHP_SCYLLADB_GET_MAP(value);
+      auto map = PHP_SCYLLADB_GET_MAP(value);
+      PHP_SCYLLADB_CLEANUP(php_scylladb_cass_collection_free) CassCollection* collection = nullptr;
       if (!php_scylladb_collection_from_map(map, &collection)) return FAILURE;
-
-      rc = cass_statement_bind_collection_by_name(statement, name, collection);
-      cass_collection_free(collection);
-      CHECK_RESULT(rc);
+      CHECK_RESULT(cass_statement_bind_collection_by_name(statement, name, collection));
     }
 
     if (instanceof_function(Z_OBJCE_P(value), php_scylladb_collection_ce)) {
-      CassError rc;
-      CassCollection* collection;
-      php_scylladb_collection* coll = PHP_SCYLLADB_GET_COLLECTION(value);
+      auto coll = PHP_SCYLLADB_GET_COLLECTION(value);
+      PHP_SCYLLADB_CLEANUP(php_scylladb_cass_collection_free) CassCollection* collection = nullptr;
       if (!php_scylladb_collection_from_collection(coll, &collection)) return FAILURE;
-
-      rc = cass_statement_bind_collection_by_name(statement, name, collection);
-      cass_collection_free(collection);
-      CHECK_RESULT(rc);
+      CHECK_RESULT(cass_statement_bind_collection_by_name(statement, name, collection));
     }
 
     if (instanceof_function(Z_OBJCE_P(value), php_scylladb_tuple_ce)) {
-      CassError rc;
-      CassTuple* tup;
-      php_scylladb_tuple* tuple = PHP_SCYLLADB_GET_TUPLE(value);
+      auto tuple = PHP_SCYLLADB_GET_TUPLE(value);
+      PHP_SCYLLADB_CLEANUP(php_scylladb_cass_tuple_free) CassTuple* tup = nullptr;
       if (!php_scylladb_tuple_from_tuple(tuple, &tup)) return FAILURE;
-
-      rc = cass_statement_bind_tuple_by_name(statement, name, tup);
-      cass_tuple_free(tup);
-      CHECK_RESULT(rc);
+      CHECK_RESULT(cass_statement_bind_tuple_by_name(statement, name, tup));
     }
 
     if (instanceof_function(Z_OBJCE_P(value), php_scylladb_user_type_value_ce)) {
-      CassError rc;
-      CassUserType* ut;
-      php_scylladb_user_type_value* user_type_value = PHP_SCYLLADB_GET_USER_TYPE_VALUE(value);
+      auto user_type_value = PHP_SCYLLADB_GET_USER_TYPE_VALUE(value);
+      PHP_SCYLLADB_CLEANUP(php_scylladb_cass_user_type_free) CassUserType* ut = nullptr;
       if (!php_scylladb_user_type_from_user_type_value(user_type_value, &ut)) return FAILURE;
-
-      rc = cass_statement_bind_user_type_by_name(statement, name, ut);
-      cass_user_type_free(ut);
-      CHECK_RESULT(rc);
+      CHECK_RESULT(cass_statement_bind_user_type_by_name(statement, name, ut));
     }
   }
 
@@ -355,7 +314,7 @@ static int bind_arguments(CassStatement* statement, HashTable* arguments) {
   int rc = SUCCESS;
 
   zval* current;
-  ulong num_key;
+  zend_ulong num_key;
   zend_string* key;
   ZEND_HASH_FOREACH_KEY_VAL(arguments, num_key, key, current) {
     if (key) {
@@ -387,18 +346,18 @@ static CassStatement* create_statement(php_scylladb_statement* statement, HashTa
       break;
     default:
       zend_throw_exception_ex(php_scylladb_runtime_exception_ce, 0, "Unsupported statement type.");
-      return NULL;
+      return nullptr;
   }
 
-  if (stmt == NULL) {
+  if (stmt == nullptr) {
     zend_throw_exception_ex(php_scylladb_runtime_exception_ce, 0,
                             "Failed to allocate a CassStatement");
-    return NULL;
+    return nullptr;
   }
 
   if (arguments && bind_arguments(stmt, arguments) == FAILURE) {
     cass_statement_free(stmt);
-    return NULL;
+    return nullptr;
   }
 
   return stmt;
@@ -407,10 +366,10 @@ static CassStatement* create_statement(php_scylladb_statement* statement, HashTa
 static CassBatch* create_batch(php_scylladb_statement* batch, CassConsistency consistency,
                                CassRetryPolicy* retry_policy, cass_int64_t timestamp) {
   CassBatch* cass_batch = cass_batch_new(batch->data.batch.type);
-  if (cass_batch == NULL) {
+  if (cass_batch == nullptr) {
     zend_throw_exception_ex(php_scylladb_runtime_exception_ce, 0,
                             "Failed to allocate a CassBatch");
-    return NULL;
+    return nullptr;
   }
   CassError rc = CASS_OK;
 
@@ -434,12 +393,12 @@ static CassBatch* create_batch(php_scylladb_statement* batch, CassConsistency co
 
     arguments = !Z_ISUNDEF(batch_statement_entry->arguments)
                     ? Z_ARRVAL_P(&batch_statement_entry->arguments)
-                    : NULL;
+                    : nullptr;
 
     stmt = create_statement(statement, arguments);
     if (!stmt) {
       cass_batch_free(cass_batch);
-      return NULL;
+      return nullptr;
     }
     cass_batch_add_statement(cass_batch, stmt);
     cass_statement_free(stmt);
@@ -447,10 +406,10 @@ static CassBatch* create_batch(php_scylladb_statement* batch, CassConsistency co
   ZEND_HASH_FOREACH_END();
 
   rc = cass_batch_set_consistency(cass_batch, consistency);
-  ASSERT_SUCCESS_BLOCK(rc, cass_batch_free(cass_batch); return NULL;);
+  ASSERT_SUCCESS_BLOCK(rc, cass_batch_free(cass_batch); return nullptr;);
 
   rc = cass_batch_set_retry_policy(cass_batch, retry_policy);
-  ASSERT_SUCCESS_BLOCK(rc, cass_batch_free(cass_batch); return NULL;);
+  ASSERT_SUCCESS_BLOCK(rc, cass_batch_free(cass_batch); return nullptr;);
 
   // INT64_MIN is our sentinel for "no explicit timestamp set" (see
   // ExecutionOptions). The legacy cpp-driver tolerated forwarding it on the
@@ -458,7 +417,7 @@ static CassBatch* create_batch(php_scylladb_statement* batch, CassConsistency co
   // protocol range excludes INT64_MIN. Only set when caller provided a value.
   if (timestamp != INT64_MIN) {
     rc = cass_batch_set_timestamp(cass_batch, timestamp);
-    ASSERT_SUCCESS_BLOCK(rc, cass_batch_free(cass_batch); return NULL;);
+    ASSERT_SUCCESS_BLOCK(rc, cass_batch_free(cass_batch); return nullptr;);
   }
 
   return cass_batch;
@@ -471,7 +430,7 @@ static CassStatement* create_single(php_scylladb_statement* statement, HashTable
                                     cass_int64_t timestamp) {
   CassError rc = CASS_OK;
   CassStatement* stmt = create_statement(statement, arguments);
-  if (!stmt) return NULL;
+  if (!stmt) return nullptr;
 
   rc = cass_statement_set_consistency(stmt, consistency);
 
@@ -495,32 +454,32 @@ static CassStatement* create_single(php_scylladb_statement* statement, HashTable
   if (rc != CASS_OK) {
     cass_statement_free(stmt);
     zend_throw_exception_ex(exception_class(rc), rc, "%s", cass_error_desc(rc));
-    return NULL;
+    return nullptr;
   }
 
   return stmt;
 }
 
 ZEND_METHOD(Cassandra_DefaultSession, execute) {
-  zval* statement = NULL;
-  zval* options = NULL;
-  php_scylladb_session* self = NULL;
-  php_scylladb_statement* stmt = NULL;
+  zval* statement = nullptr;
+  zval* options = nullptr;
+  php_scylladb_session* self = nullptr;
+  php_scylladb_statement* stmt = nullptr;
   php_scylladb_statement simple_statement;
-  HashTable* arguments = NULL;
+  HashTable* arguments = nullptr;
   CassConsistency consistency = PHP_SCYLLADB_DEFAULT_CONSISTENCY;
   int page_size = -1;
-  char* paging_state_token = NULL;
+  char* paging_state_token = nullptr;
   size_t paging_state_token_size = 0;
-  zval* timeout = NULL;
+  zval* timeout = nullptr;
   long serial_consistency = -1;
-  CassRetryPolicy* retry_policy = NULL;
+  CassRetryPolicy* retry_policy = nullptr;
   cass_int64_t timestamp = INT64_MIN;
-  php_scylladb_execution_options* opts = NULL;
+  php_scylladb_execution_options* opts = nullptr;
   php_scylladb_execution_options local_opts;
-  CassFuture* future = NULL;
-  CassStatement* single = NULL;
-  CassBatch* batch = NULL;
+  CassFuture* future = nullptr;
+  CassStatement* single = nullptr;
+  CassBatch* batch = nullptr;
 
   ZEND_PARSE_PARAMETERS_START(1, 2)
     Z_PARAM_ZVAL(statement)
@@ -609,8 +568,8 @@ ZEND_METHOD(Cassandra_DefaultSession, execute) {
   }
 
   do {
-    const CassResult* result = NULL;
-    php_scylladb_rows* rows = NULL;
+    const CassResult* result = nullptr;
+    php_scylladb_rows* rows = nullptr;
 
     if (php_scylladb_future_wait_timed(future, timeout) == FAILURE ||
         php_scylladb_future_is_error(future) == FAILURE) {
@@ -640,7 +599,7 @@ ZEND_METHOD(Cassandra_DefaultSession, execute) {
       rows->statement = zend_register_resource(single, php_le_cass_statement());
       rows->result    = result;
       ZVAL_COPY(&rows->session, getThis());
-      single = NULL;   /* ownership transferred via resource */
+      single = nullptr;   /* ownership transferred via resource */
       return;
     }
 
@@ -653,24 +612,24 @@ ZEND_METHOD(Cassandra_DefaultSession, execute) {
 }
 
 ZEND_METHOD(Cassandra_DefaultSession, executeAsync) {
-  zval* statement = NULL;
-  zval* options = NULL;
-  php_scylladb_session* self = NULL;
-  php_scylladb_statement* stmt = NULL;
+  zval* statement = nullptr;
+  zval* options = nullptr;
+  php_scylladb_session* self = nullptr;
+  php_scylladb_statement* stmt = nullptr;
   php_scylladb_statement simple_statement;
-  HashTable* arguments = NULL;
+  HashTable* arguments = nullptr;
   CassConsistency consistency = PHP_SCYLLADB_DEFAULT_CONSISTENCY;
   int page_size = -1;
-  char* paging_state_token = NULL;
+  char* paging_state_token = nullptr;
   size_t paging_state_token_size = 0;
   long serial_consistency = -1;
-  CassRetryPolicy* retry_policy = NULL;
+  CassRetryPolicy* retry_policy = nullptr;
   cass_int64_t timestamp = INT64_MIN;
-  php_scylladb_execution_options* opts = NULL;
+  php_scylladb_execution_options* opts = nullptr;
   php_scylladb_execution_options local_opts;
-  php_scylladb_future_rows* future_rows = NULL;
-  CassStatement* single = NULL;
-  CassBatch* batch = NULL;
+  php_scylladb_future_rows* future_rows = nullptr;
+  CassStatement* single = nullptr;
+  CassBatch* batch = nullptr;
 
   ZEND_PARSE_PARAMETERS_START(1, 2)
     Z_PARAM_ZVAL(statement)
@@ -763,16 +722,16 @@ ZEND_METHOD(Cassandra_DefaultSession, executeAsync) {
 }
 
 ZEND_METHOD(Cassandra_DefaultSession, prepare) {
-  zval* cql = NULL;
-  zval* options = NULL;
+  zval* cql = nullptr;
+  zval* options = nullptr;
   zend_ulong cache_key = 0;
-  php_scylladb_session* self = NULL;
-  php_scylladb_execution_options* opts = NULL;
+  php_scylladb_session* self = nullptr;
+  php_scylladb_execution_options* opts = nullptr;
   php_scylladb_execution_options local_opts;
-  CassFuture* future = NULL;
-  zval* timeout = NULL;
-  php_scylladb_statement* prepared_statement = NULL;
-  php_scylladb_pprepared_statement* pprepared_statement = NULL;
+  CassFuture* future = nullptr;
+  zval* timeout = nullptr;
+  php_scylladb_statement* prepared_statement = nullptr;
+  php_scylladb_pprepared_statement* pprepared_statement = nullptr;
 
   ZEND_PARSE_PARAMETERS_START(1, 2)
     Z_PARAM_ZVAL(cql)
@@ -810,16 +769,16 @@ ZEND_METHOD(Cassandra_DefaultSession, prepare) {
     cache_key = php_scylladb_cache_key_mix_cstr(cache_key, SAFE_STR(self->keyspace));
 
     zval* le = zend_hash_index_find(&EG(persistent_list), cache_key);
-    if (le != NULL && Z_RES_P(le)->type == php_le_php_scylladb_prepared_statement()) {
+    if (le != nullptr && Z_RES_P(le)->type == php_le_php_scylladb_prepared_statement()) {
       pprepared_statement = (php_scylladb_pprepared_statement*)Z_RES_P(le)->ptr;
 
       /* The cached future may belong to a previous prepare that has since
        * failed (e.g. a server-side schema drop). Validate the error code
-       * before trusting cass_future_get_prepared, which returns NULL on
+       * before trusting cass_future_get_prepared, which returns nullptr on
        * error futures and would otherwise corrupt the prepared statement. */
       if (cass_future_error_code(pprepared_statement->future) == CASS_OK) {
         const CassPrepared* cached = cass_future_get_prepared(pprepared_statement->future);
-        if (cached != NULL) {
+        if (cached != nullptr) {
           object_init_ex(return_value, php_scylladb_prepared_statement_ce);
           prepared_statement = PHP_SCYLLADB_GET_STATEMENT(return_value);
           prepared_statement->data.prepared.prepared = cached;
@@ -835,7 +794,7 @@ ZEND_METHOD(Cassandra_DefaultSession, prepare) {
   future =
       cass_session_prepare_n(self->session, Z_STRVAL_P(cql), Z_STRLEN_P(cql));
 
-  if (future == NULL) {
+  if (future == nullptr) {
     zend_throw_exception_ex(php_scylladb_runtime_exception_ce, 0,
                             "Failed to allocate a prepare future");
     return;
@@ -875,11 +834,11 @@ ZEND_METHOD(Cassandra_DefaultSession, prepare) {
 }
 
 ZEND_METHOD(Cassandra_DefaultSession, prepareAsync) {
-  zval* cql = NULL;
-  zval* options = NULL;
-  php_scylladb_session* self = NULL;
-  CassFuture* future = NULL;
-  php_scylladb_future_prepared_statement* future_prepared = NULL;
+  zval* cql = nullptr;
+  zval* options = nullptr;
+  php_scylladb_session* self = nullptr;
+  CassFuture* future = nullptr;
+  php_scylladb_future_prepared_statement* future_prepared = nullptr;
 
   ZEND_PARSE_PARAMETERS_START(1, 2)
     Z_PARAM_ZVAL(cql)
@@ -899,8 +858,8 @@ ZEND_METHOD(Cassandra_DefaultSession, prepareAsync) {
 }
 
 ZEND_METHOD(Cassandra_DefaultSession, close) {
-  zval* timeout = NULL;
-  CassFuture* future = NULL;
+  zval* timeout = nullptr;
+  CassFuture* future = nullptr;
   php_scylladb_session* self;
 
   ZEND_PARSE_PARAMETERS_START(0, 1)
@@ -921,7 +880,7 @@ ZEND_METHOD(Cassandra_DefaultSession, close) {
 
 ZEND_METHOD(Cassandra_DefaultSession, closeAsync) {
   php_scylladb_session* self;
-  php_scylladb_future_close* future = NULL;
+  php_scylladb_future_close* future = nullptr;
 
   if (zend_parse_parameters_none() == FAILURE) {
     return;
@@ -945,7 +904,7 @@ ZEND_METHOD(Cassandra_DefaultSession, metrics) {
   zval requests;
   zval stats;
   zval errors;
-  php_scylladb_session* self = PHP_SCYLLADB_GET_SESSION(getThis());
+  auto self = PHP_SCYLLADB_GET_SESSION(getThis());
 
   if (zend_parse_parameters_none() == FAILURE) return;
 
@@ -1014,36 +973,34 @@ int php_scylladb_default_session_compare(zval* obj1, zval* obj2) {
 }
 
 void php_scylladb_default_session_free(zend_object* object) {
-  php_scylladb_session* self = php_scylladb_session_object_fetch(object);
+  auto self = php_scylladb_session_object_fetch(object);
 
   /* Persistent: the psession entry in EG(persistent_list) owns the
      CassSession; we just borrowed the pointer. */
   if (!self->persist && self->session) {
     cass_session_free(self->session);
-    self->session = NULL;
+    self->session = nullptr;
   }
   zval_ptr_dtor(&self->default_timeout);
 
   if (self->keyspace) {
     efree(self->keyspace);
-    self->keyspace = NULL;
+    self->keyspace = nullptr;
   }
 
   zend_object_std_dtor(&self->zendObject);
 }
 
 zend_object* php_scylladb_default_session_new(zend_class_entry* ce) {
-  php_scylladb_session* self = (php_scylladb_session *)ecalloc(1, sizeof(php_scylladb_session) + zend_object_properties_size(ce));
+  php_scylladb_session* self =
+      PHP_SCYLLADB_OBJ_ALLOCATE(php_scylladb_session, ce, &php_scylladb_default_session_handlers);
 
-  self->session = NULL;
+  self->session = nullptr;
   self->persist = cass_false;
   self->default_consistency = PHP_SCYLLADB_DEFAULT_CONSISTENCY;
   self->default_page_size = 5000;
-  self->keyspace = NULL;
+  self->keyspace = nullptr;
   self->cache_key = 0;
   ZVAL_UNDEF(&self->default_timeout);
-
-  zend_object_std_init(&self->zendObject, ce);
-  self->zendObject.handlers = &php_scylladb_default_session_handlers;
   return &self->zendObject;
 }

--- a/src/DefaultSession.stub.php
+++ b/src/DefaultSession.stub.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 namespace Cassandra {
     /**
      * @strict-properties
+     * @not-serializable
  * @scylladb-struct php_scylladb_session
  */    final class DefaultSession implements Session {
         public function execute(string|Statement $statement, array|ExecutionOptions|null $options = null): Rows {}

--- a/src/Exception/exceptions.c
+++ b/src/Exception/exceptions.c
@@ -51,10 +51,8 @@ zend_class_entry *php_scylladb_overloaded_exception_ce       = nullptr;
  * there's no cross-module ordering to manage. The umbrella interface
  * Cassandra\Exception is the only ce_out the registry tracks; the children
  * are set as side effects (no other registry-owned class extends them). */
-static zend_class_entry *php_scylladb_register_exceptions(zend_class_entry *const *deps)
+static zend_class_entry *php_scylladb_register_exceptions([[maybe_unused]] zend_class_entry *const *deps)
 {
-    (void)deps;
-
     /* Cassandra\Exception interface */
     php_scylladb_exception_ce = register_class_Cassandra_Exception();
 

--- a/src/ExecutionOptions.c
+++ b/src/ExecutionOptions.c
@@ -28,7 +28,7 @@ static void init_execution_options(php_scylladb_execution_options *self)
     self->consistency = -1;
     self->serial_consistency = -1;
     self->page_size = -1;
-    self->paging_state_token = NULL;
+    self->paging_state_token = nullptr;
     self->paging_state_token_size = 0;
     self->timestamp = INT64_MIN;
     ZVAL_UNDEF(&self->arguments);
@@ -38,16 +38,16 @@ static void init_execution_options(php_scylladb_execution_options *self)
 
 static zend_result build_from_array(php_scylladb_execution_options *self, zval *options, int copy)
 {
-    zval *consistency = NULL;
-    zval *serial_consistency = NULL;
-    zval *page_size = NULL;
-    zval *paging_state_token = NULL;
-    zval *timeout = NULL;
-    zval *arguments = NULL;
-    zval *retry_policy = NULL;
-    zval *timestamp = NULL;
+    zval *consistency = nullptr;
+    zval *serial_consistency = nullptr;
+    zval *page_size = nullptr;
+    zval *paging_state_token = nullptr;
+    zval *timeout = nullptr;
+    zval *arguments = nullptr;
+    zval *retry_policy = nullptr;
+    zval *timestamp = nullptr;
 
-    if ((consistency = zend_hash_str_find(Z_ARRVAL_P(options), ZEND_STRL("consistency"))) != NULL)
+    if ((consistency = zend_hash_str_find(Z_ARRVAL_P(options), ZEND_STRL("consistency"))) != nullptr)
     {
         if (Z_TYPE_P(consistency) != IS_LONG)
         {
@@ -67,7 +67,7 @@ static zend_result build_from_array(php_scylladb_execution_options *self, zval *
         self->consistency = val;
     }
 
-    if ((serial_consistency = zend_hash_str_find(Z_ARRVAL_P(options), ZEND_STRL("serial_consistency"))) != NULL)
+    if ((serial_consistency = zend_hash_str_find(Z_ARRVAL_P(options), ZEND_STRL("serial_consistency"))) != nullptr)
     {
         if (Z_TYPE_P(serial_consistency) != IS_LONG)
         {
@@ -90,7 +90,7 @@ static zend_result build_from_array(php_scylladb_execution_options *self, zval *
         self->serial_consistency = val;
     }
 
-    if ((page_size = zend_hash_str_find(Z_ARRVAL_P(options), ZEND_STRL("page_size"))) != NULL)
+    if ((page_size = zend_hash_str_find(Z_ARRVAL_P(options), ZEND_STRL("page_size"))) != nullptr)
     {
         if (Z_TYPE_P(page_size) != IS_LONG ||
             Z_LVAL_P(page_size) <= 0)
@@ -101,7 +101,7 @@ static zend_result build_from_array(php_scylladb_execution_options *self, zval *
         self->page_size = Z_LVAL_P(page_size);
     }
 
-    if ((paging_state_token = zend_hash_str_find(Z_ARRVAL_P(options), ZEND_STRL("paging_state_token"))) != NULL)
+    if ((paging_state_token = zend_hash_str_find(Z_ARRVAL_P(options), ZEND_STRL("paging_state_token"))) != nullptr)
     {
         if (Z_TYPE_P(paging_state_token) != IS_STRING)
         {
@@ -120,7 +120,7 @@ static zend_result build_from_array(php_scylladb_execution_options *self, zval *
         self->paging_state_token_size = Z_STRLEN_P(paging_state_token);
     }
 
-    if ((timeout = zend_hash_str_find(Z_ARRVAL_P(options), ZEND_STRL("timeout"))) != NULL)
+    if ((timeout = zend_hash_str_find(Z_ARRVAL_P(options), ZEND_STRL("timeout"))) != nullptr)
     {
         if (!(Z_TYPE_P(timeout) == IS_LONG &&
               Z_LVAL_P(timeout) > 0) &&
@@ -143,7 +143,7 @@ static zend_result build_from_array(php_scylladb_execution_options *self, zval *
         }
     }
 
-    if ((arguments = zend_hash_str_find(Z_ARRVAL_P(options), ZEND_STRL("arguments"))) != NULL)
+    if ((arguments = zend_hash_str_find(Z_ARRVAL_P(options), ZEND_STRL("arguments"))) != nullptr)
     {
         if (Z_TYPE_P(arguments) != IS_ARRAY)
         {
@@ -161,7 +161,7 @@ static zend_result build_from_array(php_scylladb_execution_options *self, zval *
         }
     }
 
-    if ((retry_policy = zend_hash_str_find(Z_ARRVAL_P(options), ZEND_STRL("retry_policy"))) != NULL)
+    if ((retry_policy = zend_hash_str_find(Z_ARRVAL_P(options), ZEND_STRL("retry_policy"))) != nullptr)
     {
         if (Z_TYPE_P(retry_policy) != IS_OBJECT ||
             !instanceof_function(Z_OBJCE_P(retry_policy), php_scylladb_retry_policy_ce))
@@ -181,7 +181,7 @@ static zend_result build_from_array(php_scylladb_execution_options *self, zval *
         }
     }
 
-    if ((timestamp = zend_hash_str_find(Z_ARRVAL_P(options), ZEND_STRL("timestamp"))) != NULL)
+    if ((timestamp = zend_hash_str_find(Z_ARRVAL_P(options), ZEND_STRL("timestamp"))) != nullptr)
     {
         if (Z_TYPE_P(timestamp) == IS_LONG)
         {
@@ -212,8 +212,8 @@ int php_scylladb_execution_options_build_local_from_array(php_scylladb_execution
 
 ZEND_METHOD(Cassandra_ExecutionOptions, __construct)
 {
-    zval *options = NULL;
-    php_scylladb_execution_options *self = NULL;
+    zval *options = nullptr;
+    php_scylladb_execution_options *self = nullptr;
 
     ZEND_PARSE_PARAMETERS_START(1, 1)
         Z_PARAM_ARRAY(options)
@@ -227,7 +227,7 @@ ZEND_METHOD(Cassandra_ExecutionOptions, __construct)
 ZEND_METHOD(Cassandra_ExecutionOptions, __get)
 {
     zend_string *name;
-    php_scylladb_execution_options *self = NULL;
+    php_scylladb_execution_options *self = nullptr;
 
     ZEND_PARSE_PARAMETERS_START(1, 1)
         Z_PARAM_STR(name)
@@ -322,7 +322,7 @@ int php_scylladb_execution_options_compare(zval *obj1, zval *obj2)
 
 void php_scylladb_execution_options_free(zend_object *object)
 {
-    php_scylladb_execution_options *self = php_scylladb_execution_options_object_fetch(object);
+    auto self = php_scylladb_execution_options_object_fetch(object);
 
     if (self->paging_state_token)
     {
@@ -337,11 +337,9 @@ void php_scylladb_execution_options_free(zend_object *object)
 
 zend_object* php_scylladb_execution_options_new(zend_class_entry *ce)
 {
-    php_scylladb_execution_options *self = (php_scylladb_execution_options *)ecalloc(1, sizeof(php_scylladb_execution_options) + zend_object_properties_size(ce));
+    php_scylladb_execution_options *self =
+        PHP_SCYLLADB_OBJ_ALLOCATE(php_scylladb_execution_options, ce, &php_scylladb_execution_options_handlers);
 
     init_execution_options(self);
-
-    zend_object_std_init(&self->zendObject, ce);
-    self->zendObject.handlers = &php_scylladb_execution_options_handlers;
     return &self->zendObject;
 }

--- a/src/ExecutionOptions.stub.php
+++ b/src/ExecutionOptions.stub.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 namespace Cassandra {
     /**
      * @strict-properties
+     * @not-serializable
  * @scylladb-struct php_scylladb_execution_options
  */    final class ExecutionOptions {
         /** @deprecated */

--- a/src/FutureClose.c
+++ b/src/FutureClose.c
@@ -24,8 +24,8 @@ extern zend_object_handlers php_scylladb_future_close_handlers;
 
 ZEND_METHOD(Cassandra_FutureClose, get)
 {
-  zval *timeout = NULL;
-  php_scylladb_future_close *self = NULL;
+  zval *timeout = nullptr;
+  php_scylladb_future_close *self = nullptr;
 
   ZEND_PARSE_PARAMETERS_START(0, 1)
     Z_PARAM_OPTIONAL
@@ -59,7 +59,7 @@ int php_scylladb_future_close_compare(zval *obj1, zval *obj2)
 
 void php_scylladb_future_close_free(zend_object *object)
 {
-  php_scylladb_future_close *self = php_scylladb_future_close_object_fetch(object);
+  auto self = php_scylladb_future_close_object_fetch(object);
 
   if (self->future)
     cass_future_free(self->future);
@@ -69,11 +69,9 @@ void php_scylladb_future_close_free(zend_object *object)
 
 zend_object *php_scylladb_future_close_new(zend_class_entry *ce)
 {
-  php_scylladb_future_close *self = (php_scylladb_future_close *)ecalloc(1, sizeof(php_scylladb_future_close) + zend_object_properties_size(ce));
+  php_scylladb_future_close *self =
+      PHP_SCYLLADB_OBJ_ALLOCATE(php_scylladb_future_close, ce, &php_scylladb_future_close_handlers);
 
-  self->future = NULL;
-
-  zend_object_std_init(&self->zendObject, ce);
-  self->zendObject.handlers = &php_scylladb_future_close_handlers;
+  self->future = nullptr;
   return &self->zendObject;
 }

--- a/src/FutureClose.stub.php
+++ b/src/FutureClose.stub.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 namespace Cassandra {
     /**
      * @strict-properties
+     * @not-serializable
  * @scylladb-struct php_scylladb_future_close
  */    final class FutureClose implements Future {
         public function get(int|float|null $timeout = null): mixed {}

--- a/src/FuturePreparedStatement.c
+++ b/src/FuturePreparedStatement.c
@@ -24,10 +24,10 @@ extern zend_object_handlers php_scylladb_future_prepared_statement_handlers;
 
 ZEND_METHOD(Cassandra_FuturePreparedStatement, get)
 {
-  zval *timeout = NULL;
-  php_scylladb_statement *prepared_statement = NULL;
+  zval *timeout = nullptr;
+  php_scylladb_statement *prepared_statement = nullptr;
 
-  php_scylladb_future_prepared_statement *self = PHP_SCYLLADB_GET_FUTURE_PREPARED_STATEMENT(getThis());
+  auto self = PHP_SCYLLADB_GET_FUTURE_PREPARED_STATEMENT(getThis());
 
   if (!Z_ISUNDEF(self->prepared_statement)) {
     RETURN_ZVAL(&self->prepared_statement, 1, 0);
@@ -77,7 +77,7 @@ void php_scylladb_future_prepared_statement_free(zend_object *object)
 
   if (self->future) {
     cass_future_free(self->future);
-    self->future = NULL;
+    self->future = nullptr;
   }
 
   zval_ptr_dtor(&self->prepared_statement);
@@ -88,12 +88,10 @@ void php_scylladb_future_prepared_statement_free(zend_object *object)
 zend_object *php_scylladb_future_prepared_statement_new(zend_class_entry *ce)
 {
   php_scylladb_future_prepared_statement *self =
-      (php_scylladb_future_prepared_statement *)ecalloc(1, sizeof(php_scylladb_future_prepared_statement) + zend_object_properties_size(ce));
+      PHP_SCYLLADB_OBJ_ALLOCATE(php_scylladb_future_prepared_statement, ce,
+                                &php_scylladb_future_prepared_statement_handlers);
 
-  self->future = NULL;
+  self->future = nullptr;
   ZVAL_UNDEF(&self->prepared_statement);
-
-  zend_object_std_init(&self->zendObject, ce);
-  self->zendObject.handlers = &php_scylladb_future_prepared_statement_handlers;
   return &self->zendObject;
 }

--- a/src/FuturePreparedStatement.stub.php
+++ b/src/FuturePreparedStatement.stub.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 namespace Cassandra {
     /**
      * @strict-properties
+     * @not-serializable
  * @scylladb-struct php_scylladb_future_prepared_statement
  */    final class FuturePreparedStatement implements Future {
         public function get(int|float|null $timeout = null): mixed {}

--- a/src/FutureRows.c
+++ b/src/FutureRows.c
@@ -26,7 +26,7 @@ extern zend_object_handlers php_scylladb_future_rows_handlers;
 int php_scylladb_future_rows_get_result(php_scylladb_future_rows *future_rows, zval *timeout)
 {
   if (!future_rows->result) {
-    const CassResult *result = NULL;
+    const CassResult *result = nullptr;
 
     if (php_scylladb_future_wait_timed(future_rows->future, timeout) == FAILURE) {
       return FAILURE;
@@ -51,10 +51,10 @@ int php_scylladb_future_rows_get_result(php_scylladb_future_rows *future_rows, z
 
 ZEND_METHOD(Cassandra_FutureRows, get)
 {
-  zval *timeout = NULL;
-  php_scylladb_rows *rows = NULL;
+  zval *timeout = nullptr;
+  php_scylladb_rows *rows = nullptr;
 
-  php_scylladb_future_rows *self = PHP_SCYLLADB_GET_FUTURE_ROWS(getThis());
+  auto self = PHP_SCYLLADB_GET_FUTURE_ROWS(getThis());
 
   ZEND_PARSE_PARAMETERS_START(0, 1)
     Z_PARAM_OPTIONAL
@@ -84,7 +84,7 @@ ZEND_METHOD(Cassandra_FutureRows, get)
     GC_ADDREF(self->statement);
     rows->statement = self->statement;
     rows->result    = self->result;
-    self->result    = NULL;   /* transferred to Rows */
+    self->result    = nullptr;   /* transferred to Rows */
   }
 }
 
@@ -106,17 +106,17 @@ int php_scylladb_future_rows_compare(zval *obj1, zval *obj2)
 
 void php_scylladb_future_rows_free(zend_object *object)
 {
-  php_scylladb_future_rows *self = php_scylladb_future_rows_object_fetch(object);
+  auto self = php_scylladb_future_rows_object_fetch(object);
 
   zval_ptr_dtor(&self->rows);
 
   if (self->statement) {
     zend_list_delete(self->statement);
-    self->statement = NULL;
+    self->statement = nullptr;
   }
   if (self->result) {
     cass_result_free((CassResult *)self->result);
-    self->result = NULL;
+    self->result = nullptr;
   }
   if (!Z_ISUNDEF(self->session)) {
     zval_ptr_dtor(&self->session);
@@ -132,15 +132,13 @@ void php_scylladb_future_rows_free(zend_object *object)
 
 zend_object *php_scylladb_future_rows_new(zend_class_entry *ce)
 {
-  php_scylladb_future_rows *self = (php_scylladb_future_rows *)ecalloc(1, sizeof(php_scylladb_future_rows) + zend_object_properties_size(ce));
+  php_scylladb_future_rows *self =
+      PHP_SCYLLADB_OBJ_ALLOCATE(php_scylladb_future_rows, ce, &php_scylladb_future_rows_handlers);
 
-  self->future    = NULL;
-  self->statement = NULL;
-  self->result    = NULL;
+  self->future    = nullptr;
+  self->statement = nullptr;
+  self->result    = nullptr;
   ZVAL_UNDEF(&self->session);
   ZVAL_UNDEF(&self->rows);
-
-  zend_object_std_init(&self->zendObject, ce);
-  self->zendObject.handlers = &php_scylladb_future_rows_handlers;
   return &self->zendObject;
 }

--- a/src/FutureRows.h
+++ b/src/FutureRows.h
@@ -17,5 +17,5 @@
 #pragma once
 
 BEGIN_EXTERN_C()
-int php_scylladb_future_rows_get_result(php_scylladb_future_rows *future_rows, zval *timeout );
+[[gnu::nonnull(1)]] int php_scylladb_future_rows_get_result(php_scylladb_future_rows *future_rows, zval *timeout );
 END_EXTERN_C()

--- a/src/FutureRows.stub.php
+++ b/src/FutureRows.stub.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 namespace Cassandra {
     /**
      * @strict-properties
+     * @not-serializable
  * @scylladb-struct php_scylladb_future_rows
  */    final class FutureRows implements Future {
         public function get(int|float|null $timeout = null): mixed {}

--- a/src/FutureSession.c
+++ b/src/FutureSession.c
@@ -25,10 +25,10 @@ extern zend_object_handlers php_scylladb_future_session_handlers;
 
 ZEND_METHOD(Cassandra_FutureSession, get)
 {
-  zval *timeout = NULL;
+  zval *timeout = nullptr;
   CassError rc = CASS_OK;
-  php_scylladb_session *session = NULL;
-  php_scylladb_future_session *self = NULL;
+  php_scylladb_session *session = nullptr;
+  php_scylladb_future_session *self = nullptr;
 
   ZEND_PARSE_PARAMETERS_START(0, 1)
     Z_PARAM_OPTIONAL
@@ -47,7 +47,7 @@ ZEND_METHOD(Cassandra_FutureSession, get)
     RETURN_ZVAL(&self->default_session, 1, 0);
   }
 
-  if (self->session == NULL || self->future == NULL) {
+  if (self->session == nullptr || self->future == nullptr) {
     zend_throw_exception_ex(php_scylladb_runtime_exception_ce, 0,
                             "FutureSession has no associated session (cached entry expired)");
     return;
@@ -69,7 +69,7 @@ ZEND_METHOD(Cassandra_FutureSession, get)
     if (self->persist && self->cache_key) {
       /* Remove timed-out pending session so the next request reconnects. */
       if (zend_hash_index_del(&EG(persistent_list), self->cache_key) == SUCCESS) {
-        self->future = NULL;
+        self->future = nullptr;
       }
     }
     return;
@@ -87,7 +87,7 @@ ZEND_METHOD(Cassandra_FutureSession, get)
       self->exception_code    = rc;
 
       if (zend_hash_index_del(&EG(persistent_list), self->cache_key) == SUCCESS) {
-        self->future = NULL;
+        self->future = nullptr;
       }
 
       zend_throw_exception_ex(exception_class(self->exception_code),
@@ -121,7 +121,7 @@ int php_scylladb_future_session_compare(zval *obj1, zval *obj2)
 
 void php_scylladb_future_session_free(zend_object *object)
 {
-  php_scylladb_future_session *self = php_scylladb_future_session_object_fetch(object);
+  auto self = php_scylladb_future_session_object_fetch(object);
 
   if (!self->persist && self->future) {
     cass_future_free(self->future);
@@ -149,7 +149,8 @@ void php_scylladb_future_session_free(zend_object *object)
 
 zend_object *php_scylladb_future_session_new(zend_class_entry *ce)
 {
-  php_scylladb_future_session *self = (php_scylladb_future_session *)ecalloc(1, sizeof(php_scylladb_future_session) + zend_object_properties_size(ce));
+  php_scylladb_future_session *self =
+      PHP_SCYLLADB_OBJ_ALLOCATE(php_scylladb_future_session, ce, &php_scylladb_future_session_handlers);
 
   self->session           = nullptr;
   self->future            = nullptr;
@@ -158,8 +159,5 @@ zend_object *php_scylladb_future_session_new(zend_class_entry *ce)
   self->persist           = cass_false;
 
   ZVAL_UNDEF(&self->default_session);
-
-  zend_object_std_init(&self->zendObject, ce);
-  self->zendObject.handlers = &php_scylladb_future_session_handlers;
   return &self->zendObject;
 }

--- a/src/FutureSession.stub.php
+++ b/src/FutureSession.stub.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 namespace Cassandra {
     /**
      * @strict-properties
+     * @not-serializable
  * @scylladb-struct php_scylladb_future_session
  */    final class FutureSession implements Future {
         public function get(int|float|null $timeout = null): mixed {}

--- a/src/FutureUtil.c
+++ b/src/FutureUtil.c
@@ -25,16 +25,16 @@ php_scylladb_future_wait_timed(CassFuture* future, zval* timeout)
 {
   cass_duration_t timeout_us;
 
-  if (future == NULL) {
+  if (future == nullptr) {
     zend_throw_exception_ex(php_scylladb_runtime_exception_ce, 0,
-                            "Received a NULL future from the driver (allocation failure)");
+                            "Received a nullptr future from the driver (allocation failure)");
     return FAILURE;
   }
 
   if (cass_future_ready(future))
     return SUCCESS;
 
-  if (timeout == NULL || Z_TYPE_P(timeout) == IS_NULL || Z_TYPE_P(timeout) == IS_UNDEF) {
+  if (timeout == nullptr || Z_TYPE_P(timeout) == IS_NULL || Z_TYPE_P(timeout) == IS_UNDEF) {
     cass_future_wait(future);
     return SUCCESS;
   }
@@ -59,9 +59,9 @@ php_scylladb_future_wait_timed(CassFuture* future, zval* timeout)
 int
 php_scylladb_future_is_error(CassFuture* future)
 {
-  if (future == NULL) {
+  if (future == nullptr) {
     zend_throw_exception_ex(php_scylladb_runtime_exception_ce, 0,
-                            "Received a NULL future from the driver (allocation failure)");
+                            "Received a nullptr future from the driver (allocation failure)");
     return FAILURE;
   }
 

--- a/src/FutureUtil.h
+++ b/src/FutureUtil.h
@@ -18,5 +18,6 @@
 #include <cassandra.h>
 #include <php.h>
 
-int php_scylladb_future_wait_timed(CassFuture* future, zval* timeout);
-int php_scylladb_future_is_error(CassFuture* future);
+/* `timeout` may be nullptr (= wait forever); `future` is required. */
+[[gnu::nonnull(1)]] int php_scylladb_future_wait_timed(CassFuture* future, zval* timeout);
+[[gnu::nonnull(1)]] int php_scylladb_future_is_error(CassFuture* future);

--- a/src/FutureValue.c
+++ b/src/FutureValue.c
@@ -23,8 +23,8 @@ extern zend_object_handlers php_scylladb_future_value_handlers;
 
 ZEND_METHOD(Cassandra_FutureValue, get)
 {
-  zval *timeout = NULL;
-  php_scylladb_future_value *self = NULL;
+  zval *timeout = nullptr;
+  php_scylladb_future_value *self = nullptr;
 
   ZEND_PARSE_PARAMETERS_START(0, 1)
     Z_PARAM_OPTIONAL
@@ -56,7 +56,7 @@ int php_scylladb_future_value_compare(zval *obj1, zval *obj2)
 
 void php_scylladb_future_value_free(zend_object *object)
 {
-  php_scylladb_future_value *self = php_scylladb_future_value_object_fetch(object);
+  auto self = php_scylladb_future_value_object_fetch(object);
 
   zval_ptr_dtor(&self->value);
 
@@ -65,12 +65,9 @@ void php_scylladb_future_value_free(zend_object *object)
 
 zend_object *php_scylladb_future_value_new(zend_class_entry *ce)
 {
-  php_scylladb_future_value *self = (php_scylladb_future_value *)ecalloc(
-      1, sizeof(php_scylladb_future_value) + zend_object_properties_size(ce));
+  php_scylladb_future_value *self =
+      PHP_SCYLLADB_OBJ_ALLOCATE(php_scylladb_future_value, ce, &php_scylladb_future_value_handlers);
 
   ZVAL_UNDEF(&self->value);
-
-  zend_object_std_init(&self->zendObject, ce);
-  self->zendObject.handlers = &php_scylladb_future_value_handlers;
   return &self->zendObject;
 }

--- a/src/FutureValue.stub.php
+++ b/src/FutureValue.stub.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 namespace Cassandra {
     /**
      * @strict-properties
+     * @not-serializable
  * @scylladb-struct php_scylladb_future_value
  */    final class FutureValue implements Future {
         public function get(int|float|null $timeout = null): mixed {}

--- a/src/Inet.c
+++ b/src/Inet.c
@@ -59,7 +59,7 @@ ZEND_METHOD(Cassandra_Inet, __construct)
 /* {{{ Inet::__toString() */
 ZEND_METHOD(Cassandra_Inet, __toString)
 {
-  php_scylladb_inet *inet = PHP_SCYLLADB_GET_INET(ZEND_THIS);
+  auto inet = PHP_SCYLLADB_GET_INET(ZEND_THIS);
   char *string;
   php_scylladb_format_address(inet->inet, &string);
 
@@ -79,7 +79,7 @@ ZEND_METHOD(Cassandra_Inet, type)
 /* {{{ Inet::address() */
 ZEND_METHOD(Cassandra_Inet, address)
 {
-  php_scylladb_inet *inet = PHP_SCYLLADB_GET_INET(ZEND_THIS);
+  auto inet = PHP_SCYLLADB_GET_INET(ZEND_THIS);
   char *string;
   php_scylladb_format_address(inet->inet, &string);
 
@@ -92,9 +92,9 @@ ZEND_METHOD(Cassandra_Inet, address)
 HashTable *
 php_scylladb_inet_gc(zend_object *object, zval** table, int *n)
 {
-  *table = NULL;
+  *table = nullptr;
   *n = 0;
-  return NULL;
+  return nullptr;
 }
 
 HashTable *
@@ -104,7 +104,7 @@ php_scylladb_inet_properties(zend_object *object)
   zval type;
   zval address;
 
-  php_scylladb_inet *self = php_scylladb_inet_object_fetch(object);
+  auto self = php_scylladb_inet_object_fetch(object);
   if (object->properties) {
     zend_array_release(object->properties);
   }
@@ -127,8 +127,8 @@ int
 php_scylladb_inet_compare(zval *obj1, zval *obj2)
 {
   ZEND_COMPARE_OBJECTS_FALLBACK(obj1, obj2);
-  php_scylladb_inet *inet1 = NULL;
-  php_scylladb_inet *inet2 = NULL;
+  php_scylladb_inet *inet1 = nullptr;
+  php_scylladb_inet *inet2 = nullptr;
 
   if (Z_OBJCE_P(obj1) != Z_OBJCE_P(obj2))
     return strcmp(ZSTR_VAL(Z_OBJCE_P(obj1)->name), ZSTR_VAL(Z_OBJCE_P(obj2)->name)); /* different classes */
@@ -145,7 +145,7 @@ php_scylladb_inet_compare(zval *obj1, zval *obj2)
 unsigned
 php_scylladb_inet_hash_value(zval *obj )
 {
-  php_scylladb_inet *self = PHP_SCYLLADB_GET_INET(obj);
+  auto self = PHP_SCYLLADB_GET_INET(obj);
   return zend_inline_hash_func((const char *) self->inet.address,
                                self->inet.address_length);
 }
@@ -153,7 +153,7 @@ php_scylladb_inet_hash_value(zval *obj )
 void
 php_scylladb_inet_free(zend_object *object)
 {
-  php_scylladb_inet *self = php_scylladb_inet_object_fetch(object);
+  auto self = php_scylladb_inet_object_fetch(object);
 
   zend_object_std_dtor(&self->zendObject);
 
@@ -162,16 +162,13 @@ php_scylladb_inet_free(zend_object *object)
 zend_object*
 php_scylladb_inet_new(zend_class_entry *ce)
 {
-  php_scylladb_inet *self = (php_scylladb_inet *)ecalloc(1, sizeof(php_scylladb_inet) + zend_object_properties_size(ce));
-
-  zend_object_std_init(&self->zendObject, ce);
-  self->zendObject.handlers = (zend_object_handlers *)&php_scylladb_inet_handlers;
+  php_scylladb_inet *self =
+      PHP_SCYLLADB_OBJ_ALLOCATE(php_scylladb_inet, ce, &php_scylladb_inet_handlers);
   return &self->zendObject;
 }
 
 
-void php_scylladb_inet_post_register(zend_class_entry *ce)
+void php_scylladb_inet_post_register([[maybe_unused]] zend_class_entry *ce)
 {
-    (void)ce;
     php_scylladb_inet_handlers.std.offset = XtOffsetOf(php_scylladb_inet, zendObject);
 }

--- a/src/InetUtil.c
+++ b/src/InetUtil.c
@@ -61,7 +61,7 @@ static const char *ip_address_describe_token(enum ip_address_token_type type) {
     case TOKEN_ILLEGAL:
       return "illegal character";
     default:
-      return NULL;
+      return nullptr;
   }
 }
 

--- a/src/InetUtil.h
+++ b/src/InetUtil.h
@@ -17,5 +17,5 @@
 
 #include <cassandra.h>
 
-void php_scylladb_format_address(CassInet inet, char** out);
-int php_scylladb_parse_ip_address(char* in, CassInet* inet);
+[[gnu::nonnull(2)]] void php_scylladb_format_address(CassInet inet, char** out);
+[[gnu::nonnull(1, 2)]] int php_scylladb_parse_ip_address(char* in, CassInet* inet);

--- a/src/Map.c
+++ b/src/Map.c
@@ -56,7 +56,7 @@ php_scylladb_map_set(php_scylladb_map *map, zval *zkey, zval *zvalue)
 
   map->dirty = 1;
   HASH_FIND_ZVAL(map->entries, zkey, entry);
-  if (entry == NULL) {
+  if (entry == nullptr) {
     entry = (php_scylladb_map_entry *) emalloc(sizeof(php_scylladb_map_entry));
     ZVAL_COPY(&entry->key, zkey);
     ZVAL_COPY(&entry->value, zvalue);
@@ -84,7 +84,7 @@ php_scylladb_map_get(php_scylladb_map *map, zval *zkey, zval *zvalue)
   }
 
   HASH_FIND_ZVAL(map->entries, zkey, entry);
-  if (entry != NULL) {
+  if (entry != nullptr) {
     *zvalue = entry->value;
     result = 1;
   }
@@ -106,7 +106,7 @@ php_scylladb_map_del(php_scylladb_map *map, zval *zkey)
   }
 
   HASH_FIND_ZVAL(map->entries, zkey, entry);
-  if (entry != NULL) {
+  if (entry != nullptr) {
     map->dirty = 1;
     if (entry == map->iter_temp) {
       map->iter_temp = (php_scylladb_map_entry *)map->iter_temp->hh.next;
@@ -135,7 +135,7 @@ php_scylladb_map_has(php_scylladb_map *map, zval *zkey)
   }
 
   HASH_FIND_ZVAL(map->entries, zkey, entry);
-  if (entry != NULL) {
+  if (entry != nullptr) {
     result = 1;
   }
 
@@ -231,14 +231,14 @@ PHP_METHOD(Cassandra_Map, __construct)
 /* {{{ Map::type() */
 PHP_METHOD(Cassandra_Map, type)
 {
-  php_scylladb_map *self = PHP_SCYLLADB_GET_MAP(getThis());
+  auto self = PHP_SCYLLADB_GET_MAP(getThis());
   RETURN_ZVAL(&self->type, 1, 0);
 }
 /* }}} */
 
 PHP_METHOD(Cassandra_Map, keys)
 {
-  php_scylladb_map *self = NULL;
+  php_scylladb_map *self = nullptr;
   array_init(return_value);
   self = PHP_SCYLLADB_GET_MAP(getThis());
   php_scylladb_map_populate_keys(self, return_value );
@@ -246,7 +246,7 @@ PHP_METHOD(Cassandra_Map, keys)
 
 PHP_METHOD(Cassandra_Map, values)
 {
-  php_scylladb_map *self = NULL;
+  php_scylladb_map *self = nullptr;
   array_init(return_value);
   self = PHP_SCYLLADB_GET_MAP(getThis());
   php_scylladb_map_populate_values(self, return_value );
@@ -255,7 +255,7 @@ PHP_METHOD(Cassandra_Map, values)
 PHP_METHOD(Cassandra_Map, set)
 {
   zval *key;
-  php_scylladb_map *self = NULL;
+  php_scylladb_map *self = nullptr;
   zval *value;
 
   ZEND_PARSE_PARAMETERS_START(2, 2)
@@ -274,7 +274,7 @@ PHP_METHOD(Cassandra_Map, set)
 PHP_METHOD(Cassandra_Map, get)
 {
   zval *key;
-  php_scylladb_map *self = NULL;
+  php_scylladb_map *self = nullptr;
   zval value;
 
   ZEND_PARSE_PARAMETERS_START(1, 1)
@@ -290,7 +290,7 @@ PHP_METHOD(Cassandra_Map, get)
 PHP_METHOD(Cassandra_Map, remove)
 {
   zval *key;
-  php_scylladb_map *self = NULL;
+  php_scylladb_map *self = nullptr;
 
   ZEND_PARSE_PARAMETERS_START(1, 1)
     Z_PARAM_ZVAL(key)
@@ -307,7 +307,7 @@ PHP_METHOD(Cassandra_Map, remove)
 PHP_METHOD(Cassandra_Map, has)
 {
   zval *key;
-  php_scylladb_map *self = NULL;
+  php_scylladb_map *self = nullptr;
 
   ZEND_PARSE_PARAMETERS_START(1, 1)
     Z_PARAM_ZVAL(key)
@@ -323,48 +323,48 @@ PHP_METHOD(Cassandra_Map, has)
 
 PHP_METHOD(Cassandra_Map, count)
 {
-  php_scylladb_map *self = PHP_SCYLLADB_GET_MAP(getThis());
+  auto self = PHP_SCYLLADB_GET_MAP(getThis());
   RETURN_LONG((long)HASH_COUNT(self->entries));
 }
 
 PHP_METHOD(Cassandra_Map, current)
 {
-  php_scylladb_map *self = PHP_SCYLLADB_GET_MAP(getThis());
-  if (self->iter_curr != NULL)
+  auto self = PHP_SCYLLADB_GET_MAP(getThis());
+  if (self->iter_curr != nullptr)
     RETURN_ZVAL(&self->iter_curr->value, 1, 0);
 }
 
 PHP_METHOD(Cassandra_Map, key)
 {
-  php_scylladb_map *self = PHP_SCYLLADB_GET_MAP(getThis());
-  if (self->iter_curr != NULL)
+  auto self = PHP_SCYLLADB_GET_MAP(getThis());
+  if (self->iter_curr != nullptr)
     RETURN_ZVAL(&self->iter_curr->key, 1, 0);
 }
 
 PHP_METHOD(Cassandra_Map, next)
 {
-  php_scylladb_map *self = PHP_SCYLLADB_GET_MAP(getThis());
+  auto self = PHP_SCYLLADB_GET_MAP(getThis());
   self->iter_curr = self->iter_temp;
-  self->iter_temp = self->iter_temp != NULL ? (php_scylladb_map_entry *)self->iter_temp->hh.next : NULL;
+  self->iter_temp = self->iter_temp != nullptr ? (php_scylladb_map_entry *)self->iter_temp->hh.next : nullptr;
 }
 
 PHP_METHOD(Cassandra_Map, valid)
 {
-  php_scylladb_map *self = PHP_SCYLLADB_GET_MAP(getThis());
-  RETURN_BOOL(self->iter_curr != NULL);
+  auto self = PHP_SCYLLADB_GET_MAP(getThis());
+  RETURN_BOOL(self->iter_curr != nullptr);
 }
 
 PHP_METHOD(Cassandra_Map, rewind)
 {
-  php_scylladb_map *self = PHP_SCYLLADB_GET_MAP(getThis());
+  auto self = PHP_SCYLLADB_GET_MAP(getThis());
   self->iter_curr = self->entries;
-  self->iter_temp = self->entries != NULL ? (php_scylladb_map_entry *)self->entries->hh.next : NULL;
+  self->iter_temp = self->entries != nullptr ? (php_scylladb_map_entry *)self->entries->hh.next : nullptr;
 }
 
 PHP_METHOD(Cassandra_Map, offsetSet)
 {
   zval *key;
-  php_scylladb_map *self = NULL;
+  php_scylladb_map *self = nullptr;
   zval *value;
 
   ZEND_PARSE_PARAMETERS_START(2, 2)
@@ -380,7 +380,7 @@ PHP_METHOD(Cassandra_Map, offsetSet)
 PHP_METHOD(Cassandra_Map, offsetGet)
 {
   zval *key;
-  php_scylladb_map *self = NULL;
+  php_scylladb_map *self = nullptr;
   zval value;
 
   ZEND_PARSE_PARAMETERS_START(1, 1)
@@ -396,7 +396,7 @@ PHP_METHOD(Cassandra_Map, offsetGet)
 PHP_METHOD(Cassandra_Map, offsetUnset)
 {
   zval *key;
-  php_scylladb_map *self = NULL;
+  php_scylladb_map *self = nullptr;
 
   ZEND_PARSE_PARAMETERS_START(1, 1)
     Z_PARAM_ZVAL(key)
@@ -410,7 +410,7 @@ PHP_METHOD(Cassandra_Map, offsetUnset)
 PHP_METHOD(Cassandra_Map, offsetExists)
 {
   zval *key;
-  php_scylladb_map *self = NULL;
+  php_scylladb_map *self = nullptr;
 
   ZEND_PARSE_PARAMETERS_START(1, 1)
     Z_PARAM_ZVAL(key)
@@ -438,7 +438,7 @@ php_scylladb_map_properties(zend_object *object)
   zval keys;
   zval values;
 
-  php_scylladb_map *self = php_scylladb_map_object_fetch(object);
+  auto self = php_scylladb_map_object_fetch(object);
   if (object->properties) {
     zend_array_release(object->properties);
   }
@@ -491,9 +491,9 @@ php_scylladb_map_compare(zval *obj1, zval *obj2)
   }
 
   HASH_ITER(hh, map1->entries, curr, temp) {
-    php_scylladb_map_entry *entry = NULL;
+    php_scylladb_map_entry *entry = nullptr;
     HASH_FIND_ZVAL(map2->entries, &curr->key, entry);
-    if (entry == NULL) {
+    if (entry == nullptr) {
       return 1;
     }
     result = php_scylladb_value_compare(&curr->value,
@@ -507,7 +507,7 @@ php_scylladb_map_compare(zval *obj1, zval *obj2)
 unsigned
 php_scylladb_map_hash_value(zval *obj)
 {
-  php_scylladb_map *self = PHP_SCYLLADB_GET_MAP(obj);
+  auto self = PHP_SCYLLADB_GET_MAP(obj);
   php_scylladb_map_entry *curr, *temp;
   unsigned hashv = 0;
 
@@ -529,7 +529,7 @@ php_scylladb_map_hash_value(zval *obj)
 void
 php_scylladb_map_free(zend_object *object)
 {
-  php_scylladb_map *self = php_scylladb_map_object_fetch(object);
+  auto self = php_scylladb_map_object_fetch(object);
   php_scylladb_map_entry *curr, *temp;
 
   HASH_ITER(hh, self->entries, curr, temp) {
@@ -549,22 +549,19 @@ zend_object*
 php_scylladb_map_new(zend_class_entry *ce)
 {
   php_scylladb_map *self =
-      (php_scylladb_map *)ecalloc(1, sizeof(php_scylladb_map) + zend_object_properties_size(ce));
+      PHP_SCYLLADB_OBJ_ALLOCATE(php_scylladb_map, ce, &php_scylladb_map_handlers);
 
-  self->entries = self->iter_curr = self->iter_temp = NULL;
+  self->entries = self->iter_curr = self->iter_temp = nullptr;
   self->dirty = 1;
   ZVAL_UNDEF(&self->type);
 
-  zend_object_std_init(&self->zendObject, ce);
   php_scylladb_map_handlers.std.offset = XtOffsetOf(php_scylladb_map, zendObject);
   php_scylladb_map_handlers.std.free_obj = php_scylladb_map_free;
-  self->zendObject.handlers = (zend_object_handlers *)&php_scylladb_map_handlers;
   return &self->zendObject;
 }
 
 
-void php_scylladb_map_post_register(zend_class_entry *ce)
+void php_scylladb_map_post_register([[maybe_unused]] zend_class_entry *ce)
 {
-    (void)ce;
     php_scylladb_map_handlers.std.offset = XtOffsetOf(php_scylladb_map, zendObject);
 }

--- a/src/Map.h
+++ b/src/Map.h
@@ -20,5 +20,5 @@
 #include "php_scylladb_types.h"
 
 BEGIN_EXTERN_C()
-int php_scylladb_map_set(php_scylladb_map* map, zval* zkey, zval* zvalue);
+[[gnu::nonnull(1, 2, 3)]] int php_scylladb_map_set(php_scylladb_map* map, zval* zkey, zval* zvalue);
 END_EXTERN_C()

--- a/src/Numbers/Bigint.c
+++ b/src/Numbers/Bigint.c
@@ -110,7 +110,7 @@ void php_scylladb_bigint_init(INTERNAL_FUNCTION_PARAMETERS)
     }
     else if (Z_TYPE_P(value) == IS_OBJECT && instanceof_function(Z_OBJCE_P(value), php_scylladb_bigint_ce))
     {
-        php_scylladb_numeric *bigint = PHP_SCYLLADB_GET_NUMERIC(value);
+        auto bigint = PHP_SCYLLADB_GET_NUMERIC(value);
         self->data.bigint.value = bigint->data.bigint.value;
     }
     else
@@ -129,7 +129,7 @@ ZEND_METHOD(Cassandra_Bigint, __construct)
 /* {{{ Bigint::__toString() */
 ZEND_METHOD(Cassandra_Bigint, __toString)
 {
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+    auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
 
     to_string(return_value, self);
 }
@@ -146,7 +146,7 @@ ZEND_METHOD(Cassandra_Bigint, type)
 /* {{{ Bigint::value() */
 ZEND_METHOD(Cassandra_Bigint, value)
 {
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+    auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
 
     to_string(return_value, self);
 }
@@ -187,7 +187,7 @@ ZEND_METHOD(Cassandra_Bigint, add)
 ZEND_METHOD(Cassandra_Bigint, sub)
 {
     zval *num;
-    php_scylladb_numeric *result = NULL;
+    php_scylladb_numeric *result = nullptr;
 
     // clang-format off
     ZEND_PARSE_PARAMETERS_START(1, 1)
@@ -197,8 +197,8 @@ ZEND_METHOD(Cassandra_Bigint, sub)
 
     if (Z_TYPE_P(num) == IS_OBJECT && instanceof_function(Z_OBJCE_P(num), php_scylladb_bigint_ce))
     {
-        php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
-        php_scylladb_numeric *bigint = PHP_SCYLLADB_GET_NUMERIC(num);
+        auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+        auto bigint = PHP_SCYLLADB_GET_NUMERIC(num);
 
         object_init_ex(return_value, php_scylladb_bigint_ce);
         result = PHP_SCYLLADB_GET_NUMERIC(return_value);
@@ -216,7 +216,7 @@ ZEND_METHOD(Cassandra_Bigint, sub)
 ZEND_METHOD(Cassandra_Bigint, mul)
 {
     zval *num;
-    php_scylladb_numeric *result = NULL;
+    php_scylladb_numeric *result = nullptr;
 
     // clang-format off
     ZEND_PARSE_PARAMETERS_START(1, 1)
@@ -226,8 +226,8 @@ ZEND_METHOD(Cassandra_Bigint, mul)
 
     if (Z_TYPE_P(num) == IS_OBJECT && instanceof_function(Z_OBJCE_P(num), php_scylladb_bigint_ce))
     {
-        php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
-        php_scylladb_numeric *bigint = PHP_SCYLLADB_GET_NUMERIC(num);
+        auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+        auto bigint = PHP_SCYLLADB_GET_NUMERIC(num);
 
         object_init_ex(return_value, php_scylladb_bigint_ce);
         result = PHP_SCYLLADB_GET_NUMERIC(return_value);
@@ -245,7 +245,7 @@ ZEND_METHOD(Cassandra_Bigint, mul)
 ZEND_METHOD(Cassandra_Bigint, div)
 {
     zval *num;
-    php_scylladb_numeric *result = NULL;
+    php_scylladb_numeric *result = nullptr;
 
     // clang-format off
     ZEND_PARSE_PARAMETERS_START(1, 1)
@@ -255,8 +255,8 @@ ZEND_METHOD(Cassandra_Bigint, div)
 
     if (Z_TYPE_P(num) == IS_OBJECT && instanceof_function(Z_OBJCE_P(num), php_scylladb_bigint_ce))
     {
-        php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
-        php_scylladb_numeric *bigint = PHP_SCYLLADB_GET_NUMERIC(num);
+        auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+        auto bigint = PHP_SCYLLADB_GET_NUMERIC(num);
 
         object_init_ex(return_value, php_scylladb_bigint_ce);
         result = PHP_SCYLLADB_GET_NUMERIC(return_value);
@@ -280,7 +280,7 @@ ZEND_METHOD(Cassandra_Bigint, div)
 ZEND_METHOD(Cassandra_Bigint, mod)
 {
     zval *num;
-    php_scylladb_numeric *result = NULL;
+    php_scylladb_numeric *result = nullptr;
 
     // clang-format off
     ZEND_PARSE_PARAMETERS_START(1, 1)
@@ -290,8 +290,8 @@ ZEND_METHOD(Cassandra_Bigint, mod)
 
     if (Z_TYPE_P(num) == IS_OBJECT && instanceof_function(Z_OBJCE_P(num), php_scylladb_bigint_ce))
     {
-        php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
-        php_scylladb_numeric *bigint = PHP_SCYLLADB_GET_NUMERIC(num);
+        auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+        auto bigint = PHP_SCYLLADB_GET_NUMERIC(num);
 
         object_init_ex(return_value, php_scylladb_bigint_ce);
         result = PHP_SCYLLADB_GET_NUMERIC(return_value);
@@ -314,8 +314,8 @@ ZEND_METHOD(Cassandra_Bigint, mod)
 /* {{{ Bigint::abs() */
 ZEND_METHOD(Cassandra_Bigint, abs)
 {
-    php_scylladb_numeric *result = NULL;
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+    php_scylladb_numeric *result = nullptr;
+    auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
 
     if (self->data.bigint.value == INT64_MIN)
     {
@@ -332,8 +332,8 @@ ZEND_METHOD(Cassandra_Bigint, abs)
 /* {{{ Bigint::neg() */
 ZEND_METHOD(Cassandra_Bigint, neg)
 {
-    php_scylladb_numeric *result = NULL;
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+    php_scylladb_numeric *result = nullptr;
+    auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
 
     object_init_ex(return_value, php_scylladb_bigint_ce);
     result = PHP_SCYLLADB_GET_NUMERIC(return_value);
@@ -344,8 +344,8 @@ ZEND_METHOD(Cassandra_Bigint, neg)
 /* {{{ Bigint::sqrt() */
 ZEND_METHOD(Cassandra_Bigint, sqrt)
 {
-    php_scylladb_numeric *result = NULL;
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+    php_scylladb_numeric *result = nullptr;
+    auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
 
     if (self->data.bigint.value < 0)
     {
@@ -362,7 +362,7 @@ ZEND_METHOD(Cassandra_Bigint, sqrt)
 /* {{{ Bigint::toInt() */
 ZEND_METHOD(Cassandra_Bigint, toInt)
 {
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+    auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
 
     to_long(return_value, self);
 }
@@ -371,7 +371,7 @@ ZEND_METHOD(Cassandra_Bigint, toInt)
 /* {{{ Bigint::toDouble() */
 ZEND_METHOD(Cassandra_Bigint, toDouble)
 {
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+    auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
 
     to_double(return_value, self);
 }
@@ -380,7 +380,7 @@ ZEND_METHOD(Cassandra_Bigint, toDouble)
 /* {{{ Bigint::min() */
 ZEND_METHOD(Cassandra_Bigint, min)
 {
-    php_scylladb_numeric *bigint = NULL;
+    php_scylladb_numeric *bigint = nullptr;
     object_init_ex(return_value, php_scylladb_bigint_ce);
     bigint = PHP_SCYLLADB_GET_NUMERIC(return_value);
     bigint->data.bigint.value = INT64_MIN;
@@ -390,7 +390,7 @@ ZEND_METHOD(Cassandra_Bigint, min)
 /* {{{ Bigint::max() */
 ZEND_METHOD(Cassandra_Bigint, max)
 {
-    php_scylladb_numeric *bigint = NULL;
+    php_scylladb_numeric *bigint = nullptr;
     object_init_ex(return_value, php_scylladb_bigint_ce);
     bigint = PHP_SCYLLADB_GET_NUMERIC(return_value);
     bigint->data.bigint.value = INT64_MAX;
@@ -406,9 +406,9 @@ HashTable *php_scylladb_bigint_gc(
 #endif
     zval** table, int *n)
 {
-    *table = NULL;
+    *table = nullptr;
     *n = 0;
-    return NULL;
+    return nullptr;
 }
 
 HashTable *php_scylladb_bigint_properties(
@@ -423,9 +423,9 @@ HashTable *php_scylladb_bigint_properties(
     zval value;
 
 #if PHP_MAJOR_VERSION >= 8
-    php_scylladb_numeric *self = php_scylladb_numeric_object_fetch(object);
+    auto self = php_scylladb_numeric_object_fetch(object);
 #else
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(object);
+    auto self = PHP_SCYLLADB_GET_NUMERIC(object);
 #endif
     if (object->properties) {
         zend_array_release(object->properties);
@@ -448,8 +448,8 @@ int php_scylladb_bigint_compare(zval *obj1, zval *obj2)
 #if PHP_MAJOR_VERSION >= 8
     ZEND_COMPARE_OBJECTS_FALLBACK(obj1, obj2);
 #endif
-    php_scylladb_numeric *bigint1 = NULL;
-    php_scylladb_numeric *bigint2 = NULL;
+    php_scylladb_numeric *bigint1 = nullptr;
+    php_scylladb_numeric *bigint2 = nullptr;
 
     if (Z_OBJCE_P(obj1) != Z_OBJCE_P(obj2))
         return strcmp(ZSTR_VAL(Z_OBJCE_P(obj1)->name), ZSTR_VAL(Z_OBJCE_P(obj2)->name)); /* different classes */
@@ -467,16 +467,16 @@ int php_scylladb_bigint_compare(zval *obj1, zval *obj2)
 
 unsigned php_scylladb_bigint_hash_value(zval *obj)
 {
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(obj);
+    auto self = PHP_SCYLLADB_GET_NUMERIC(obj);
     return (unsigned)(self->data.bigint.value ^ (self->data.bigint.value >> 32));
 }
 
 zend_result php_scylladb_bigint_cast(zend_object *object, zval *retval, int type)
 {
 #if PHP_MAJOR_VERSION >= 8
-    php_scylladb_numeric *self = php_scylladb_numeric_object_fetch(object);
+    auto self = php_scylladb_numeric_object_fetch(object);
 #else
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(object);
+    auto self = PHP_SCYLLADB_GET_NUMERIC(object);
 #endif
 
     switch (type)
@@ -496,7 +496,7 @@ zend_result php_scylladb_bigint_cast(zend_object *object, zval *retval, int type
 
 void php_scylladb_bigint_free(zend_object *object)
 {
-    php_scylladb_numeric *self = php_scylladb_numeric_object_fetch(object);
+    auto self = php_scylladb_numeric_object_fetch(object);
 
     zend_object_std_dtor(&self->zendObject);
 
@@ -504,17 +504,14 @@ void php_scylladb_bigint_free(zend_object *object)
 
 zend_object* php_scylladb_bigint_new(zend_class_entry *ce)
 {
-    php_scylladb_numeric *self = (php_scylladb_numeric *)ecalloc(1, sizeof(php_scylladb_numeric) + zend_object_properties_size(ce));
+    php_scylladb_numeric *self =
+        PHP_SCYLLADB_OBJ_ALLOCATE(php_scylladb_numeric, ce, &php_scylladb_bigint_handlers);
 
     self->type = PHP_SCYLLADB_BIGINT;
-
-    zend_object_std_init(&self->zendObject, ce);
-    self->zendObject.handlers = (zend_object_handlers *)&php_scylladb_bigint_handlers;
     return &self->zendObject;
 }
 
-void php_scylladb_bigint_post_register(zend_class_entry *ce)
+void php_scylladb_bigint_post_register([[maybe_unused]] zend_class_entry *ce)
 {
-    (void)ce;
     php_scylladb_bigint_handlers.std.offset = XtOffsetOf(php_scylladb_numeric, zendObject);
 }

--- a/src/Numbers/Decimal.c
+++ b/src/Numbers/Decimal.c
@@ -276,7 +276,7 @@ void php_scylladb_decimal_init(INTERNAL_FUNCTION_PARAMETERS)
     }
     else if (Z_TYPE_P(value) == IS_OBJECT && instanceof_function(Z_OBJCE_P(value), php_scylladb_decimal_ce))
     {
-        php_scylladb_numeric *decimal = PHP_SCYLLADB_GET_NUMERIC(value);
+        auto decimal = PHP_SCYLLADB_GET_NUMERIC(value);
         mpz_set(self->data.decimal.value, decimal->data.decimal.value);
         self->data.decimal.scale = decimal->data.decimal.scale;
     }
@@ -296,7 +296,7 @@ ZEND_METHOD(Cassandra_Decimal, __construct)
 /* {{{ Decimal::__toString() */
 ZEND_METHOD(Cassandra_Decimal, __toString)
 {
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+    auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
 
     to_string(return_value, self);
 }
@@ -313,7 +313,7 @@ ZEND_METHOD(Cassandra_Decimal, type)
 /* {{{ Decimal::value() */
 ZEND_METHOD(Cassandra_Decimal, value)
 {
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+    auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
 
     char *string;
     int string_len;
@@ -326,7 +326,7 @@ ZEND_METHOD(Cassandra_Decimal, value)
 
 ZEND_METHOD(Cassandra_Decimal, scale)
 {
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+    auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
 
     RETURN_LONG(self->data.decimal.scale);
 }
@@ -335,7 +335,7 @@ ZEND_METHOD(Cassandra_Decimal, scale)
 ZEND_METHOD(Cassandra_Decimal, add)
 {
     zval *num;
-    php_scylladb_numeric *result = NULL;
+    php_scylladb_numeric *result = nullptr;
 
     // clang-format off
     ZEND_PARSE_PARAMETERS_START(1, 1)
@@ -345,8 +345,8 @@ ZEND_METHOD(Cassandra_Decimal, add)
 
     if (Z_TYPE_P(num) == IS_OBJECT && instanceof_function(Z_OBJCE_P(num), php_scylladb_decimal_ce))
     {
-        php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
-        php_scylladb_numeric *decimal = PHP_SCYLLADB_GET_NUMERIC(num);
+        auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+        auto decimal = PHP_SCYLLADB_GET_NUMERIC(num);
 
         object_init_ex(return_value, php_scylladb_decimal_ce);
         result = PHP_SCYLLADB_GET_NUMERIC(return_value);
@@ -366,7 +366,7 @@ ZEND_METHOD(Cassandra_Decimal, add)
 ZEND_METHOD(Cassandra_Decimal, sub)
 {
     zval *num;
-    php_scylladb_numeric *result = NULL;
+    php_scylladb_numeric *result = nullptr;
 
     // clang-format off
     ZEND_PARSE_PARAMETERS_START(1, 1)
@@ -376,8 +376,8 @@ ZEND_METHOD(Cassandra_Decimal, sub)
 
     if (Z_TYPE_P(num) == IS_OBJECT && instanceof_function(Z_OBJCE_P(num), php_scylladb_decimal_ce))
     {
-        php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
-        php_scylladb_numeric *decimal = PHP_SCYLLADB_GET_NUMERIC(num);
+        auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+        auto decimal = PHP_SCYLLADB_GET_NUMERIC(num);
 
         object_init_ex(return_value, php_scylladb_decimal_ce);
         result = PHP_SCYLLADB_GET_NUMERIC(return_value);
@@ -397,7 +397,7 @@ ZEND_METHOD(Cassandra_Decimal, sub)
 ZEND_METHOD(Cassandra_Decimal, mul)
 {
     zval *num;
-    php_scylladb_numeric *result = NULL;
+    php_scylladb_numeric *result = nullptr;
 
     // clang-format off
     ZEND_PARSE_PARAMETERS_START(1, 1)
@@ -407,8 +407,8 @@ ZEND_METHOD(Cassandra_Decimal, mul)
 
     if (Z_TYPE_P(num) == IS_OBJECT && instanceof_function(Z_OBJCE_P(num), php_scylladb_decimal_ce))
     {
-        php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
-        php_scylladb_numeric *decimal = PHP_SCYLLADB_GET_NUMERIC(num);
+        auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+        auto decimal = PHP_SCYLLADB_GET_NUMERIC(num);
 
         object_init_ex(return_value, php_scylladb_decimal_ce);
         result = PHP_SCYLLADB_GET_NUMERIC(return_value);
@@ -441,8 +441,8 @@ ZEND_METHOD(Cassandra_Decimal, mod)
 /* {{{ Decimal::abs() */
 ZEND_METHOD(Cassandra_Decimal, abs)
 {
-    php_scylladb_numeric *result = NULL;
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+    php_scylladb_numeric *result = nullptr;
+    auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
 
     object_init_ex(return_value, php_scylladb_decimal_ce);
     result = PHP_SCYLLADB_GET_NUMERIC(return_value);
@@ -455,8 +455,8 @@ ZEND_METHOD(Cassandra_Decimal, abs)
 /* {{{ Decimal::neg() */
 ZEND_METHOD(Cassandra_Decimal, neg)
 {
-    php_scylladb_numeric *result = NULL;
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+    php_scylladb_numeric *result = nullptr;
+    auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
 
     object_init_ex(return_value, php_scylladb_decimal_ce);
     result = PHP_SCYLLADB_GET_NUMERIC(return_value);
@@ -471,7 +471,7 @@ ZEND_METHOD(Cassandra_Decimal, sqrt)
 {
     zend_throw_exception_ex(php_scylladb_runtime_exception_ce, 0, "Not implemented");
 #if 0
-  php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+  auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
 
   mpf_t value;
   mpf_init(value);
@@ -480,10 +480,10 @@ ZEND_METHOD(Cassandra_Decimal, sqrt)
   mpf_sqrt(value, value);
 
   mp_exp_t exponent;
-  char* mantissa = mpf_get_str(NULL, &exponent, 10, 0, value);
+  char* mantissa = mpf_get_str(nullptr, &exponent, 10, 0, value);
 
   object_init_ex(return_value, php_scylladb_decimal_ce);
-  php_scylladb_numeric *result = PHP_SCYLLADB_GET_NUMERIC(return_value);
+  auto result = PHP_SCYLLADB_GET_NUMERIC(return_value);
 
   mpz_set_str(result->value.decimal_value, mantissa, 10);
   mp_bitcnt_t prec = mpf_get_prec(value);
@@ -499,7 +499,7 @@ ZEND_METHOD(Cassandra_Decimal, sqrt)
 /* {{{ Decimal::toInt() */
 ZEND_METHOD(Cassandra_Decimal, toInt)
 {
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+    auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
 
     to_long(return_value, self);
 }
@@ -508,7 +508,7 @@ ZEND_METHOD(Cassandra_Decimal, toInt)
 /* {{{ Decimal::toDouble() */
 ZEND_METHOD(Cassandra_Decimal, toDouble)
 {
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+    auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
 
     to_double(return_value, self);
 }
@@ -542,9 +542,9 @@ HashTable *php_scylladb_decimal_properties(
     zval scale;
 
 #if PHP_MAJOR_VERSION >= 8
-    php_scylladb_numeric *self = php_scylladb_numeric_object_fetch(object);
+    auto self = php_scylladb_numeric_object_fetch(object);
 #else
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(object);
+    auto self = PHP_SCYLLADB_GET_NUMERIC(object);
 #endif
     if (object->properties) {
         zend_array_release(object->properties);
@@ -573,8 +573,8 @@ int php_scylladb_decimal_compare(zval *obj1, zval *obj2)
 #if PHP_MAJOR_VERSION >= 8
     ZEND_COMPARE_OBJECTS_FALLBACK(obj1, obj2);
 #endif
-    php_scylladb_numeric *decimal1 = NULL;
-    php_scylladb_numeric *decimal2 = NULL;
+    php_scylladb_numeric *decimal1 = nullptr;
+    php_scylladb_numeric *decimal2 = nullptr;
 
     if (Z_OBJCE_P(obj1) != Z_OBJCE_P(obj2))
         return strcmp(ZSTR_VAL(Z_OBJCE_P(obj1)->name), ZSTR_VAL(Z_OBJCE_P(obj2)->name)); /* different classes */
@@ -598,16 +598,16 @@ int php_scylladb_decimal_compare(zval *obj1, zval *obj2)
 
 unsigned php_scylladb_decimal_hash_value(zval *obj)
 {
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(obj);
+    auto self = PHP_SCYLLADB_GET_NUMERIC(obj);
     return php_scylladb_mpz_hash((unsigned)self->data.decimal.scale, self->data.decimal.value);
 }
 
 zend_result php_scylladb_decimal_cast(zend_object *object, zval *retval, int type)
 {
 #if PHP_MAJOR_VERSION >= 8
-    php_scylladb_numeric *self = php_scylladb_numeric_object_fetch(object);
+    auto self = php_scylladb_numeric_object_fetch(object);
 #else
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(object);
+    auto self = PHP_SCYLLADB_GET_NUMERIC(object);
 #endif
 
     switch (type)
@@ -625,7 +625,7 @@ zend_result php_scylladb_decimal_cast(zend_object *object, zval *retval, int typ
 
 void php_scylladb_decimal_free(zend_object *object)
 {
-    php_scylladb_numeric *self = php_scylladb_numeric_object_fetch(object);
+    auto self = php_scylladb_numeric_object_fetch(object);
 
     mpz_clear(self->data.decimal.value);
 
@@ -635,20 +635,17 @@ void php_scylladb_decimal_free(zend_object *object)
 
 zend_object* php_scylladb_decimal_new(zend_class_entry *ce)
 {
-    php_scylladb_numeric *self = (php_scylladb_numeric *)ecalloc(1, sizeof(php_scylladb_numeric) + zend_object_properties_size(ce));
+    php_scylladb_numeric *self =
+        PHP_SCYLLADB_OBJ_ALLOCATE(php_scylladb_numeric, ce, &php_scylladb_decimal_handlers);
 
     self->type = PHP_SCYLLADB_DECIMAL;
     self->data.decimal.scale = 0;
     mpz_init(self->data.decimal.value);
-
-    zend_object_std_init(&self->zendObject, ce);
-    self->zendObject.handlers = (zend_object_handlers *)&php_scylladb_decimal_handlers;
     return &self->zendObject;
 }
 
 
-void php_scylladb_decimal_post_register(zend_class_entry *ce)
+void php_scylladb_decimal_post_register([[maybe_unused]] zend_class_entry *ce)
 {
-    (void)ce;
     php_scylladb_decimal_handlers.std.offset = XtOffsetOf(php_scylladb_numeric, zendObject);
 }

--- a/src/Numbers/Float.c
+++ b/src/Numbers/Float.c
@@ -64,7 +64,7 @@ php_scylladb_float_init(INTERNAL_FUNCTION_PARAMETERS)
     }
   } else if (Z_TYPE_P(value) == IS_OBJECT &&
              instanceof_function(Z_OBJCE_P(value), php_scylladb_float_ce )) {
-    php_scylladb_numeric *flt = PHP_SCYLLADB_GET_NUMERIC(return_value);
+    auto flt = PHP_SCYLLADB_GET_NUMERIC(return_value);
     self->data.floating.value = flt->data.floating.value;
   } else {
     INVALID_ARGUMENT(value, "a long, double, numeric string or a " \
@@ -82,7 +82,7 @@ ZEND_METHOD(Cassandra_Float, __construct)
 /* {{{ Float::__toString() */
 ZEND_METHOD(Cassandra_Float, __toString)
 {
-  php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+  auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
 
   to_string(return_value, self );
 }
@@ -99,7 +99,7 @@ ZEND_METHOD(Cassandra_Float, type)
 /* {{{ Float::value() */
 ZEND_METHOD(Cassandra_Float, value)
 {
-  php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+  auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
   RETURN_DOUBLE((double) self->data.floating.value);
 }
 /* }}} */
@@ -107,7 +107,7 @@ ZEND_METHOD(Cassandra_Float, value)
 /* {{{ Float::isInfinite() */
 ZEND_METHOD(Cassandra_Float, isInfinite)
 {
-  php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+  auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
   RETURN_BOOL(zend_isinf(self->data.floating.value));
 }
 /* }}} */
@@ -115,7 +115,7 @@ ZEND_METHOD(Cassandra_Float, isInfinite)
 /* {{{ Float::isFinite() */
 ZEND_METHOD(Cassandra_Float, isFinite)
 {
-  php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+  auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
   RETURN_BOOL(zend_finite(self->data.floating.value));
 }
 /* }}} */
@@ -123,7 +123,7 @@ ZEND_METHOD(Cassandra_Float, isFinite)
 /* {{{ Float::isNaN() */
 ZEND_METHOD(Cassandra_Float, isNaN)
 {
-  php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+  auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
   RETURN_BOOL(zend_isnan(self->data.floating.value));
 }
 /* }}} */
@@ -132,7 +132,7 @@ ZEND_METHOD(Cassandra_Float, isNaN)
 ZEND_METHOD(Cassandra_Float, add)
 {
   zval *num;
-  php_scylladb_numeric *result = NULL;
+  php_scylladb_numeric *result = nullptr;
 
   // clang-format off
   ZEND_PARSE_PARAMETERS_START(1, 1)
@@ -142,8 +142,8 @@ ZEND_METHOD(Cassandra_Float, add)
 
   if (Z_TYPE_P(num) == IS_OBJECT &&
       instanceof_function(Z_OBJCE_P(num), php_scylladb_float_ce )) {
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
-    php_scylladb_numeric *flt = PHP_SCYLLADB_GET_NUMERIC(num);
+    auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+    auto flt = PHP_SCYLLADB_GET_NUMERIC(num);
 
     object_init_ex(return_value, php_scylladb_float_ce);
     result = PHP_SCYLLADB_GET_NUMERIC(return_value);
@@ -159,7 +159,7 @@ ZEND_METHOD(Cassandra_Float, add)
 ZEND_METHOD(Cassandra_Float, sub)
 {
   zval *num;
-  php_scylladb_numeric *result = NULL;
+  php_scylladb_numeric *result = nullptr;
 
   // clang-format off
   ZEND_PARSE_PARAMETERS_START(1, 1)
@@ -169,8 +169,8 @@ ZEND_METHOD(Cassandra_Float, sub)
 
   if (Z_TYPE_P(num) == IS_OBJECT &&
       instanceof_function(Z_OBJCE_P(num), php_scylladb_float_ce )) {
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
-    php_scylladb_numeric *flt = PHP_SCYLLADB_GET_NUMERIC(num);
+    auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+    auto flt = PHP_SCYLLADB_GET_NUMERIC(num);
 
     object_init_ex(return_value, php_scylladb_float_ce);
     result = PHP_SCYLLADB_GET_NUMERIC(return_value);
@@ -186,7 +186,7 @@ ZEND_METHOD(Cassandra_Float, sub)
 ZEND_METHOD(Cassandra_Float, mul)
 {
   zval *num;
-  php_scylladb_numeric *result = NULL;
+  php_scylladb_numeric *result = nullptr;
 
   // clang-format off
   ZEND_PARSE_PARAMETERS_START(1, 1)
@@ -196,8 +196,8 @@ ZEND_METHOD(Cassandra_Float, mul)
 
   if (Z_TYPE_P(num) == IS_OBJECT &&
       instanceof_function(Z_OBJCE_P(num), php_scylladb_float_ce )) {
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
-    php_scylladb_numeric *flt = PHP_SCYLLADB_GET_NUMERIC(num);
+    auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+    auto flt = PHP_SCYLLADB_GET_NUMERIC(num);
 
     object_init_ex(return_value, php_scylladb_float_ce);
     result = PHP_SCYLLADB_GET_NUMERIC(return_value);
@@ -213,7 +213,7 @@ ZEND_METHOD(Cassandra_Float, mul)
 ZEND_METHOD(Cassandra_Float, div)
 {
   zval *num;
-  php_scylladb_numeric *result = NULL;
+  php_scylladb_numeric *result = nullptr;
 
   // clang-format off
   ZEND_PARSE_PARAMETERS_START(1, 1)
@@ -223,8 +223,8 @@ ZEND_METHOD(Cassandra_Float, div)
 
   if (Z_TYPE_P(num) == IS_OBJECT &&
       instanceof_function(Z_OBJCE_P(num), php_scylladb_float_ce )) {
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
-    php_scylladb_numeric *flt = PHP_SCYLLADB_GET_NUMERIC(num);
+    auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+    auto flt = PHP_SCYLLADB_GET_NUMERIC(num);
 
     object_init_ex(return_value, php_scylladb_float_ce);
     result = PHP_SCYLLADB_GET_NUMERIC(return_value);
@@ -245,7 +245,7 @@ ZEND_METHOD(Cassandra_Float, div)
 ZEND_METHOD(Cassandra_Float, mod)
 {
   zval *num;
-  php_scylladb_numeric *result = NULL;
+  php_scylladb_numeric *result = nullptr;
 
   // clang-format off
   ZEND_PARSE_PARAMETERS_START(1, 1)
@@ -255,8 +255,8 @@ ZEND_METHOD(Cassandra_Float, mod)
 
   if (Z_TYPE_P(num) == IS_OBJECT &&
       instanceof_function(Z_OBJCE_P(num), php_scylladb_float_ce )) {
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
-    php_scylladb_numeric *flt = PHP_SCYLLADB_GET_NUMERIC(num);
+    auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+    auto flt = PHP_SCYLLADB_GET_NUMERIC(num);
 
     object_init_ex(return_value, php_scylladb_float_ce);
     result = PHP_SCYLLADB_GET_NUMERIC(return_value);
@@ -275,8 +275,8 @@ ZEND_METHOD(Cassandra_Float, mod)
 /* {{{ Float::abs() */
 ZEND_METHOD(Cassandra_Float, abs)
 {
-  php_scylladb_numeric *result = NULL;
-  php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+  php_scylladb_numeric *result = nullptr;
+  auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
   object_init_ex(return_value, php_scylladb_float_ce);
   result = PHP_SCYLLADB_GET_NUMERIC(return_value);
   result->data.floating.value = fabsf(self->data.floating.value);
@@ -286,8 +286,8 @@ ZEND_METHOD(Cassandra_Float, abs)
 /* {{{ Float::neg() */
 ZEND_METHOD(Cassandra_Float, neg)
 {
-  php_scylladb_numeric *result = NULL;
-  php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+  php_scylladb_numeric *result = nullptr;
+  auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
   object_init_ex(return_value, php_scylladb_float_ce);
   result = PHP_SCYLLADB_GET_NUMERIC(return_value);
   result->data.floating.value = -self->data.floating.value;
@@ -297,8 +297,8 @@ ZEND_METHOD(Cassandra_Float, neg)
 /* {{{ Float::sqrt() */
 ZEND_METHOD(Cassandra_Float, sqrt)
 {
-  php_scylladb_numeric *result = NULL;
-  php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+  php_scylladb_numeric *result = nullptr;
+  auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
 
   if (self->data.floating.value < 0) {
     zend_throw_exception_ex(php_scylladb_range_exception_ce, 0 ,
@@ -314,7 +314,7 @@ ZEND_METHOD(Cassandra_Float, sqrt)
 /* {{{ Float::toInt() */
 ZEND_METHOD(Cassandra_Float, toInt)
 {
-  php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+  auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
 
   RETURN_LONG((long) self->data.floating.value);
 }
@@ -323,7 +323,7 @@ ZEND_METHOD(Cassandra_Float, toInt)
 /* {{{ Float::toDouble() */
 ZEND_METHOD(Cassandra_Float, toDouble)
 {
-  php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+  auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
 
   RETURN_DOUBLE((double) self->data.floating.value);
 }
@@ -332,7 +332,7 @@ ZEND_METHOD(Cassandra_Float, toDouble)
 /* {{{ Float::min() */
 ZEND_METHOD(Cassandra_Float, min)
 {
-  php_scylladb_numeric *flt = NULL;
+  php_scylladb_numeric *flt = nullptr;
   object_init_ex(return_value, php_scylladb_float_ce);
   flt = PHP_SCYLLADB_GET_NUMERIC(return_value);
   flt->data.floating.value = FLT_MIN;
@@ -342,7 +342,7 @@ ZEND_METHOD(Cassandra_Float, min)
 /* {{{ Float::max() */
 ZEND_METHOD(Cassandra_Float, max)
 {
-  php_scylladb_numeric *flt = NULL;
+  php_scylladb_numeric *flt = nullptr;
   object_init_ex(return_value, php_scylladb_float_ce);
   flt = PHP_SCYLLADB_GET_NUMERIC(return_value);
   flt->data.floating.value = FLT_MAX;
@@ -361,9 +361,9 @@ php_scylladb_float_gc(
         zval** table, int *n
 )
 {
-  *table = NULL;
+  *table = nullptr;
   *n = 0;
-  return NULL;
+  return nullptr;
 }
 
 HashTable *
@@ -379,9 +379,9 @@ php_scylladb_float_properties(
   zval value;
 
 #if PHP_MAJOR_VERSION >= 8
-  php_scylladb_numeric *self = php_scylladb_numeric_object_fetch(object);
+  auto self = php_scylladb_numeric_object_fetch(object);
 #else
-  php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(object);
+  auto self = PHP_SCYLLADB_GET_NUMERIC(object);
 #endif
   if (object->properties) {
     zend_array_release(object->properties);
@@ -414,8 +414,8 @@ php_scylladb_float_compare(zval *obj1, zval *obj2 )
   ZEND_COMPARE_OBJECTS_FALLBACK(obj1, obj2);
 #endif
   cass_int32_t bits1, bits2;
-  php_scylladb_numeric *flt1 = NULL;
-  php_scylladb_numeric *flt2 = NULL;
+  php_scylladb_numeric *flt1 = nullptr;
+  php_scylladb_numeric *flt2 = nullptr;
 
   if (Z_OBJCE_P(obj1) != Z_OBJCE_P(obj2))
     return strcmp(ZSTR_VAL(Z_OBJCE_P(obj1)->name), ZSTR_VAL(Z_OBJCE_P(obj2)->name)); /* different classes */
@@ -436,7 +436,7 @@ php_scylladb_float_compare(zval *obj1, zval *obj2 )
 unsigned
 php_scylladb_float_hash_value(zval *obj )
 {
-  php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(obj);
+  auto self = PHP_SCYLLADB_GET_NUMERIC(obj);
   return float_to_bits(self->data.floating.value);
 }
 
@@ -446,9 +446,9 @@ zend_result php_scylladb_float_cast(
 )
 {
 #if PHP_MAJOR_VERSION >= 8
-  php_scylladb_numeric *self = php_scylladb_numeric_object_fetch(object);
+  auto self = php_scylladb_numeric_object_fetch(object);
 #else
-  php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(object);
+  auto self = PHP_SCYLLADB_GET_NUMERIC(object);
 #endif
 
   switch (type) {
@@ -470,7 +470,7 @@ zend_result php_scylladb_float_cast(
 void
 php_scylladb_float_free(zend_object *object )
 {
-  php_scylladb_numeric *self = php_scylladb_numeric_object_fetch(object);
+  auto self = php_scylladb_numeric_object_fetch(object);
 
   zend_object_std_dtor(&self->zendObject);
 
@@ -479,16 +479,13 @@ php_scylladb_float_free(zend_object *object )
 zend_object*
 php_scylladb_float_new(zend_class_entry *ce )
 {
-  php_scylladb_numeric *self = (php_scylladb_numeric *)ecalloc(1, sizeof(php_scylladb_numeric) + zend_object_properties_size(ce));
-
-  zend_object_std_init(&self->zendObject, ce);
-  self->zendObject.handlers = (zend_object_handlers *)&php_scylladb_float_handlers;
+  php_scylladb_numeric *self =
+      PHP_SCYLLADB_OBJ_ALLOCATE(php_scylladb_numeric, ce, &php_scylladb_float_handlers);
   return &self->zendObject;
 }
 
 
-void php_scylladb_float_post_register(zend_class_entry *ce)
+void php_scylladb_float_post_register([[maybe_unused]] zend_class_entry *ce)
 {
-    (void)ce;
     php_scylladb_float_handlers.std.offset = XtOffsetOf(php_scylladb_numeric, zendObject);
 }

--- a/src/Numbers/NumberParser.c
+++ b/src/Numbers/NumberParser.c
@@ -108,7 +108,7 @@ php_scylladb_parse_double(char* in, int in_len, cass_double_t* number )
 int
 php_scylladb_parse_int(char* in, int in_len, cass_int32_t* number )
 {
-  char* end          = NULL;
+  char* end          = nullptr;
   int pos            = 0;
   int negative       = 0;
   cass_uint32_t temp = 0;
@@ -158,7 +158,7 @@ php_scylladb_parse_int(char* in, int in_len, cass_int32_t* number )
 int
 php_scylladb_parse_bigint(char* in, int in_len, cass_int64_t* number )
 {
-  char* end          = NULL;
+  char* end          = nullptr;
   int pos            = 0;
   int negative       = 0;
   cass_uint64_t temp = 0;
@@ -415,7 +415,7 @@ php_scylladb_format_integer(mpz_t number, char** out, int* out_len)
 void
 php_scylladb_format_decimal(mpz_t number, long scale, char** out, int* out_len)
 {
-  char* tmp    = NULL;
+  char* tmp    = nullptr;
   size_t total = 0;
   size_t len   = mpz_sizeinbase(number, 10);
   int negative = 0;
@@ -550,7 +550,7 @@ export_twos_complement(mpz_t number, size_t* size)
   cass_byte_t* bytes;
 
   if (mpz_sgn(number) == 0) {
-    /* mpz_export() returns NULL for 0 */
+    /* mpz_export() returns nullptr for 0 */
     bytes  = (cass_byte_t*) malloc(sizeof(cass_byte_t));
     *bytes = 0;
     *size  = 1;
@@ -586,7 +586,7 @@ export_twos_complement(mpz_t number, size_t* size)
     mpz_set_ui(temp, 1);
     mpz_mul_2exp(temp, temp, 8 * n);
     mpz_add(temp, number, temp);
-    bytes = (cass_byte_t*) mpz_export(NULL, size, 1, sizeof(cass_byte_t), 1, 0, temp);
+    bytes = (cass_byte_t*) mpz_export(nullptr, size, 1, sizeof(cass_byte_t), 1, 0, temp);
     mpz_clear(temp);
   } else {
     /* mpz_export() always returns a unsigned number and can have
@@ -598,7 +598,7 @@ export_twos_complement(mpz_t number, size_t* size)
     *size    = (mpz_sizeinbase(number, 2) + 7) / 8 + 1;
     bytes    = (cass_byte_t*) malloc(*size);
     bytes[0] = 0;
-    mpz_export(bytes + 1, NULL, 1, sizeof(cass_byte_t), 1, 0, number);
+    mpz_export(bytes + 1, nullptr, 1, sizeof(cass_byte_t), 1, 0, number);
   }
 
   return bytes;

--- a/src/Numbers/Smallint.c
+++ b/src/Numbers/Smallint.c
@@ -75,7 +75,7 @@ void php_scylladb_smallint_init(INTERNAL_FUNCTION_PARAMETERS)
 
     if (Z_TYPE_P(value) == IS_OBJECT && instanceof_function(Z_OBJCE_P(value), php_scylladb_smallint_ce ))
     {
-        php_scylladb_numeric *other = PHP_SCYLLADB_GET_NUMERIC(value);
+        auto other = PHP_SCYLLADB_GET_NUMERIC(value);
         self->data.smallint.value = other->data.smallint.value;
     }
     else
@@ -145,7 +145,7 @@ ZEND_METHOD(Cassandra_Smallint, __construct)
 /* {{{ Smallint::__toString() */
 ZEND_METHOD(Cassandra_Smallint, __toString)
 {
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+    auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
 
     to_string(return_value, self );
 }
@@ -162,7 +162,7 @@ ZEND_METHOD(Cassandra_Smallint, type)
 /* {{{ Smallint::value() */
 ZEND_METHOD(Cassandra_Smallint, value)
 {
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+    auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
 
     to_long(return_value, self );
 }
@@ -208,7 +208,7 @@ ZEND_METHOD(Cassandra_Smallint, add)
 ZEND_METHOD(Cassandra_Smallint, sub)
 {
     zval *difference;
-    php_scylladb_numeric *result = NULL;
+    php_scylladb_numeric *result = nullptr;
 
     // clang-format off
     ZEND_PARSE_PARAMETERS_START(1, 1)
@@ -219,8 +219,8 @@ ZEND_METHOD(Cassandra_Smallint, sub)
     if (Z_TYPE_P(difference) == IS_OBJECT &&
         instanceof_function(Z_OBJCE_P(difference), php_scylladb_smallint_ce ))
     {
-        php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
-        php_scylladb_numeric *smallint = PHP_SCYLLADB_GET_NUMERIC(difference);
+        auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+        auto smallint = PHP_SCYLLADB_GET_NUMERIC(difference);
 
         object_init_ex(return_value, php_scylladb_smallint_ce);
         result = PHP_SCYLLADB_GET_NUMERIC(return_value);
@@ -243,7 +243,7 @@ ZEND_METHOD(Cassandra_Smallint, sub)
 ZEND_METHOD(Cassandra_Smallint, mul)
 {
     zval *multiplier;
-    php_scylladb_numeric *result = NULL;
+    php_scylladb_numeric *result = nullptr;
 
     // clang-format off
     ZEND_PARSE_PARAMETERS_START(1, 1)
@@ -254,8 +254,8 @@ ZEND_METHOD(Cassandra_Smallint, mul)
     if (Z_TYPE_P(multiplier) == IS_OBJECT &&
         instanceof_function(Z_OBJCE_P(multiplier), php_scylladb_smallint_ce ))
     {
-        php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
-        php_scylladb_numeric *smallint = PHP_SCYLLADB_GET_NUMERIC(multiplier);
+        auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+        auto smallint = PHP_SCYLLADB_GET_NUMERIC(multiplier);
 
         object_init_ex(return_value, php_scylladb_smallint_ce);
         result = PHP_SCYLLADB_GET_NUMERIC(return_value);
@@ -279,7 +279,7 @@ ZEND_METHOD(Cassandra_Smallint, mul)
 ZEND_METHOD(Cassandra_Smallint, div)
 {
     zval *divisor;
-    php_scylladb_numeric *result = NULL;
+    php_scylladb_numeric *result = nullptr;
 
     // clang-format off
     ZEND_PARSE_PARAMETERS_START(1, 1)
@@ -289,8 +289,8 @@ ZEND_METHOD(Cassandra_Smallint, div)
 
     if (Z_TYPE_P(divisor) == IS_OBJECT && instanceof_function(Z_OBJCE_P(divisor), php_scylladb_smallint_ce ))
     {
-        php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
-        php_scylladb_numeric *smallint = PHP_SCYLLADB_GET_NUMERIC(divisor);
+        auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+        auto smallint = PHP_SCYLLADB_GET_NUMERIC(divisor);
 
         object_init_ex(return_value, php_scylladb_smallint_ce);
         result = PHP_SCYLLADB_GET_NUMERIC(return_value);
@@ -314,7 +314,7 @@ ZEND_METHOD(Cassandra_Smallint, div)
 ZEND_METHOD(Cassandra_Smallint, mod)
 {
     zval *divisor;
-    php_scylladb_numeric *result = NULL;
+    php_scylladb_numeric *result = nullptr;
 
     // clang-format off
     ZEND_PARSE_PARAMETERS_START(1, 1)
@@ -324,8 +324,8 @@ ZEND_METHOD(Cassandra_Smallint, mod)
 
     if (Z_TYPE_P(divisor) == IS_OBJECT && instanceof_function(Z_OBJCE_P(divisor), php_scylladb_smallint_ce ))
     {
-        php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
-        php_scylladb_numeric *smallint = PHP_SCYLLADB_GET_NUMERIC(divisor);
+        auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+        auto smallint = PHP_SCYLLADB_GET_NUMERIC(divisor);
 
         object_init_ex(return_value, php_scylladb_smallint_ce);
         result = PHP_SCYLLADB_GET_NUMERIC(return_value);
@@ -348,8 +348,8 @@ ZEND_METHOD(Cassandra_Smallint, mod)
 /* {{{ Smallint::abs() */
 ZEND_METHOD(Cassandra_Smallint, abs)
 {
-    php_scylladb_numeric *result = NULL;
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+    php_scylladb_numeric *result = nullptr;
+    auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
 
     if (self->data.smallint.value == INT16_MIN)
     {
@@ -367,8 +367,8 @@ ZEND_METHOD(Cassandra_Smallint, abs)
 /* {{{ Smallint::neg() */
 ZEND_METHOD(Cassandra_Smallint, neg)
 {
-    php_scylladb_numeric *result = NULL;
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+    php_scylladb_numeric *result = nullptr;
+    auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
 
     if (self->data.smallint.value == INT16_MIN)
     {
@@ -385,8 +385,8 @@ ZEND_METHOD(Cassandra_Smallint, neg)
 /* {{{ Smallint::sqrt() */
 ZEND_METHOD(Cassandra_Smallint, sqrt)
 {
-    php_scylladb_numeric *result = NULL;
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+    php_scylladb_numeric *result = nullptr;
+    auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
 
     if (self->data.smallint.value < 0)
     {
@@ -403,7 +403,7 @@ ZEND_METHOD(Cassandra_Smallint, sqrt)
 /* {{{ Smallint::toInt() */
 ZEND_METHOD(Cassandra_Smallint, toInt)
 {
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+    auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
 
     to_long(return_value, self );
 }
@@ -412,7 +412,7 @@ ZEND_METHOD(Cassandra_Smallint, toInt)
 /* {{{ Smallint::toDouble() */
 ZEND_METHOD(Cassandra_Smallint, toDouble)
 {
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+    auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
 
     to_double(return_value, self );
 }
@@ -421,7 +421,7 @@ ZEND_METHOD(Cassandra_Smallint, toDouble)
 /* {{{ Smallint::min() */
 ZEND_METHOD(Cassandra_Smallint, min)
 {
-    php_scylladb_numeric *smallint = NULL;
+    php_scylladb_numeric *smallint = nullptr;
     object_init_ex(return_value, php_scylladb_smallint_ce);
     smallint = PHP_SCYLLADB_GET_NUMERIC(return_value);
     smallint->data.smallint.value = INT16_MIN;
@@ -431,7 +431,7 @@ ZEND_METHOD(Cassandra_Smallint, min)
 /* {{{ Smallint::max() */
 ZEND_METHOD(Cassandra_Smallint, max)
 {
-    php_scylladb_numeric *smallint = NULL;
+    php_scylladb_numeric *smallint = nullptr;
     object_init_ex(return_value, php_scylladb_smallint_ce);
     smallint = PHP_SCYLLADB_GET_NUMERIC(return_value);
     smallint->data.smallint.value = INT16_MAX;
@@ -448,9 +448,9 @@ HashTable *php_scylladb_smallint_gc(
 #endif
     zval** table, int *n )
 {
-    *table = NULL;
+    *table = nullptr;
     *n = 0;
-    return NULL;
+    return nullptr;
 }
 
 HashTable *php_scylladb_smallint_properties(
@@ -465,9 +465,9 @@ HashTable *php_scylladb_smallint_properties(
     zval value;
 
 #if PHP_MAJOR_VERSION >= 8
-    php_scylladb_numeric *self = php_scylladb_numeric_object_fetch(object);
+    auto self = php_scylladb_numeric_object_fetch(object);
 #else
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(object);
+    auto self = PHP_SCYLLADB_GET_NUMERIC(object);
 #endif
     if (object->properties) {
         zend_array_release(object->properties);
@@ -490,8 +490,8 @@ int php_scylladb_smallint_compare(zval *obj1, zval *obj2 )
 #if PHP_MAJOR_VERSION >= 8
     ZEND_COMPARE_OBJECTS_FALLBACK(obj1, obj2);
 #endif
-    php_scylladb_numeric *smallint1 = NULL;
-    php_scylladb_numeric *smallint2 = NULL;
+    php_scylladb_numeric *smallint1 = nullptr;
+    php_scylladb_numeric *smallint2 = nullptr;
 
     if (Z_OBJCE_P(obj1) != Z_OBJCE_P(obj2))
         return strcmp(ZSTR_VAL(Z_OBJCE_P(obj1)->name), ZSTR_VAL(Z_OBJCE_P(obj2)->name)); /* different classes */
@@ -509,16 +509,16 @@ int php_scylladb_smallint_compare(zval *obj1, zval *obj2 )
 
 unsigned php_scylladb_smallint_hash_value(zval *obj )
 {
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(obj);
+    auto self = PHP_SCYLLADB_GET_NUMERIC(obj);
     return 31 * 17 + self->data.smallint.value;
 }
 
 zend_result php_scylladb_smallint_cast(zend_object *object, zval *retval, int type )
 {
 #if PHP_MAJOR_VERSION >= 8
-    php_scylladb_numeric *self = php_scylladb_numeric_object_fetch(object);
+    auto self = php_scylladb_numeric_object_fetch(object);
 #else
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(object);
+    auto self = PHP_SCYLLADB_GET_NUMERIC(object);
 #endif
 
     switch (type)
@@ -538,7 +538,7 @@ zend_result php_scylladb_smallint_cast(zend_object *object, zval *retval, int ty
 
 void php_scylladb_smallint_free(zend_object *object )
 {
-    php_scylladb_numeric *self = php_scylladb_numeric_object_fetch(object);
+    auto self = php_scylladb_numeric_object_fetch(object);
 
     zend_object_std_dtor(&self->zendObject);
 
@@ -546,17 +546,14 @@ void php_scylladb_smallint_free(zend_object *object )
 
 zend_object* php_scylladb_smallint_new(zend_class_entry *ce )
 {
-    php_scylladb_numeric *self = (php_scylladb_numeric *)ecalloc(1, sizeof(php_scylladb_numeric) + zend_object_properties_size(ce));
+    php_scylladb_numeric *self =
+        PHP_SCYLLADB_OBJ_ALLOCATE(php_scylladb_numeric, ce, &php_scylladb_smallint_handlers);
 
     self->type = PHP_SCYLLADB_SMALLINT;
-
-    zend_object_std_init(&self->zendObject, ce);
-    self->zendObject.handlers = (zend_object_handlers *)&php_scylladb_smallint_handlers;
     return &self->zendObject;
 }
 
-void php_scylladb_smallint_post_register(zend_class_entry *ce)
+void php_scylladb_smallint_post_register([[maybe_unused]] zend_class_entry *ce)
 {
-    (void)ce;
     php_scylladb_smallint_handlers.std.offset = XtOffsetOf(php_scylladb_numeric, zendObject);
 }

--- a/src/Numbers/Tinyint.c
+++ b/src/Numbers/Tinyint.c
@@ -73,7 +73,7 @@ void php_scylladb_tinyint_init(INTERNAL_FUNCTION_PARAMETERS)
 
     if (Z_TYPE_P(value) == IS_OBJECT && instanceof_function(Z_OBJCE_P(value), php_scylladb_tinyint_ce ))
     {
-        php_scylladb_numeric *other = PHP_SCYLLADB_GET_NUMERIC(value);
+        auto other = PHP_SCYLLADB_GET_NUMERIC(value);
         self->data.tinyint.value = other->data.tinyint.value;
     }
     else
@@ -142,7 +142,7 @@ ZEND_METHOD(Cassandra_Tinyint, __construct)
 /* {{{ Tinyint::__toString() */
 ZEND_METHOD(Cassandra_Tinyint, __toString)
 {
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+    auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
 
     to_string(return_value, self );
 }
@@ -159,7 +159,7 @@ ZEND_METHOD(Cassandra_Tinyint, type)
 /* {{{ Tinyint::value() */
 ZEND_METHOD(Cassandra_Tinyint, value)
 {
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+    auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
 
     to_long(return_value, self );
 }
@@ -205,7 +205,7 @@ ZEND_METHOD(Cassandra_Tinyint, add)
 ZEND_METHOD(Cassandra_Tinyint, sub)
 {
     zval *difference;
-    php_scylladb_numeric *result = NULL;
+    php_scylladb_numeric *result = nullptr;
 
     // clang-format off
     ZEND_PARSE_PARAMETERS_START(1, 1)
@@ -216,8 +216,8 @@ ZEND_METHOD(Cassandra_Tinyint, sub)
     if (Z_TYPE_P(difference) == IS_OBJECT &&
         instanceof_function(Z_OBJCE_P(difference), php_scylladb_tinyint_ce ))
     {
-        php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
-        php_scylladb_numeric *tinyint = PHP_SCYLLADB_GET_NUMERIC(difference);
+        auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+        auto tinyint = PHP_SCYLLADB_GET_NUMERIC(difference);
 
         object_init_ex(return_value, php_scylladb_tinyint_ce);
         result = PHP_SCYLLADB_GET_NUMERIC(return_value);
@@ -240,7 +240,7 @@ ZEND_METHOD(Cassandra_Tinyint, sub)
 ZEND_METHOD(Cassandra_Tinyint, mul)
 {
     zval *multiplier;
-    php_scylladb_numeric *result = NULL;
+    php_scylladb_numeric *result = nullptr;
 
     // clang-format off
     ZEND_PARSE_PARAMETERS_START(1, 1)
@@ -251,8 +251,8 @@ ZEND_METHOD(Cassandra_Tinyint, mul)
     if (Z_TYPE_P(multiplier) == IS_OBJECT &&
         instanceof_function(Z_OBJCE_P(multiplier), php_scylladb_tinyint_ce ))
     {
-        php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
-        php_scylladb_numeric *tinyint = PHP_SCYLLADB_GET_NUMERIC(multiplier);
+        auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+        auto tinyint = PHP_SCYLLADB_GET_NUMERIC(multiplier);
 
         object_init_ex(return_value, php_scylladb_tinyint_ce);
         result = PHP_SCYLLADB_GET_NUMERIC(return_value);
@@ -276,7 +276,7 @@ ZEND_METHOD(Cassandra_Tinyint, mul)
 ZEND_METHOD(Cassandra_Tinyint, div)
 {
     zval *divisor;
-    php_scylladb_numeric *result = NULL;
+    php_scylladb_numeric *result = nullptr;
 
     // clang-format off
     ZEND_PARSE_PARAMETERS_START(1, 1)
@@ -286,8 +286,8 @@ ZEND_METHOD(Cassandra_Tinyint, div)
 
     if (Z_TYPE_P(divisor) == IS_OBJECT && instanceof_function(Z_OBJCE_P(divisor), php_scylladb_tinyint_ce ))
     {
-        php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
-        php_scylladb_numeric *tinyint = PHP_SCYLLADB_GET_NUMERIC(divisor);
+        auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+        auto tinyint = PHP_SCYLLADB_GET_NUMERIC(divisor);
 
         object_init_ex(return_value, php_scylladb_tinyint_ce);
         result = PHP_SCYLLADB_GET_NUMERIC(return_value);
@@ -311,7 +311,7 @@ ZEND_METHOD(Cassandra_Tinyint, div)
 ZEND_METHOD(Cassandra_Tinyint, mod)
 {
     zval *divisor;
-    php_scylladb_numeric *result = NULL;
+    php_scylladb_numeric *result = nullptr;
 
     // clang-format off
     ZEND_PARSE_PARAMETERS_START(1, 1)
@@ -321,8 +321,8 @@ ZEND_METHOD(Cassandra_Tinyint, mod)
 
     if (Z_TYPE_P(divisor) == IS_OBJECT && instanceof_function(Z_OBJCE_P(divisor), php_scylladb_tinyint_ce ))
     {
-        php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
-        php_scylladb_numeric *tinyint = PHP_SCYLLADB_GET_NUMERIC(divisor);
+        auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+        auto tinyint = PHP_SCYLLADB_GET_NUMERIC(divisor);
 
         object_init_ex(return_value, php_scylladb_tinyint_ce);
         result = PHP_SCYLLADB_GET_NUMERIC(return_value);
@@ -345,8 +345,8 @@ ZEND_METHOD(Cassandra_Tinyint, mod)
 /* {{{ Tinyint::abs() */
 ZEND_METHOD(Cassandra_Tinyint, abs)
 {
-    php_scylladb_numeric *result = NULL;
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+    php_scylladb_numeric *result = nullptr;
+    auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
 
     if (self->data.tinyint.value == INT8_MIN)
     {
@@ -363,8 +363,8 @@ ZEND_METHOD(Cassandra_Tinyint, abs)
 /* {{{ Tinyint::neg() */
 ZEND_METHOD(Cassandra_Tinyint, neg)
 {
-    php_scylladb_numeric *result = NULL;
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+    php_scylladb_numeric *result = nullptr;
+    auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
 
     if (self->data.tinyint.value == INT8_MIN)
     {
@@ -381,8 +381,8 @@ ZEND_METHOD(Cassandra_Tinyint, neg)
 /* {{{ Tinyint::sqrt() */
 ZEND_METHOD(Cassandra_Tinyint, sqrt)
 {
-    php_scylladb_numeric *result = NULL;
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+    php_scylladb_numeric *result = nullptr;
+    auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
 
     if (self->data.tinyint.value < 0)
     {
@@ -400,7 +400,7 @@ ZEND_METHOD(Cassandra_Tinyint, sqrt)
 /* {{{ Tinyint::toInt() */
 ZEND_METHOD(Cassandra_Tinyint, toInt)
 {
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+    auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
 
     to_long(return_value, self );
 }
@@ -409,7 +409,7 @@ ZEND_METHOD(Cassandra_Tinyint, toInt)
 /* {{{ Tinyint::toDouble() */
 ZEND_METHOD(Cassandra_Tinyint, toDouble)
 {
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+    auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
 
     to_double(return_value, self );
 }
@@ -418,7 +418,7 @@ ZEND_METHOD(Cassandra_Tinyint, toDouble)
 /* {{{ Tinyint::min() */
 ZEND_METHOD(Cassandra_Tinyint, min)
 {
-    php_scylladb_numeric *tinyint = NULL;
+    php_scylladb_numeric *tinyint = nullptr;
     object_init_ex(return_value, php_scylladb_tinyint_ce);
     tinyint = PHP_SCYLLADB_GET_NUMERIC(return_value);
     tinyint->data.tinyint.value = INT8_MIN;
@@ -428,7 +428,7 @@ ZEND_METHOD(Cassandra_Tinyint, min)
 /* {{{ Tinyint::max() */
 ZEND_METHOD(Cassandra_Tinyint, max)
 {
-    php_scylladb_numeric *tinyint = NULL;
+    php_scylladb_numeric *tinyint = nullptr;
     object_init_ex(return_value, php_scylladb_tinyint_ce);
     tinyint = PHP_SCYLLADB_GET_NUMERIC(return_value);
     tinyint->data.tinyint.value = INT8_MAX;
@@ -445,9 +445,9 @@ HashTable *php_scylladb_tinyint_gc(
 #endif
     zval** table, int *n )
 {
-    *table = NULL;
+    *table = nullptr;
     *n = 0;
-    return NULL;
+    return nullptr;
 }
 
 HashTable *php_scylladb_tinyint_properties(
@@ -462,9 +462,9 @@ HashTable *php_scylladb_tinyint_properties(
     zval value;
 
 #if PHP_MAJOR_VERSION >= 8
-    php_scylladb_numeric *self = php_scylladb_numeric_object_fetch(object);
+    auto self = php_scylladb_numeric_object_fetch(object);
 #else
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(object);
+    auto self = PHP_SCYLLADB_GET_NUMERIC(object);
 #endif
     if (object->properties) {
         zend_array_release(object->properties);
@@ -487,8 +487,8 @@ int php_scylladb_tinyint_compare(zval *obj1, zval *obj2 )
 #if PHP_MAJOR_VERSION >= 8
     ZEND_COMPARE_OBJECTS_FALLBACK(obj1, obj2);
 #endif
-    php_scylladb_numeric *tinyint1 = NULL;
-    php_scylladb_numeric *tinyint2 = NULL;
+    php_scylladb_numeric *tinyint1 = nullptr;
+    php_scylladb_numeric *tinyint2 = nullptr;
 
     if (Z_OBJCE_P(obj1) != Z_OBJCE_P(obj2))
         return strcmp(ZSTR_VAL(Z_OBJCE_P(obj1)->name), ZSTR_VAL(Z_OBJCE_P(obj2)->name)); /* different classes */
@@ -506,16 +506,16 @@ int php_scylladb_tinyint_compare(zval *obj1, zval *obj2 )
 
 unsigned php_scylladb_tinyint_hash_value(zval *obj )
 {
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(obj);
+    auto self = PHP_SCYLLADB_GET_NUMERIC(obj);
     return 31 * 17 + self->data.tinyint.value;
 }
 
 zend_result php_scylladb_tinyint_cast(zend_object *object, zval *retval, int type )
 {
 #if PHP_MAJOR_VERSION >= 8
-    php_scylladb_numeric *self = php_scylladb_numeric_object_fetch(object);
+    auto self = php_scylladb_numeric_object_fetch(object);
 #else
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(object);
+    auto self = PHP_SCYLLADB_GET_NUMERIC(object);
 #endif
 
     switch (type)
@@ -535,7 +535,7 @@ zend_result php_scylladb_tinyint_cast(zend_object *object, zval *retval, int typ
 
 void php_scylladb_tinyint_free(zend_object *object )
 {
-    php_scylladb_numeric *self = php_scylladb_numeric_object_fetch(object);
+    auto self = php_scylladb_numeric_object_fetch(object);
 
     zend_object_std_dtor(&self->zendObject);
 
@@ -543,18 +543,15 @@ void php_scylladb_tinyint_free(zend_object *object )
 
 zend_object* php_scylladb_tinyint_new(zend_class_entry *ce )
 {
-    php_scylladb_numeric *self = (php_scylladb_numeric *)ecalloc(1, sizeof(php_scylladb_numeric) + zend_object_properties_size(ce));
+    php_scylladb_numeric *self =
+        PHP_SCYLLADB_OBJ_ALLOCATE(php_scylladb_numeric, ce, &php_scylladb_tinyint_handlers);
 
     self->type = PHP_SCYLLADB_TINYINT;
-
-    zend_object_std_init(&self->zendObject, ce);
-    self->zendObject.handlers = (zend_object_handlers *)&php_scylladb_tinyint_handlers;
     return &self->zendObject;
 }
 
 
-void php_scylladb_tinyint_post_register(zend_class_entry *ce)
+void php_scylladb_tinyint_post_register([[maybe_unused]] zend_class_entry *ce)
 {
-    (void)ce;
     php_scylladb_tinyint_handlers.std.offset = XtOffsetOf(php_scylladb_numeric, zendObject);
 }

--- a/src/Numbers/Varint.c
+++ b/src/Numbers/Varint.c
@@ -109,7 +109,7 @@ void php_scylladb_varint_init(INTERNAL_FUNCTION_PARAMETERS)
     }
     else if (Z_TYPE_P(num) == IS_OBJECT && instanceof_function(Z_OBJCE_P(num), php_scylladb_varint_ce ))
     {
-        php_scylladb_numeric *varint = PHP_SCYLLADB_GET_NUMERIC(num);
+        auto varint = PHP_SCYLLADB_GET_NUMERIC(num);
         mpz_set(self->data.varint.value, varint->data.varint.value);
     }
     else
@@ -127,7 +127,7 @@ ZEND_METHOD(Cassandra_Varint, __construct)
 /* {{{ Varint::__toString() */
 ZEND_METHOD(Cassandra_Varint, __toString)
 {
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+    auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
 
     to_string(return_value, self );
 }
@@ -144,7 +144,7 @@ ZEND_METHOD(Cassandra_Varint, type)
 /* {{{ Varint::value() */
 ZEND_METHOD(Cassandra_Varint, value)
 {
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+    auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
 
     char *string;
     int string_len;
@@ -159,7 +159,7 @@ ZEND_METHOD(Cassandra_Varint, value)
 ZEND_METHOD(Cassandra_Varint, add)
 {
     zval *num;
-    php_scylladb_numeric *result = NULL;
+    php_scylladb_numeric *result = nullptr;
 
     // clang-format off
     ZEND_PARSE_PARAMETERS_START(1, 1)
@@ -169,8 +169,8 @@ ZEND_METHOD(Cassandra_Varint, add)
 
     if (Z_TYPE_P(num) == IS_OBJECT && instanceof_function(Z_OBJCE_P(num), php_scylladb_varint_ce ))
     {
-        php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
-        php_scylladb_numeric *varint = PHP_SCYLLADB_GET_NUMERIC(num);
+        auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+        auto varint = PHP_SCYLLADB_GET_NUMERIC(num);
 
         object_init_ex(return_value, php_scylladb_varint_ce);
         result = PHP_SCYLLADB_GET_NUMERIC(return_value);
@@ -188,7 +188,7 @@ ZEND_METHOD(Cassandra_Varint, add)
 ZEND_METHOD(Cassandra_Varint, sub)
 {
     zval *num;
-    php_scylladb_numeric *result = NULL;
+    php_scylladb_numeric *result = nullptr;
 
     // clang-format off
     ZEND_PARSE_PARAMETERS_START(1, 1)
@@ -198,8 +198,8 @@ ZEND_METHOD(Cassandra_Varint, sub)
 
     if (Z_TYPE_P(num) == IS_OBJECT && instanceof_function(Z_OBJCE_P(num), php_scylladb_varint_ce ))
     {
-        php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
-        php_scylladb_numeric *varint = PHP_SCYLLADB_GET_NUMERIC(num);
+        auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+        auto varint = PHP_SCYLLADB_GET_NUMERIC(num);
 
         object_init_ex(return_value, php_scylladb_varint_ce);
         result = PHP_SCYLLADB_GET_NUMERIC(return_value);
@@ -217,7 +217,7 @@ ZEND_METHOD(Cassandra_Varint, sub)
 ZEND_METHOD(Cassandra_Varint, mul)
 {
     zval *num;
-    php_scylladb_numeric *result = NULL;
+    php_scylladb_numeric *result = nullptr;
 
     // clang-format off
     ZEND_PARSE_PARAMETERS_START(1, 1)
@@ -227,8 +227,8 @@ ZEND_METHOD(Cassandra_Varint, mul)
 
     if (Z_TYPE_P(num) == IS_OBJECT && instanceof_function(Z_OBJCE_P(num), php_scylladb_varint_ce ))
     {
-        php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
-        php_scylladb_numeric *varint = PHP_SCYLLADB_GET_NUMERIC(num);
+        auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+        auto varint = PHP_SCYLLADB_GET_NUMERIC(num);
 
         object_init_ex(return_value, php_scylladb_varint_ce);
         result = PHP_SCYLLADB_GET_NUMERIC(return_value);
@@ -246,7 +246,7 @@ ZEND_METHOD(Cassandra_Varint, mul)
 ZEND_METHOD(Cassandra_Varint, div)
 {
     zval *num;
-    php_scylladb_numeric *result = NULL;
+    php_scylladb_numeric *result = nullptr;
 
     // clang-format off
     ZEND_PARSE_PARAMETERS_START(1, 1)
@@ -256,8 +256,8 @@ ZEND_METHOD(Cassandra_Varint, div)
 
     if (Z_TYPE_P(num) == IS_OBJECT && instanceof_function(Z_OBJCE_P(num), php_scylladb_varint_ce ))
     {
-        php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
-        php_scylladb_numeric *varint = PHP_SCYLLADB_GET_NUMERIC(num);
+        auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+        auto varint = PHP_SCYLLADB_GET_NUMERIC(num);
 
         object_init_ex(return_value, php_scylladb_varint_ce);
         result = PHP_SCYLLADB_GET_NUMERIC(return_value);
@@ -281,7 +281,7 @@ ZEND_METHOD(Cassandra_Varint, div)
 ZEND_METHOD(Cassandra_Varint, mod)
 {
     zval *num;
-    php_scylladb_numeric *result = NULL;
+    php_scylladb_numeric *result = nullptr;
 
     // clang-format off
     ZEND_PARSE_PARAMETERS_START(1, 1)
@@ -291,8 +291,8 @@ ZEND_METHOD(Cassandra_Varint, mod)
 
     if (Z_TYPE_P(num) == IS_OBJECT && instanceof_function(Z_OBJCE_P(num), php_scylladb_varint_ce ))
     {
-        php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
-        php_scylladb_numeric *varint = PHP_SCYLLADB_GET_NUMERIC(num);
+        auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+        auto varint = PHP_SCYLLADB_GET_NUMERIC(num);
 
         object_init_ex(return_value, php_scylladb_varint_ce);
         result = PHP_SCYLLADB_GET_NUMERIC(return_value);
@@ -315,8 +315,8 @@ ZEND_METHOD(Cassandra_Varint, mod)
 /* {{{ Varint::abs() */
 ZEND_METHOD(Cassandra_Varint, abs)
 {
-    php_scylladb_numeric *result = NULL;
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+    php_scylladb_numeric *result = nullptr;
+    auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
 
     object_init_ex(return_value, php_scylladb_varint_ce);
     result = PHP_SCYLLADB_GET_NUMERIC(return_value);
@@ -328,8 +328,8 @@ ZEND_METHOD(Cassandra_Varint, abs)
 /* {{{ Varint::neg() */
 ZEND_METHOD(Cassandra_Varint, neg)
 {
-    php_scylladb_numeric *result = NULL;
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+    php_scylladb_numeric *result = nullptr;
+    auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
 
     object_init_ex(return_value, php_scylladb_varint_ce);
     result = PHP_SCYLLADB_GET_NUMERIC(return_value);
@@ -341,8 +341,8 @@ ZEND_METHOD(Cassandra_Varint, neg)
 /* {{{ Varint::sqrt() */
 ZEND_METHOD(Cassandra_Varint, sqrt)
 {
-    php_scylladb_numeric *result = NULL;
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+    php_scylladb_numeric *result = nullptr;
+    auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
 
     if (mpz_sgn(self->data.varint.value) < 0)
     {
@@ -361,7 +361,7 @@ ZEND_METHOD(Cassandra_Varint, sqrt)
 /* {{{ Varint::toInt() */
 ZEND_METHOD(Cassandra_Varint, toInt)
 {
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+    auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
 
     to_long(return_value, self );
 }
@@ -370,7 +370,7 @@ ZEND_METHOD(Cassandra_Varint, toInt)
 /* {{{ Varint::toDouble() */
 ZEND_METHOD(Cassandra_Varint, toDouble)
 {
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
+    auto self = PHP_SCYLLADB_GET_NUMERIC(ZEND_THIS);
 
     to_double(return_value, self );
 }
@@ -403,9 +403,9 @@ HashTable *php_scylladb_varint_properties(
     zval value;
 
 #if PHP_MAJOR_VERSION >= 8
-    php_scylladb_numeric *self = php_scylladb_numeric_object_fetch(object);
+    auto self = php_scylladb_numeric_object_fetch(object);
 #else
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(object);
+    auto self = PHP_SCYLLADB_GET_NUMERIC(object);
 #endif
     if (object->properties) {
         zend_array_release(object->properties);
@@ -431,8 +431,8 @@ int php_scylladb_varint_compare(zval *obj1, zval *obj2 )
 #if PHP_MAJOR_VERSION >= 8
     ZEND_COMPARE_OBJECTS_FALLBACK(obj1, obj2);
 #endif
-    php_scylladb_numeric *varint1 = NULL;
-    php_scylladb_numeric *varint2 = NULL;
+    php_scylladb_numeric *varint1 = nullptr;
+    php_scylladb_numeric *varint2 = nullptr;
 
     if (Z_OBJCE_P(obj1) != Z_OBJCE_P(obj2))
         return strcmp(ZSTR_VAL(Z_OBJCE_P(obj1)->name), ZSTR_VAL(Z_OBJCE_P(obj2)->name)); /* different classes */
@@ -445,16 +445,16 @@ int php_scylladb_varint_compare(zval *obj1, zval *obj2 )
 
 unsigned php_scylladb_varint_hash_value(zval *obj )
 {
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(obj);
+    auto self = PHP_SCYLLADB_GET_NUMERIC(obj);
     return php_scylladb_mpz_hash(0, self->data.varint.value);
 }
 
 zend_result php_scylladb_varint_cast(zend_object *object, zval *retval, int type )
 {
 #if PHP_MAJOR_VERSION >= 8
-    php_scylladb_numeric *self = php_scylladb_numeric_object_fetch(object);
+    auto self = php_scylladb_numeric_object_fetch(object);
 #else
-    php_scylladb_numeric *self = PHP_SCYLLADB_GET_NUMERIC(object);
+    auto self = PHP_SCYLLADB_GET_NUMERIC(object);
 #endif
 
     switch (type)
@@ -474,7 +474,7 @@ zend_result php_scylladb_varint_cast(zend_object *object, zval *retval, int type
 
 void php_scylladb_varint_free(zend_object *object )
 {
-    php_scylladb_numeric *self = php_scylladb_numeric_object_fetch(object);
+    auto self = php_scylladb_numeric_object_fetch(object);
 
     mpz_clear(self->data.varint.value);
 
@@ -484,18 +484,15 @@ void php_scylladb_varint_free(zend_object *object )
 
 zend_object* php_scylladb_varint_new(zend_class_entry *ce )
 {
-    php_scylladb_numeric *self = (php_scylladb_numeric *)ecalloc(1, sizeof(php_scylladb_numeric) + zend_object_properties_size(ce));
+    php_scylladb_numeric *self =
+        PHP_SCYLLADB_OBJ_ALLOCATE(php_scylladb_numeric, ce, &php_scylladb_varint_handlers);
 
     mpz_init(self->data.varint.value);
-
-    zend_object_std_init(&self->zendObject, ce);
-    self->zendObject.handlers = (zend_object_handlers *)&php_scylladb_varint_handlers;
     return &self->zendObject;
 }
 
 
-void php_scylladb_varint_post_register(zend_class_entry *ce)
+void php_scylladb_varint_post_register([[maybe_unused]] zend_class_entry *ce)
 {
-    (void)ce;
     php_scylladb_varint_handlers.std.offset = XtOffsetOf(php_scylladb_numeric, zendObject);
 }

--- a/src/PreparedStatement.c
+++ b/src/PreparedStatement.c
@@ -46,7 +46,7 @@ php_scylladb_prepared_statement_compare(zval *obj1, zval *obj2)
 void
 php_scylladb_prepared_statement_free(zend_object *object)
 {
-  php_scylladb_statement *self = php_scylladb_statement_object_fetch(object);
+  auto self = php_scylladb_statement_object_fetch(object);
 
   if (self->data.prepared.prepared)
     cass_prepared_free(self->data.prepared.prepared);
@@ -59,12 +59,9 @@ zend_object*
 php_scylladb_prepared_statement_new(zend_class_entry *ce)
 {
   php_scylladb_statement *self =
-      (php_scylladb_statement *)ecalloc(1, sizeof(php_scylladb_statement) + zend_object_properties_size(ce));
+      PHP_SCYLLADB_OBJ_ALLOCATE(php_scylladb_statement, ce, &php_scylladb_prepared_statement_handlers);
 
   self->type = PHP_SCYLLADB_PREPARED_STATEMENT;
-  self->data.prepared.prepared = NULL;
-
-  zend_object_std_init(&self->zendObject, ce);
-  self->zendObject.handlers = &php_scylladb_prepared_statement_handlers;
+  self->data.prepared.prepared = nullptr;
   return &self->zendObject;
 }

--- a/src/PreparedStatement.stub.php
+++ b/src/PreparedStatement.stub.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 namespace Cassandra {
     /**
      * @strict-properties
+     * @not-serializable
  * @scylladb-struct php_scylladb_statement
  */    final class PreparedStatement implements Statement {
         private function __construct() {}

--- a/src/Registry/Registry.c
+++ b/src/Registry/Registry.c
@@ -101,7 +101,7 @@ void php_scylladb_class_registry_minit(void) {
             zend_class_entry *ce = d->register_(n_deps > 0 ? resolved : nullptr);
             if (ce == nullptr) {
                 zend_error_noreturn(E_CORE_ERROR,
-                    "scylladb registry: register_ for '%s' returned NULL", d->name);
+                    "scylladb registry: register_ for '%s' returned nullptr", d->name);
             }
             *(d->ce_out)  = ce;
             d->registered = true;

--- a/src/Registry/Registry.h
+++ b/src/Registry/Registry.h
@@ -19,30 +19,25 @@
  * MINIT with a clear message naming the culprit.
  */
 
-#include <stdbool.h>
-
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include <Zend/zend_API.h>
 
 /* Register callback. `deps` is a parallel array to the descriptor's `deps`
  * field, with each FQN resolved to its zend_class_entry*. Length = however
  * many strings were declared (no terminator slot exposed). When the
- * descriptor was declared with no deps, `deps` may be NULL. */
+ * descriptor was declared with no deps, `deps` may be nullptr. */
 typedef zend_class_entry *(*php_scylladb_class_register_fn)(zend_class_entry *const *deps);
 
 typedef struct php_scylladb_class_descriptor {
     const char                          *name;        /* FQN, e.g. "Cassandra\\RetryPolicy\\DefaultPolicy" */
-    const char *const                   *deps;        /* NULL-terminated FQN array, or NULL for no deps */
+    const char *const                   *deps;        /* nullptr-terminated FQN array, or nullptr for no deps */
     zend_class_entry                   **ce_out;      /* where to publish the resolved ce */
     php_scylladb_class_register_fn       register_;
     struct php_scylladb_class_descriptor *next;       /* internals */
     bool                                 registered;
 } php_scylladb_class_descriptor_t;
 
-void php_scylladb_class_registry_add(php_scylladb_class_descriptor_t *d);
+[[gnu::nonnull(1)]] void php_scylladb_class_registry_add(php_scylladb_class_descriptor_t *d);
 void php_scylladb_class_registry_minit(void);
 
 /*
@@ -51,7 +46,7 @@ void php_scylladb_class_registry_minit(void);
  *   slug         — unique C identifier suffix
  *   _name        — FQN string literal
  *   _ce_out      — &php_scylladb_*_ce
- *   _parent      — FQN string literal, or NULL/nullptr for no parent
+ *   _parent      — FQN string literal, or nullptr/nullptr for no parent
  *   _register_fn — zend_class_entry *(*)(zend_class_entry *const *deps).
  *                  For zero-parent it can ignore deps; for single-parent
  *                  read deps[0].
@@ -73,7 +68,7 @@ void php_scylladb_class_registry_minit(void);
 
 /*
  * Declare a class with N (>=1) dependencies. `_deps_array` must be a
- * NULL-terminated `static const char *const xxx[]` defined in the same file.
+ * nullptr-terminated `static const char *const xxx[]` defined in the same file.
  * register_fn reads deps[0], deps[1], … in the same order.
  *
  * Use this for classes that extend one class AND implement an interface, or
@@ -92,7 +87,3 @@ void php_scylladb_class_registry_minit(void);
     static void scylladb_cls_register_##slug##_ctor(void) {                     \
         php_scylladb_class_registry_add(&scylladb_cls_##slug);                  \
     }
-
-#ifdef __cplusplus
-} /* extern "C" */
-#endif

--- a/src/RetryPolicy/DefaultPolicy.stub.php
+++ b/src/RetryPolicy/DefaultPolicy.stub.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Cassandra\RetryPolicy {
     /**
      * @strict-properties
+     * @not-serializable
  * @scylladb-struct php_scylladb_retry_policy
  */    final class DefaultPolicy implements \Cassandra\RetryPolicy { }
 }

--- a/src/RetryPolicy/DowngradingConsistency.stub.php
+++ b/src/RetryPolicy/DowngradingConsistency.stub.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Cassandra\RetryPolicy {
     /**
      * @strict-properties
+     * @not-serializable
      * @deprecated
      *
      * This still works, but should not be used in new applications.

--- a/src/RetryPolicy/Fallthrough.stub.php
+++ b/src/RetryPolicy/Fallthrough.stub.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Cassandra\RetryPolicy {
     /**
      * @strict-properties
+     * @not-serializable
  * @scylladb-struct php_scylladb_retry_policy
  */    final class Fallthrough implements \Cassandra\RetryPolicy { }
 }

--- a/src/RetryPolicy/Logging.stub.php
+++ b/src/RetryPolicy/Logging.stub.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Cassandra\RetryPolicy {
     /**
      * @strict-properties
+     * @not-serializable
  * @scylladb-struct php_scylladb_retry_policy
  */    final class Logging implements \Cassandra\RetryPolicy
     {

--- a/src/SSLOptions/Builder.c
+++ b/src/SSLOptions/Builder.c
@@ -24,7 +24,7 @@
 
 static zend_result file_get_contents(const zend_string *path, zend_string** out_val) {
   php_stream *stream =
-      php_stream_open_wrapper(ZSTR_VAL(path), "rb", USE_PATH | REPORT_ERRORS, NULL);
+      php_stream_open_wrapper(ZSTR_VAL(path), "rb", USE_PATH | REPORT_ERRORS, nullptr);
   if (!stream) {
     zend_throw_exception_ex(php_scylladb_runtime_exception_ce, 0,
                             "The path '%s' doesn't exist or is not readable", ZSTR_VAL(path));
@@ -144,7 +144,7 @@ ZEND_METHOD(Cassandra_SSLOptions_Builder, withTrustedCerts) {
     certs[i] = zend_string_copy(Z_STR_P(path));
   }
 
-  php_scylladb_ssl_builder *builder = Z_SCYLLADB_SSL_BUILDER_P(ZEND_THIS);
+  auto builder = Z_SCYLLADB_SSL_BUILDER_P(ZEND_THIS);
 
   if (builder->trusted_certs) {
     for (size_t i = 0; i < builder->trusted_certs_cnt; i++) {
@@ -193,7 +193,7 @@ ZEND_METHOD(Cassandra_SSLOptions_Builder, withClientCert) {
     return;
   }
 
-  php_scylladb_ssl_builder *builder = Z_SCYLLADB_SSL_BUILDER_P(ZEND_THIS);
+  auto builder = Z_SCYLLADB_SSL_BUILDER_P(ZEND_THIS);
 
   if (builder->client_cert) {
     zend_string_release(builder->client_cert);

--- a/src/SSLOptions/Builder.stub.php
+++ b/src/SSLOptions/Builder.stub.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Cassandra\SSLOptions {
     /**
      * @strict-properties
+     * @not-serializable
  * @scylladb-struct php_scylladb_ssl_builder
  */     final class Builder {
         public function withTrustedCerts(string ...$path): static {}

--- a/src/SSLOptions/SSLOptions.c
+++ b/src/SSLOptions/SSLOptions.c
@@ -47,8 +47,7 @@ zend_object *php_scylladb_ssl_options_new(zend_class_entry *ce) {
   return &self->zendObject;
 }
 
-void php_scylladb_ssl_options_post_register(zend_class_entry *ce) {
-  (void)ce;
+void php_scylladb_ssl_options_post_register([[maybe_unused]] zend_class_entry *ce) {
   php_scylladb_ssl_options_handlers.clone_obj = nullptr;
 }
 
@@ -59,6 +58,6 @@ PHP_SCYLLADB_API php_scylladb_ssl *php_scylladb_ssl_instantiate(zval *object) {
   }
 
   ZVAL_OBJ(object, Z_OBJ(val));
-  php_scylladb_ssl *ssl = Z_SCYLLADB_SSL_P(object);
+  auto ssl = Z_SCYLLADB_SSL_P(object);
   return ssl;
 }

--- a/src/SSLOptions/SSLOptions.stub.php
+++ b/src/SSLOptions/SSLOptions.stub.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Cassandra {
     /**
      * @strict-properties
+     * @not-serializable
  * @scylladb-struct php_scylladb_ssl
  */     final class SSLOptions {
      }

--- a/src/Set.c
+++ b/src/Set.c
@@ -46,7 +46,7 @@ php_scylladb_set_add(php_scylladb_set* set, zval* object)
   }
 
   HASH_FIND_ZVAL(set->entries, object, entry);
-  if (entry == NULL) {
+  if (entry == nullptr) {
     set->dirty = 1;
     entry      = (php_scylladb_set_entry*) emalloc(sizeof(php_scylladb_set_entry));
     ZVAL_COPY(&entry->value, object);
@@ -70,7 +70,7 @@ php_scylladb_set_del(php_scylladb_set* set, zval* object)
   }
 
   HASH_FIND_ZVAL(set->entries, object, entry);
-  if (entry != NULL) {
+  if (entry != nullptr) {
     set->dirty = 1;
     if (entry == set->iter_temp) {
       set->iter_temp = (php_scylladb_set_entry*) set->iter_temp->hh.next;
@@ -98,7 +98,7 @@ php_scylladb_set_has(php_scylladb_set* set, zval* object)
   }
 
   HASH_FIND_ZVAL(set->entries, object, entry);
-  if (entry != NULL) {
+  if (entry != nullptr) {
     result = 1;
   }
 
@@ -150,7 +150,7 @@ PHP_METHOD(Cassandra_Set, __construct)
 /* {{{ Set::type() */
 PHP_METHOD(Cassandra_Set, type)
 {
-  php_scylladb_set* self = PHP_SCYLLADB_GET_SET(getThis());
+  auto self = PHP_SCYLLADB_GET_SET(getThis());
   RETURN_ZVAL(&self->type, 1, 0);
 }
 /* }}} */
@@ -158,7 +158,7 @@ PHP_METHOD(Cassandra_Set, type)
 /* {{{ Set::values() */
 PHP_METHOD(Cassandra_Set, values)
 {
-  php_scylladb_set* set = NULL;
+  php_scylladb_set* set = nullptr;
   array_init(return_value);
   set = PHP_SCYLLADB_GET_SET(getThis());
   php_scylladb_set_populate(set, return_value );
@@ -168,7 +168,7 @@ PHP_METHOD(Cassandra_Set, values)
 /* {{{ Set::add(value) */
 PHP_METHOD(Cassandra_Set, add)
 {
-  php_scylladb_set* self = NULL;
+  php_scylladb_set* self = nullptr;
 
   zval* object;
   ZEND_PARSE_PARAMETERS_START(1, 1)
@@ -187,7 +187,7 @@ PHP_METHOD(Cassandra_Set, add)
 /* {{{ Set::remove(value) */
 PHP_METHOD(Cassandra_Set, remove)
 {
-  php_scylladb_set* self = NULL;
+  php_scylladb_set* self = nullptr;
 
   zval* object;
   ZEND_PARSE_PARAMETERS_START(1, 1)
@@ -206,7 +206,7 @@ PHP_METHOD(Cassandra_Set, remove)
 /* {{{ Set::has(value) */
 PHP_METHOD(Cassandra_Set, has)
 {
-  php_scylladb_set* self = NULL;
+  php_scylladb_set* self = nullptr;
 
   zval* object;
   ZEND_PARSE_PARAMETERS_START(1, 1)
@@ -225,7 +225,7 @@ PHP_METHOD(Cassandra_Set, has)
 /* {{{ Set::count() */
 PHP_METHOD(Cassandra_Set, count)
 {
-  php_scylladb_set* self = PHP_SCYLLADB_GET_SET(getThis());
+  auto self = PHP_SCYLLADB_GET_SET(getThis());
   RETURN_LONG((long) HASH_COUNT(self->entries));
 }
 /* }}} */
@@ -233,8 +233,8 @@ PHP_METHOD(Cassandra_Set, count)
 /* {{{ Set::current() */
 PHP_METHOD(Cassandra_Set, current)
 {
-  php_scylladb_set* self = PHP_SCYLLADB_GET_SET(getThis());
-  if (self->iter_curr != NULL)
+  auto self = PHP_SCYLLADB_GET_SET(getThis());
+  if (self->iter_curr != nullptr)
     RETURN_ZVAL(&self->iter_curr->value, 1, 0);
 }
 /* }}} */
@@ -242,7 +242,7 @@ PHP_METHOD(Cassandra_Set, current)
 /* {{{ Set::key() */
 PHP_METHOD(Cassandra_Set, key)
 {
-  php_scylladb_set* self = PHP_SCYLLADB_GET_SET(getThis());
+  auto self = PHP_SCYLLADB_GET_SET(getThis());
   RETURN_LONG(self->iter_index);
 }
 /* }}} */
@@ -250,9 +250,9 @@ PHP_METHOD(Cassandra_Set, key)
 /* {{{ Set::next() */
 PHP_METHOD(Cassandra_Set, next)
 {
-  php_scylladb_set* self = PHP_SCYLLADB_GET_SET(getThis());
+  auto self = PHP_SCYLLADB_GET_SET(getThis());
   self->iter_curr      = self->iter_temp;
-  self->iter_temp      = self->iter_temp != NULL ? (php_scylladb_set_entry*) self->iter_temp->hh.next : NULL;
+  self->iter_temp      = self->iter_temp != nullptr ? (php_scylladb_set_entry*) self->iter_temp->hh.next : nullptr;
   self->iter_index++;
 }
 /* }}} */
@@ -260,17 +260,17 @@ PHP_METHOD(Cassandra_Set, next)
 /* {{{ Set::valid() */
 PHP_METHOD(Cassandra_Set, valid)
 {
-  php_scylladb_set* self = PHP_SCYLLADB_GET_SET(getThis());
-  RETURN_BOOL(self->iter_curr != NULL);
+  auto self = PHP_SCYLLADB_GET_SET(getThis());
+  RETURN_BOOL(self->iter_curr != nullptr);
 }
 /* }}} */
 
 /* {{{ Set::rewind() */
 PHP_METHOD(Cassandra_Set, rewind)
 {
-  php_scylladb_set* self = PHP_SCYLLADB_GET_SET(getThis());
+  auto self = PHP_SCYLLADB_GET_SET(getThis());
   self->iter_curr      = self->entries;
-  self->iter_temp      = self->entries != NULL ? (php_scylladb_set_entry*) self->entries->hh.next : NULL;
+  self->iter_temp      = self->entries != nullptr ? (php_scylladb_set_entry*) self->entries->hh.next : nullptr;
   self->iter_index     = 0;
 }
 /* }}} */
@@ -288,7 +288,7 @@ php_scylladb_set_properties(zend_object* object)
 {
   zval values;
 
-  php_scylladb_set* self = php_scylladb_set_object_fetch(object);
+  auto self = php_scylladb_set_object_fetch(object);
   if (object->properties) {
     zend_array_release(object->properties);
   }
@@ -339,7 +339,7 @@ php_scylladb_set_compare(zval* obj1, zval* obj2)
   {
     php_scylladb_set_entry* entry;
     HASH_FIND_ZVAL(set2->entries, &curr->value, entry);
-    if (entry == NULL) {
+    if (entry == nullptr) {
       return 1;
     }
   }
@@ -352,7 +352,7 @@ php_scylladb_set_hash_value(zval* obj)
 {
   unsigned hashv = 0;
   php_scylladb_set_entry *curr, *temp;
-  php_scylladb_set* self = PHP_SCYLLADB_GET_SET(obj);
+  auto self = PHP_SCYLLADB_GET_SET(obj);
 
   if (!self->dirty)
     return self->hashv;
@@ -371,7 +371,7 @@ php_scylladb_set_hash_value(zval* obj)
 void
 php_scylladb_set_free(zend_object* object)
 {
-  php_scylladb_set* self = php_scylladb_set_object_fetch(object);
+  auto self = php_scylladb_set_object_fetch(object);
   php_scylladb_set_entry *curr, *temp;
 
   HASH_ITER(hh, self->entries, curr, temp)
@@ -391,22 +391,19 @@ zend_object*
 php_scylladb_set_new(zend_class_entry* ce)
 {
   php_scylladb_set* self =
-    (php_scylladb_set *)ecalloc(1, sizeof(php_scylladb_set) + zend_object_properties_size(ce));
+    PHP_SCYLLADB_OBJ_ALLOCATE(php_scylladb_set, ce, &php_scylladb_set_handlers);
 
-  self->entries = self->iter_curr = self->iter_temp = NULL;
+  self->entries = self->iter_curr = self->iter_temp = nullptr;
   self->iter_index                                  = 0;
   self->dirty                                       = 1;
   ZVAL_UNDEF(&self->type);
 
-  zend_object_std_init(&self->zendObject, ce);
   php_scylladb_set_handlers.std.offset = XtOffsetOf(php_scylladb_set, zendObject);
   php_scylladb_set_handlers.std.free_obj = php_scylladb_set_free;
-  self->zendObject.handlers = (zend_object_handlers *)&php_scylladb_set_handlers;
   return &self->zendObject;
 }
 
-void php_scylladb_set_post_register(zend_class_entry *ce)
+void php_scylladb_set_post_register([[maybe_unused]] zend_class_entry *ce)
 {
-    (void)ce;
     php_scylladb_set_handlers.std.offset = XtOffsetOf(php_scylladb_set, zendObject);
 }

--- a/src/Set.h
+++ b/src/Set.h
@@ -19,5 +19,5 @@
 #include <php.h>
 #include <php_scylladb_types.h>
 BEGIN_EXTERN_C()
-int php_scylladb_set_add(php_scylladb_set *set, zval *object);
+[[gnu::nonnull(1, 2)]] int php_scylladb_set_add(php_scylladb_set *set, zval *object);
 END_EXTERN_C()

--- a/src/SimpleStatement.c
+++ b/src/SimpleStatement.c
@@ -23,8 +23,8 @@ extern zend_object_handlers php_scylladb_simple_statement_handlers;
 
 ZEND_METHOD(Cassandra_SimpleStatement, __construct)
 {
-  zend_string *cql = NULL;
-  php_scylladb_statement *self = NULL;
+  zend_string *cql = nullptr;
+  php_scylladb_statement *self = nullptr;
 
   ZEND_PARSE_PARAMETERS_START(1, 1)
     Z_PARAM_STR(cql)
@@ -56,11 +56,11 @@ php_scylladb_simple_statement_compare(zval *obj1, zval *obj2)
 void
 php_scylladb_simple_statement_free(zend_object *object)
 {
-  php_scylladb_statement *self = php_scylladb_statement_object_fetch(object);
+  auto self = php_scylladb_statement_object_fetch(object);
 
   if (self->data.simple.cql) {
     efree(self->data.simple.cql);
-    self->data.simple.cql = NULL;
+    self->data.simple.cql = nullptr;
   }
 
   zend_object_std_dtor(&self->zendObject);
@@ -71,12 +71,9 @@ zend_object*
 php_scylladb_simple_statement_new(zend_class_entry *ce)
 {
   php_scylladb_statement *self =
-      (php_scylladb_statement *)ecalloc(1, sizeof(php_scylladb_statement) + zend_object_properties_size(ce));
+      PHP_SCYLLADB_OBJ_ALLOCATE(php_scylladb_statement, ce, &php_scylladb_simple_statement_handlers);
 
   self->type = PHP_SCYLLADB_SIMPLE_STATEMENT;
-  self->data.simple.cql  = NULL;
-
-  zend_object_std_init(&self->zendObject, ce);
-  self->zendObject.handlers = &php_scylladb_simple_statement_handlers;
+  self->data.simple.cql  = nullptr;
   return &self->zendObject;
 }

--- a/src/SimpleStatement.stub.php
+++ b/src/SimpleStatement.stub.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 namespace Cassandra {
     /**
      * @strict-properties
+     * @not-serializable
  * @scylladb-struct php_scylladb_statement
  */    final class SimpleStatement implements Statement {
         public function __construct(string $cql) {}

--- a/src/TimestampGenerator/Monotonic.c
+++ b/src/TimestampGenerator/Monotonic.c
@@ -24,7 +24,7 @@ extern zend_object_handlers php_scylladb_timestamp_generator_monotonic_handlers;
 void
 php_scylladb_timestamp_generator_monotonic_free(zend_object *object)
 {
-    php_scylladb_timestamp_gen *self = php_scylladb_timestamp_gen_object_fetch(object);
+    auto self = php_scylladb_timestamp_gen_object_fetch(object);
 
     cass_timestamp_gen_free(self->gen);
 
@@ -35,18 +35,15 @@ zend_object *
 php_scylladb_timestamp_generator_monotonic_new(zend_class_entry *ce)
 {
     php_scylladb_timestamp_gen *self =
-        (php_scylladb_timestamp_gen *)ecalloc(1, sizeof(php_scylladb_timestamp_gen) + zend_object_properties_size(ce));
+        PHP_SCYLLADB_OBJ_ALLOCATE(php_scylladb_timestamp_gen, ce,
+                                  &php_scylladb_timestamp_generator_monotonic_handlers);
 
     self->gen = cass_timestamp_gen_monotonic_new();
-
-    zend_object_std_init(&self->zendObject, ce);
-    self->zendObject.handlers = &php_scylladb_timestamp_generator_monotonic_handlers;
 
     return &self->zendObject;
 }
 
-void php_scylladb_timestamp_generator_monotonic_post_register(zend_class_entry *ce)
+void php_scylladb_timestamp_generator_monotonic_post_register([[maybe_unused]] zend_class_entry *ce)
 {
-    (void)ce;
     php_scylladb_timestamp_generator_monotonic_handlers.offset = XtOffsetOf(php_scylladb_timestamp_gen, zendObject);
 }

--- a/src/TimestampGenerator/Monotonic.stub.php
+++ b/src/TimestampGenerator/Monotonic.stub.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 namespace Cassandra\TimestampGenerator {
     /**
      * @strict-properties
+     * @not-serializable
  * @scylladb-struct php_scylladb_timestamp_gen
  */    final class Monotonic implements \Cassandra\TimestampGenerator {}
 }

--- a/src/TimestampGenerator/ServerSide.c
+++ b/src/TimestampGenerator/ServerSide.c
@@ -24,7 +24,7 @@ extern zend_object_handlers php_scylladb_timestamp_generator_server_side_handler
 void
 php_scylladb_timestamp_generator_server_side_free(zend_object *object)
 {
-    php_scylladb_timestamp_gen *self = php_scylladb_timestamp_gen_object_fetch(object);
+    auto self = php_scylladb_timestamp_gen_object_fetch(object);
 
     cass_timestamp_gen_free(self->gen);
 
@@ -35,18 +35,15 @@ zend_object *
 php_scylladb_timestamp_generator_server_side_new(zend_class_entry *ce)
 {
     php_scylladb_timestamp_gen *self =
-        (php_scylladb_timestamp_gen *)ecalloc(1, sizeof(php_scylladb_timestamp_gen) + zend_object_properties_size(ce));
+        PHP_SCYLLADB_OBJ_ALLOCATE(php_scylladb_timestamp_gen, ce,
+                                  &php_scylladb_timestamp_generator_server_side_handlers);
 
     self->gen = cass_timestamp_gen_server_side_new();
-
-    zend_object_std_init(&self->zendObject, ce);
-    self->zendObject.handlers = &php_scylladb_timestamp_generator_server_side_handlers;
 
     return &self->zendObject;
 }
 
-void php_scylladb_timestamp_generator_server_side_post_register(zend_class_entry *ce)
+void php_scylladb_timestamp_generator_server_side_post_register([[maybe_unused]] zend_class_entry *ce)
 {
-    (void)ce;
     php_scylladb_timestamp_generator_server_side_handlers.offset = XtOffsetOf(php_scylladb_timestamp_gen, zendObject);
 }

--- a/src/TimestampGenerator/ServerSide.stub.php
+++ b/src/TimestampGenerator/ServerSide.stub.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 namespace Cassandra\TimestampGenerator {
     /**
      * @strict-properties
+     * @not-serializable
  * @scylladb-struct php_scylladb_timestamp_gen
  */    final class ServerSide implements \Cassandra\TimestampGenerator {}
 }

--- a/src/Tuple.c
+++ b/src/Tuple.c
@@ -29,7 +29,7 @@
 extern php_scylladb_value_handlers php_scylladb_tuple_handlers;
 
 void
-php_scylladb_tuple_set(php_scylladb_tuple *tuple, ulong index, zval *object)
+php_scylladb_tuple_set(php_scylladb_tuple *tuple, zend_ulong index, zval *object)
 {
   (void)zend_hash_index_update(&tuple->values, index, object);
   Z_TRY_ADDREF_P(object);
@@ -41,7 +41,6 @@ php_scylladb_tuple_populate(php_scylladb_tuple *tuple, zval *array)
 {
   zend_ulong index;
   php_scylladb_type *type;
-  zval *current;
   zval null;
 
 
@@ -49,10 +48,9 @@ php_scylladb_tuple_populate(php_scylladb_tuple *tuple, zval *array)
 
   type = PHP_SCYLLADB_GET_TYPE(&tuple->type);
 
-  ZEND_HASH_FOREACH_NUM_KEY_VAL(&type->data.tuple.types, index, current) {
-    zval *value = NULL;
-    (void) current;
-    if ((value = zend_hash_index_find(&tuple->values, (zend_ulong)(index))) != NULL) {
+  ZEND_HASH_FOREACH_NUM_KEY(&type->data.tuple.types, index) {
+    zval *value = nullptr;
+    if ((value = zend_hash_index_find(&tuple->values, (zend_ulong)(index))) != nullptr) {
       if (add_next_index_zval(array, value) == SUCCESS)
         Z_TRY_ADDREF_P(value);
       else
@@ -118,14 +116,14 @@ ZEND_METHOD(Cassandra_Tuple, __construct)
 /* {{{ Tuple::type() */
 ZEND_METHOD(Cassandra_Tuple, type)
 {
-  php_scylladb_tuple *self = PHP_SCYLLADB_GET_TUPLE(getThis());
+  auto self = PHP_SCYLLADB_GET_TUPLE(getThis());
   RETURN_ZVAL(&self->type, 1, 0);
 }
 
 /* {{{ Tuple::values() */
 ZEND_METHOD(Cassandra_Tuple, values)
 {
-  php_scylladb_tuple *self = NULL;
+  php_scylladb_tuple *self = nullptr;
   array_init(return_value);
   self = PHP_SCYLLADB_GET_TUPLE(getThis());
   php_scylladb_tuple_populate(self, return_value );
@@ -135,7 +133,7 @@ ZEND_METHOD(Cassandra_Tuple, values)
 /* {{{ Tuple::set(int, mixed) */
 ZEND_METHOD(Cassandra_Tuple, set)
 {
-  php_scylladb_tuple *self = NULL;
+  php_scylladb_tuple *self = nullptr;
   zend_long index;
   php_scylladb_type *type;
   zval *sub_type;
@@ -155,7 +153,7 @@ ZEND_METHOD(Cassandra_Tuple, set)
     return;
   }
 
-  if ((sub_type = zend_hash_index_find(&type->data.tuple.types, (zend_ulong)(index))) == NULL ||
+  if ((sub_type = zend_hash_index_find(&type->data.tuple.types, (zend_ulong)(index))) == nullptr ||
       !php_scylladb_validate_object(value,
                                   sub_type )) {
     return;
@@ -168,7 +166,7 @@ ZEND_METHOD(Cassandra_Tuple, set)
 /* {{{ Tuple::get(int) */
 ZEND_METHOD(Cassandra_Tuple, get)
 {
-  php_scylladb_tuple *self = NULL;
+  php_scylladb_tuple *self = nullptr;
   zend_long index;
   php_scylladb_type *type;
   zval *value;
@@ -186,7 +184,7 @@ ZEND_METHOD(Cassandra_Tuple, get)
     return;
   }
 
-  if ((value = zend_hash_index_find(&self->values, (zend_ulong)(index))) != NULL) {
+  if ((value = zend_hash_index_find(&self->values, (zend_ulong)(index))) != nullptr) {
     RETURN_ZVAL(value, 1, 0);
   }
 }
@@ -195,8 +193,8 @@ ZEND_METHOD(Cassandra_Tuple, get)
 /* {{{ Tuple::count() */
 ZEND_METHOD(Cassandra_Tuple, count)
 {
-  php_scylladb_tuple *self = PHP_SCYLLADB_GET_TUPLE(getThis());
-  php_scylladb_type *type = PHP_SCYLLADB_GET_TYPE(&self->type);
+  auto self = PHP_SCYLLADB_GET_TUPLE(getThis());
+  auto type = PHP_SCYLLADB_GET_TYPE(&self->type);
   RETURN_LONG(zend_hash_num_elements(&type->data.tuple.types));
 }
 /* }}} */
@@ -205,12 +203,12 @@ ZEND_METHOD(Cassandra_Tuple, count)
 ZEND_METHOD(Cassandra_Tuple, current)
 {
   zend_ulong index;
-  php_scylladb_tuple *self = PHP_SCYLLADB_GET_TUPLE(getThis());
-  php_scylladb_type *type = PHP_SCYLLADB_GET_TYPE(&self->type);
+  auto self = PHP_SCYLLADB_GET_TUPLE(getThis());
+  auto type = PHP_SCYLLADB_GET_TYPE(&self->type);
 
-  if (zend_hash_get_current_key_ex(&type->data.tuple.types, NULL, &index, &self->pos) == HASH_KEY_IS_LONG) {
+  if (zend_hash_get_current_key_ex(&type->data.tuple.types, nullptr, &index, &self->pos) == HASH_KEY_IS_LONG) {
     zval *value;
-    if ((value = zend_hash_index_find(&self->values, (zend_ulong)(index))) != NULL) {
+    if ((value = zend_hash_index_find(&self->values, (zend_ulong)(index))) != nullptr) {
       RETURN_ZVAL(value, 1, 0);
     }
   }
@@ -221,9 +219,9 @@ ZEND_METHOD(Cassandra_Tuple, current)
 ZEND_METHOD(Cassandra_Tuple, key)
 {
   zend_ulong index;
-  php_scylladb_tuple *self = PHP_SCYLLADB_GET_TUPLE(getThis());
-  php_scylladb_type *type = PHP_SCYLLADB_GET_TYPE(&self->type);
-  if (zend_hash_get_current_key_ex(&type->data.tuple.types, NULL, &index, &self->pos) == HASH_KEY_IS_LONG) {
+  auto self = PHP_SCYLLADB_GET_TUPLE(getThis());
+  auto type = PHP_SCYLLADB_GET_TYPE(&self->type);
+  if (zend_hash_get_current_key_ex(&type->data.tuple.types, nullptr, &index, &self->pos) == HASH_KEY_IS_LONG) {
     RETURN_LONG(index);
   }
 }
@@ -232,8 +230,8 @@ ZEND_METHOD(Cassandra_Tuple, key)
 /* {{{ Tuple::next() */
 ZEND_METHOD(Cassandra_Tuple, next)
 {
-  php_scylladb_tuple *self = PHP_SCYLLADB_GET_TUPLE(getThis());
-  php_scylladb_type *type = PHP_SCYLLADB_GET_TYPE(&self->type);
+  auto self = PHP_SCYLLADB_GET_TUPLE(getThis());
+  auto type = PHP_SCYLLADB_GET_TYPE(&self->type);
   zend_hash_move_forward_ex(&type->data.tuple.types, &self->pos);
 }
 /* }}} */
@@ -241,8 +239,8 @@ ZEND_METHOD(Cassandra_Tuple, next)
 /* {{{ Tuple::valid() */
 ZEND_METHOD(Cassandra_Tuple, valid)
 {
-  php_scylladb_tuple *self = PHP_SCYLLADB_GET_TUPLE(getThis());
-  php_scylladb_type *type = PHP_SCYLLADB_GET_TYPE(&self->type);
+  auto self = PHP_SCYLLADB_GET_TUPLE(getThis());
+  auto type = PHP_SCYLLADB_GET_TYPE(&self->type);
   RETURN_BOOL(zend_hash_has_more_elements_ex(&type->data.tuple.types, &self->pos) == SUCCESS);
 }
 /* }}} */
@@ -250,8 +248,8 @@ ZEND_METHOD(Cassandra_Tuple, valid)
 /* {{{ Tuple::rewind() */
 ZEND_METHOD(Cassandra_Tuple, rewind)
 {
-  php_scylladb_tuple *self = PHP_SCYLLADB_GET_TUPLE(getThis());
-  php_scylladb_type *type = PHP_SCYLLADB_GET_TYPE(&self->type);
+  auto self = PHP_SCYLLADB_GET_TUPLE(getThis());
+  auto type = PHP_SCYLLADB_GET_TYPE(&self->type);
   zend_hash_internal_pointer_reset_ex(&type->data.tuple.types, &self->pos);
 }
 /* }}} */
@@ -269,7 +267,7 @@ php_scylladb_tuple_properties(zend_object *object)
 {
   zval values;
 
-  php_scylladb_tuple  *self = php_scylladb_tuple_object_fetch(object);
+  auto self = php_scylladb_tuple_object_fetch(object);
   if (object->properties) {
     zend_array_release(object->properties);
   }
@@ -320,8 +318,8 @@ php_scylladb_tuple_compare(zval *obj1, zval *obj2)
   zend_hash_internal_pointer_reset_ex(&tuple1->values, &pos1);
   zend_hash_internal_pointer_reset_ex(&tuple2->values, &pos2);
 
-  while ((current1 = zend_hash_get_current_data_ex(&tuple1->values, &pos1)) != NULL &&
-         (current2 = zend_hash_get_current_data_ex(&tuple2->values, &pos2)) != NULL) {
+  while ((current1 = zend_hash_get_current_data_ex(&tuple1->values, &pos1)) != nullptr &&
+         (current2 = zend_hash_get_current_data_ex(&tuple2->values, &pos2)) != nullptr) {
     result = php_scylladb_value_compare(current1,
                                          current2 );
     if (result != 0) return result;
@@ -337,7 +335,7 @@ php_scylladb_tuple_hash_value(zval *obj)
 {
   zval *current;
   unsigned hashv = 0;
-  php_scylladb_tuple *self = PHP_SCYLLADB_GET_TUPLE(obj);
+  auto self = PHP_SCYLLADB_GET_TUPLE(obj);
 
   if (!self->dirty) return self->hashv;
 
@@ -369,23 +367,20 @@ zend_object*
 php_scylladb_tuple_new(zend_class_entry *ce)
 {
   php_scylladb_tuple *self =
-      (php_scylladb_tuple *)ecalloc(1, sizeof(php_scylladb_tuple) + zend_object_properties_size(ce));
+      PHP_SCYLLADB_OBJ_ALLOCATE(php_scylladb_tuple, ce, &php_scylladb_tuple_handlers);
 
-  zend_hash_init(&self->values, 0, NULL, ZVAL_PTR_DTOR, 0);
+  zend_hash_init(&self->values, 0, nullptr, ZVAL_PTR_DTOR, 0);
   self->pos = HT_INVALID_IDX;
   self->dirty = 1;
   ZVAL_UNDEF(&self->type);
 
-  zend_object_std_init(&self->zendObject, ce);
   php_scylladb_tuple_handlers.std.offset = XtOffsetOf(php_scylladb_tuple, zendObject);
   php_scylladb_tuple_handlers.std.free_obj = php_scylladb_tuple_free;
-  self->zendObject.handlers = (zend_object_handlers *)&php_scylladb_tuple_handlers;
   return &self->zendObject;
 }
 
 
-void php_scylladb_tuple_post_register(zend_class_entry *ce)
+void php_scylladb_tuple_post_register([[maybe_unused]] zend_class_entry *ce)
 {
-    (void)ce;
     php_scylladb_tuple_handlers.std.offset = XtOffsetOf(php_scylladb_tuple, zendObject);
 }

--- a/src/Tuple.h
+++ b/src/Tuple.h
@@ -19,5 +19,5 @@
 #include "php_scylladb_types.h"
 
 BEGIN_EXTERN_C()
-void php_scylladb_tuple_set(php_scylladb_tuple *tuple, ulong index, zval *object);
+[[gnu::nonnull(1, 3)]] void php_scylladb_tuple_set(php_scylladb_tuple *tuple, zend_ulong index, zval *object);
 END_EXTERN_C()

--- a/src/Type.c
+++ b/src/Type.c
@@ -79,7 +79,7 @@ ZEND_METHOD(Cassandra_Type, tuple)
 {
   zval ztype;
   php_scylladb_type *type;
-  zval* args = NULL;
+  zval* args = nullptr;
   int argc = 0, i;
 
   ZEND_PARSE_PARAMETERS_START(0, -1)
@@ -112,7 +112,7 @@ ZEND_METHOD(Cassandra_Type, userType)
 {
   zval ztype;
   php_scylladb_type *type;
-  zval* args = NULL;
+  zval* args = nullptr;
   int argc = 0, i;
 
   ZEND_PARSE_PARAMETERS_START(0, -1)

--- a/src/Type/Collection.c
+++ b/src/Type/Collection.c
@@ -53,7 +53,7 @@ ZEND_METHOD(Cassandra_Type_Collection, valueType) {
 
 ZEND_METHOD(Cassandra_Type_Collection, __toString) {
   php_scylladb_type* self;
-  smart_str string = {NULL,0};
+  smart_str string = {nullptr,0};
 
   if (zend_parse_parameters_none() == FAILURE) {
     return;
@@ -71,7 +71,7 @@ ZEND_METHOD(Cassandra_Type_Collection, __toString) {
 ZEND_METHOD(Cassandra_Type_Collection, create) {
   php_scylladb_type* self;
   php_scylladb_collection* collection;
-  zval* args = NULL;
+  zval* args = nullptr;
   int argc = 0, i;
 
   ZEND_PARSE_PARAMETERS_START(0, -1)
@@ -107,9 +107,9 @@ HashTable* php_scylladb_type_collection_gc(
     zendObject* object,
 #endif
     zval** table, int* n) {
-  *table = NULL;
+  *table = nullptr;
   *n = 0;
-  return NULL;
+  return nullptr;
 }
 
 HashTable* php_scylladb_type_collection_properties(
@@ -120,9 +120,9 @@ HashTable* php_scylladb_type_collection_properties(
 #endif
 ) {
 #if PHP_MAJOR_VERSION >= 8
-  php_scylladb_type* self = php_scylladb_type_object_fetch(object);
+  auto self = php_scylladb_type_object_fetch(object);
 #else
-  php_scylladb_type* self = PHP_SCYLLADB_GET_TYPE(object);
+  auto self = PHP_SCYLLADB_GET_TYPE(object);
 #endif
   if (object->properties) {
     zend_array_release(object->properties);
@@ -140,14 +140,14 @@ int php_scylladb_type_collection_compare(zval* obj1, zval* obj2) {
 #if PHP_MAJOR_VERSION >= 8
   ZEND_COMPARE_OBJECTS_FALLBACK(obj1, obj2);
 #endif
-  php_scylladb_type* type1 = PHP_SCYLLADB_GET_TYPE(obj1);
-  php_scylladb_type* type2 = PHP_SCYLLADB_GET_TYPE(obj2);
+  auto type1 = PHP_SCYLLADB_GET_TYPE(obj1);
+  auto type2 = PHP_SCYLLADB_GET_TYPE(obj2);
 
   return php_scylladb_type_compare(type1, type2);
 }
 
 void php_scylladb_type_collection_free(zend_object* object) {
-  php_scylladb_type* self = php_scylladb_type_object_fetch(object);
+  auto self = php_scylladb_type_object_fetch(object);
 
   if (self->data_type) cass_data_type_free(self->data_type);
   zval_ptr_dtor(&self->data.collection.value_type);
@@ -158,16 +158,15 @@ void php_scylladb_type_collection_free(zend_object* object) {
 
 zend_object* php_scylladb_type_collection_new(
     zend_class_entry* ce) {
-  php_scylladb_type* self = (php_scylladb_type *)ecalloc(1, sizeof(php_scylladb_type) + zend_object_properties_size(ce));
+  php_scylladb_type* self =
+      PHP_SCYLLADB_OBJ_ALLOCATE(php_scylladb_type, ce, &php_scylladb_type_collection_handlers);
 
   self->type = CASS_VALUE_TYPE_LIST;
   self->data_type = cass_data_type_new(self->type);
   ZVAL_UNDEF(&self->data.collection.value_type);
 
-  zend_object_std_init(&self->zendObject, ce);
   php_scylladb_type_collection_handlers.offset = XtOffsetOf(php_scylladb_type, zendObject);
   php_scylladb_type_collection_handlers.free_obj = php_scylladb_type_collection_free;
-  self->zendObject.handlers = (zend_object_handlers *)&php_scylladb_type_collection_handlers;
   return &self->zendObject;
 }
 

--- a/src/Type/Conversions.c
+++ b/src/Type/Conversions.c
@@ -158,8 +158,8 @@ int php_scylladb_validate_object(zval* object, zval* ztype) {
       if (!INSTANCE_OF(php_scylladb_map_ce)) {
         EXPECTING_VALUE("an instance of " PHP_SCYLLADB_NAMESPACE "\\Map");
       } else {
-        php_scylladb_map* map = PHP_SCYLLADB_GET_MAP(object);
-        php_scylladb_type* map_type = PHP_SCYLLADB_GET_TYPE(&(map->type));
+        auto map = PHP_SCYLLADB_GET_MAP(object);
+        auto map_type = PHP_SCYLLADB_GET_TYPE(&(map->type));
         if (php_scylladb_type_compare(map_type, type) != 0) {
           return 0;
         }
@@ -170,8 +170,8 @@ int php_scylladb_validate_object(zval* object, zval* ztype) {
       if (!INSTANCE_OF(php_scylladb_set_ce)) {
         EXPECTING_VALUE("an instance of " PHP_SCYLLADB_NAMESPACE "\\Set");
       } else {
-        php_scylladb_set* set = PHP_SCYLLADB_GET_SET(object);
-        php_scylladb_type* set_type = PHP_SCYLLADB_GET_TYPE(&(set->type));
+        auto set = PHP_SCYLLADB_GET_SET(object);
+        auto set_type = PHP_SCYLLADB_GET_TYPE(&(set->type));
         if (php_scylladb_type_compare(set_type, type) != 0) {
           return 0;
         }
@@ -182,8 +182,8 @@ int php_scylladb_validate_object(zval* object, zval* ztype) {
       if (!INSTANCE_OF(php_scylladb_collection_ce)) {
         EXPECTING_VALUE("an instance of " PHP_SCYLLADB_NAMESPACE "\\Collection");
       } else {
-        php_scylladb_collection* collection = PHP_SCYLLADB_GET_COLLECTION(object);
-        php_scylladb_type* collection_type = PHP_SCYLLADB_GET_TYPE(&(collection->type));
+        auto collection = PHP_SCYLLADB_GET_COLLECTION(object);
+        auto collection_type = PHP_SCYLLADB_GET_TYPE(&(collection->type));
         if (php_scylladb_type_compare(collection_type, type) != 0) {
           return 0;
         }
@@ -194,8 +194,8 @@ int php_scylladb_validate_object(zval* object, zval* ztype) {
       if (!INSTANCE_OF(php_scylladb_tuple_ce)) {
         EXPECTING_VALUE("an instance of " PHP_SCYLLADB_NAMESPACE "\\Tuple");
       } else {
-        php_scylladb_tuple* tuple = PHP_SCYLLADB_GET_TUPLE(object);
-        php_scylladb_type* tuple_type = PHP_SCYLLADB_GET_TYPE(&(tuple->type));
+        auto tuple = PHP_SCYLLADB_GET_TUPLE(object);
+        auto tuple_type = PHP_SCYLLADB_GET_TYPE(&(tuple->type));
         if (php_scylladb_type_compare(tuple_type, type) != 0) {
           return 0;
         }
@@ -206,8 +206,8 @@ int php_scylladb_validate_object(zval* object, zval* ztype) {
       if (!INSTANCE_OF(php_scylladb_user_type_value_ce)) {
         EXPECTING_VALUE("an instance of " PHP_SCYLLADB_NAMESPACE "\\UserTypeValue");
       } else {
-        php_scylladb_user_type_value* user_type_value = PHP_SCYLLADB_GET_USER_TYPE_VALUE(object);
-        php_scylladb_type* user_type = PHP_SCYLLADB_GET_TYPE(&(user_type_value->type));
+        auto user_type_value = PHP_SCYLLADB_GET_USER_TYPE_VALUE(object);
+        auto user_type = PHP_SCYLLADB_GET_TYPE(&(user_type_value->type));
         if (php_scylladb_type_compare(user_type, type) != 0) {
           return 0;
         }
@@ -713,7 +713,7 @@ int php_scylladb_collection_from_set(php_scylladb_set* set, CassCollection** col
   type = PHP_SCYLLADB_GET_TYPE(&set->type);
   value_type = PHP_SCYLLADB_GET_TYPE(&type->data.set.value_type);
   collection = cass_collection_new_from_data_type(type->data_type, HASH_COUNT(set->entries));
-  if (collection == NULL) {
+  if (collection == nullptr) {
     zend_throw_exception_ex(php_scylladb_runtime_exception_ce, 0,
                             "Failed to allocate a CassCollection for set");
     return 0;
@@ -746,7 +746,7 @@ int php_scylladb_collection_from_collection(php_scylladb_collection* coll,
   value_type = PHP_SCYLLADB_GET_TYPE(&(type->data.collection.value_type));
   collection =
       cass_collection_new_from_data_type(type->data_type, zend_hash_num_elements(&coll->values));
-  if (collection == NULL) {
+  if (collection == nullptr) {
     zend_throw_exception_ex(php_scylladb_runtime_exception_ce, 0,
                             "Failed to allocate a CassCollection for list");
     return 0;
@@ -780,7 +780,7 @@ int php_scylladb_collection_from_map(php_scylladb_map* map, CassCollection** col
   value_type = PHP_SCYLLADB_GET_TYPE(&(type->data.map.value_type));
   key_type = PHP_SCYLLADB_GET_TYPE(&(type->data.map.key_type));
   collection = cass_collection_new_from_data_type(type->data_type, HASH_COUNT(map->entries));
-  if (collection == NULL) {
+  if (collection == nullptr) {
     zend_throw_exception_ex(php_scylladb_runtime_exception_ce, 0,
                             "Failed to allocate a CassCollection for map");
     return 0;
@@ -813,7 +813,7 @@ int php_scylladb_tuple_from_tuple(php_scylladb_tuple* tuple, CassTuple** output)
 
   type = PHP_SCYLLADB_GET_TYPE(&(tuple->type));
   tup = cass_tuple_new_from_data_type(type->data_type);
-  if (tup == NULL) {
+  if (tup == nullptr) {
     zend_throw_exception_ex(php_scylladb_runtime_exception_ce, 0,
                             "Failed to allocate a CassTuple");
     return 0;
@@ -822,7 +822,7 @@ int php_scylladb_tuple_from_tuple(php_scylladb_tuple* tuple, CassTuple** output)
   ZEND_HASH_FOREACH_NUM_KEY_VAL(&tuple->values, num_key, current) {
     zval* zsub_type;
     php_scylladb_type* sub_type;
-    if ((zsub_type = zend_hash_index_find(&type->data.tuple.types, (zend_ulong)(num_key))) == NULL ||
+    if ((zsub_type = zend_hash_index_find(&type->data.tuple.types, (zend_ulong)(num_key))) == nullptr ||
         !php_scylladb_validate_object((current), (zsub_type))) {
       result = 0;
       break;
@@ -853,7 +853,7 @@ int php_scylladb_user_type_from_user_type_value(php_scylladb_user_type_value* us
 
   type = PHP_SCYLLADB_GET_TYPE(&user_type_value->type);
   ut = cass_user_type_new_from_data_type(type->data_type);
-  if (ut == NULL) {
+  if (ut == nullptr) {
     zend_throw_exception_ex(php_scylladb_runtime_exception_ce, 0,
                             "Failed to allocate a CassUserType");
     return 0;
@@ -862,7 +862,7 @@ int php_scylladb_user_type_from_user_type_value(php_scylladb_user_type_value* us
   ZEND_HASH_FOREACH_STR_KEY_VAL(&user_type_value->values, name, current) {
     zval* zsub_type;
     php_scylladb_type* sub_type;
-    if ((zsub_type = zend_hash_str_find(&type->data.udt.types, ZSTR_VAL(name), (size_t)(ZSTR_LEN(name) + 1 - 1))) == NULL ||
+    if ((zsub_type = zend_hash_str_find(&type->data.udt.types, ZSTR_VAL(name), (size_t)(ZSTR_LEN(name) + 1 - 1))) == nullptr ||
         !php_scylladb_validate_object((current), (zsub_type))) {
       result = 0;
       break;

--- a/src/Type/Custom.c
+++ b/src/Type/Custom.c
@@ -66,15 +66,15 @@ HashTable *php_scylladb_type_custom_gc(
     zendObject *object,
 #endif
     zval **table, int *n) {
-  *table = NULL;
+  *table = nullptr;
   *n = 0;
-  return NULL;
+  return nullptr;
 }
 
 HashTable *php_scylladb_type_custom_properties(zend_object *object) {
   zval name;
 
-  php_scylladb_type *self = php_scylladb_type_object_fetch(object);
+  auto self = php_scylladb_type_object_fetch(object);
   if (object->properties) {
     zend_array_release(object->properties);
   }
@@ -89,19 +89,19 @@ HashTable *php_scylladb_type_custom_properties(zend_object *object) {
 
 int php_scylladb_type_custom_compare(zval *obj1, zval *obj2) {
   ZEND_COMPARE_OBJECTS_FALLBACK(obj1, obj2)
-  php_scylladb_type *type1 = PHP_SCYLLADB_GET_TYPE(obj1);
-  php_scylladb_type *type2 = PHP_SCYLLADB_GET_TYPE(obj2);
+  auto type1 = PHP_SCYLLADB_GET_TYPE(obj1);
+  auto type2 = PHP_SCYLLADB_GET_TYPE(obj2);
 
   return php_scylladb_type_compare(type1, type2);
 }
 
 void php_scylladb_type_custom_free(zend_object *object) {
-  php_scylladb_type *self = php_scylladb_type_object_fetch(object);
+  auto self = php_scylladb_type_object_fetch(object);
 
   if (self->data_type) cass_data_type_free(self->data_type);
   if (self->data.custom.class_name) {
     efree(self->data.custom.class_name);
-    self->data.custom.class_name = NULL;
+    self->data.custom.class_name = nullptr;
   }
 
   zend_object_std_dtor(&self->zendObject);
@@ -109,16 +109,15 @@ void php_scylladb_type_custom_free(zend_object *object) {
 }
 
 zend_object *php_scylladb_type_custom_new(zend_class_entry *ce) {
-  php_scylladb_type *self = (php_scylladb_type *)ecalloc(1, sizeof(php_scylladb_type) + zend_object_properties_size(ce));
+  php_scylladb_type *self =
+      PHP_SCYLLADB_OBJ_ALLOCATE(php_scylladb_type, ce, &php_scylladb_type_custom_handlers);
 
   self->type = CASS_VALUE_TYPE_CUSTOM;
   self->data_type = cass_data_type_new(self->type);
-  self->data.custom.class_name = NULL;
+  self->data.custom.class_name = nullptr;
 
-  zend_object_std_init(&self->zendObject, ce);
   php_scylladb_type_custom_handlers.offset = XtOffsetOf(php_scylladb_type, zendObject);
   php_scylladb_type_custom_handlers.free_obj = php_scylladb_type_custom_free;
-  self->zendObject.handlers = (zend_object_handlers *)&php_scylladb_type_custom_handlers;
   return &self->zendObject;
 }
 

--- a/src/Type/Map.c
+++ b/src/Type/Map.c
@@ -67,7 +67,7 @@ ZEND_METHOD(Cassandra_Type_Map, valueType)
 ZEND_METHOD(Cassandra_Type_Map, __toString)
 {
   php_scylladb_type *self;
-  smart_str string = {NULL,0};
+  smart_str string = {nullptr,0};
 
   if (zend_parse_parameters_none() == FAILURE) {
     return;
@@ -85,7 +85,7 @@ ZEND_METHOD(Cassandra_Type_Map, __toString)
 ZEND_METHOD(Cassandra_Type_Map, create)
 {
   php_scylladb_map *map;
-  zval* args = NULL;
+  zval* args = nullptr;
   int argc = 0, i;
 
   ZEND_PARSE_PARAMETERS_START(0, -1)
@@ -130,9 +130,9 @@ php_scylladb_type_map_gc(
         zval** table, int *n
 )
 {
-  *table = NULL;
+  *table = nullptr;
   *n = 0;
-  return NULL;
+  return nullptr;
 }
 
 HashTable *
@@ -145,9 +145,9 @@ php_scylladb_type_map_properties(
 )
 {
 #if PHP_MAJOR_VERSION >= 8
-  php_scylladb_type *self  = php_scylladb_type_object_fetch(object);
+  auto self = php_scylladb_type_object_fetch(object);
 #else
-  php_scylladb_type *self  = PHP_SCYLLADB_GET_TYPE(object);
+  auto self = PHP_SCYLLADB_GET_TYPE(object);
 #endif
   if (object->properties) {
     zend_array_release(object->properties);
@@ -170,8 +170,8 @@ php_scylladb_type_map_compare(zval *obj1, zval *obj2 )
 #if PHP_MAJOR_VERSION >= 8
   ZEND_COMPARE_OBJECTS_FALLBACK(obj1, obj2);
 #endif
-  php_scylladb_type* type1 = PHP_SCYLLADB_GET_TYPE(obj1);
-  php_scylladb_type* type2 = PHP_SCYLLADB_GET_TYPE(obj2);
+  auto type1 = PHP_SCYLLADB_GET_TYPE(obj1);
+  auto type2 = PHP_SCYLLADB_GET_TYPE(obj2);
 
   return php_scylladb_type_compare(type1, type2 );
 }
@@ -179,7 +179,7 @@ php_scylladb_type_map_compare(zval *obj1, zval *obj2 )
 void
 php_scylladb_type_map_free(zend_object *object )
 {
-  php_scylladb_type *self = php_scylladb_type_object_fetch(object);
+  auto self = php_scylladb_type_object_fetch(object);
 
   if (self->data_type) cass_data_type_free(self->data_type);
   zval_ptr_dtor(&self->data.map.key_type);
@@ -193,17 +193,15 @@ zend_object*
 php_scylladb_type_map_new(zend_class_entry *ce )
 {
   php_scylladb_type *self =
-      (php_scylladb_type *)ecalloc(1, sizeof(php_scylladb_type) + zend_object_properties_size(ce));
+      PHP_SCYLLADB_OBJ_ALLOCATE(php_scylladb_type, ce, &php_scylladb_type_map_handlers);
 
   self->type = CASS_VALUE_TYPE_MAP;
   self->data_type = cass_data_type_new(self->type);
   ZVAL_UNDEF(&self->data.map.key_type);
   ZVAL_UNDEF(&self->data.map.value_type);
 
-  zend_object_std_init(&self->zendObject, ce);
   php_scylladb_type_map_handlers.offset = XtOffsetOf(php_scylladb_type, zendObject);
   php_scylladb_type_map_handlers.free_obj = php_scylladb_type_map_free;
-  self->zendObject.handlers = (zend_object_handlers *)&php_scylladb_type_map_handlers;
   return &self->zendObject;
 }
 

--- a/src/Type/Scalar.c
+++ b/src/Type/Scalar.c
@@ -70,12 +70,12 @@ HashTable *php_scylladb_type_scalar_gc(zend_object *object, zval **table,
                                             int *n) {
   *table = nullptr;
   *n = 0;
-  return NULL;
+  return nullptr;
 }
 
 HashTable *php_scylladb_type_scalar_properties(zend_object *object) {
   zval name;
-  php_scylladb_type *self = php_scylladb_type_object_fetch(object);
+  auto self = php_scylladb_type_object_fetch(object);
   if (object->properties) {
     zend_array_release(object->properties);
   }
@@ -94,14 +94,14 @@ HashTable *php_scylladb_type_scalar_properties(zend_object *object) {
 
 int php_scylladb_type_scalar_compare(zval *obj1, zval *obj2) {
   ZEND_COMPARE_OBJECTS_FALLBACK(obj1, obj2)
-  php_scylladb_type *type1 = PHP_SCYLLADB_GET_TYPE(obj1);
-  php_scylladb_type *type2 = PHP_SCYLLADB_GET_TYPE(obj2);
+  auto type1 = PHP_SCYLLADB_GET_TYPE(obj1);
+  auto type2 = PHP_SCYLLADB_GET_TYPE(obj2);
 
   return php_scylladb_type_compare(type1, type2);
 }
 
 void php_scylladb_type_scalar_free(zend_object *object) {
-  php_scylladb_type *self = php_scylladb_type_object_fetch(object);
+  auto self = php_scylladb_type_object_fetch(object);
 
   if (self->data_type) cass_data_type_free(self->data_type);
 
@@ -110,15 +110,14 @@ void php_scylladb_type_scalar_free(zend_object *object) {
 }
 
 zend_object* php_scylladb_type_scalar_new(zend_class_entry *ce) {
-  php_scylladb_type *self = (php_scylladb_type *)ecalloc(1, sizeof(php_scylladb_type) + zend_object_properties_size(ce));
+  php_scylladb_type *self =
+      PHP_SCYLLADB_OBJ_ALLOCATE(php_scylladb_type, ce, &php_scylladb_type_scalar_handlers);
 
   self->type = CASS_VALUE_TYPE_UNKNOWN;
   self->data_type = nullptr;
 
-  zend_object_std_init(&self->zendObject, ce);
   php_scylladb_type_scalar_handlers.offset = XtOffsetOf(php_scylladb_type, zendObject);
   php_scylladb_type_scalar_handlers.free_obj = php_scylladb_type_scalar_free;
-  self->zendObject.handlers = (zend_object_handlers *)&php_scylladb_type_scalar_handlers;
   return &self->zendObject;
 }
 

--- a/src/Type/Set.c
+++ b/src/Type/Set.c
@@ -56,7 +56,7 @@ ZEND_METHOD(Cassandra_Type_Set, valueType)
 ZEND_METHOD(Cassandra_Type_Set, __toString)
 {
   php_scylladb_type *self;
-  smart_str string = {NULL,0};
+  smart_str string = {nullptr,0};
 
   if (zend_parse_parameters_none() == FAILURE) {
     return;
@@ -74,7 +74,7 @@ ZEND_METHOD(Cassandra_Type_Set, __toString)
 ZEND_METHOD(Cassandra_Type_Set, create)
 {
   php_scylladb_set *set;
-  zval* args = NULL;
+  zval* args = nullptr;
   int argc = 0, i;
 
   ZEND_PARSE_PARAMETERS_START(0, -1)
@@ -109,9 +109,9 @@ php_scylladb_type_set_gc(
         zval** table, int *n
 )
 {
-  *table = NULL;
+  *table = nullptr;
   *n = 0;
-  return NULL;
+  return nullptr;
 }
 
 HashTable *
@@ -124,9 +124,9 @@ php_scylladb_type_set_properties(
 )
 {
 #if PHP_MAJOR_VERSION >= 8
-  php_scylladb_type *self  = php_scylladb_type_object_fetch(object);
+  auto self = php_scylladb_type_object_fetch(object);
 #else
-  php_scylladb_type *self  = PHP_SCYLLADB_GET_TYPE(object);
+  auto self = PHP_SCYLLADB_GET_TYPE(object);
 #endif
   if (object->properties) {
     zend_array_release(object->properties);
@@ -146,8 +146,8 @@ php_scylladb_type_set_compare(zval *obj1, zval *obj2 )
 #if PHP_MAJOR_VERSION >= 8
   ZEND_COMPARE_OBJECTS_FALLBACK(obj1, obj2);
 #endif
-  php_scylladb_type* type1 = PHP_SCYLLADB_GET_TYPE(obj1);
-  php_scylladb_type* type2 = PHP_SCYLLADB_GET_TYPE(obj2);
+  auto type1 = PHP_SCYLLADB_GET_TYPE(obj1);
+  auto type2 = PHP_SCYLLADB_GET_TYPE(obj2);
 
   return php_scylladb_type_compare(type1, type2 );
 }
@@ -155,7 +155,7 @@ php_scylladb_type_set_compare(zval *obj1, zval *obj2 )
 void
 php_scylladb_type_set_free(zend_object *object )
 {
-  php_scylladb_type *self = php_scylladb_type_object_fetch(object);
+  auto self = php_scylladb_type_object_fetch(object);
 
   if (self->data_type) cass_data_type_free(self->data_type);
   zval_ptr_dtor(&self->data.set.value_type);
@@ -168,16 +168,14 @@ zend_object*
 php_scylladb_type_set_new(zend_class_entry *ce )
 {
   php_scylladb_type *self =
-      (php_scylladb_type *)ecalloc(1, sizeof(php_scylladb_type) + zend_object_properties_size(ce));
+      PHP_SCYLLADB_OBJ_ALLOCATE(php_scylladb_type, ce, &php_scylladb_type_set_handlers);
 
   self->type = CASS_VALUE_TYPE_SET;
   self->data_type = cass_data_type_new(self->type);
   ZVAL_UNDEF(&self->data.set.value_type);
 
-  zend_object_std_init(&self->zendObject, ce);
   php_scylladb_type_set_handlers.offset = XtOffsetOf(php_scylladb_type, zendObject);
   php_scylladb_type_set_handlers.free_obj = php_scylladb_type_set_free;
-  self->zendObject.handlers = (zend_object_handlers *)&php_scylladb_type_set_handlers;
   return &self->zendObject;
 }
 

--- a/src/Type/Tuple.c
+++ b/src/Type/Tuple.c
@@ -29,7 +29,7 @@ int
 php_scylladb_type_tuple_add(php_scylladb_type* type,
                           zval* zsub_type )
 {
-  php_scylladb_type* sub_type = PHP_SCYLLADB_GET_TYPE(zsub_type);
+  auto sub_type = PHP_SCYLLADB_GET_TYPE(zsub_type);
   if (cass_data_type_add_sub_type(type->data_type,
                                   sub_type->data_type)
       != CASS_OK) {
@@ -72,7 +72,7 @@ ZEND_METHOD(Cassandra_Type_Tuple, types)
 ZEND_METHOD(Cassandra_Type_Tuple, __toString)
 {
   php_scylladb_type* self;
-  smart_str string = {NULL,0};
+  smart_str string = {nullptr,0};
 
   if (zend_parse_parameters_none() == FAILURE) {
     return;
@@ -91,7 +91,7 @@ ZEND_METHOD(Cassandra_Type_Tuple, create)
 {
   php_scylladb_type* self;
   php_scylladb_tuple* tuple;
-  zval* args = NULL;
+  zval* args = nullptr;
   int argc               = 0, i, num_types;
 
   ZEND_PARSE_PARAMETERS_START(0, -1)
@@ -120,7 +120,7 @@ ZEND_METHOD(Cassandra_Type_Tuple, create)
     for (i = 0; i < argc; i++) {
       zval* sub_type;
 
-      if ((sub_type = zend_hash_index_find(&self->data.tuple.types, (zend_ulong)(i))) == NULL || !php_scylladb_validate_object(&args[i], sub_type )) {
+      if ((sub_type = zend_hash_index_find(&self->data.tuple.types, (zend_ulong)(i))) == nullptr || !php_scylladb_validate_object(&args[i], sub_type )) {
 
         return;
       }
@@ -141,9 +141,9 @@ php_scylladb_type_tuple_gc(
   zval** table,
   int* n )
 {
-  *table = NULL;
+  *table = nullptr;
   *n     = 0;
-  return NULL;
+  return nullptr;
 }
 
 HashTable*
@@ -157,9 +157,9 @@ php_scylladb_type_tuple_properties(
 {
   zval types;
 #if PHP_MAJOR_VERSION >= 8
-  php_scylladb_type* self = php_scylladb_type_object_fetch(object);
+  auto self = php_scylladb_type_object_fetch(object);
 #else
-  php_scylladb_type* self                          = PHP_SCYLLADB_GET_TYPE(object);
+  auto self = PHP_SCYLLADB_GET_TYPE(object);
 #endif
   if (object->properties) {
     zend_array_release(object->properties);
@@ -180,8 +180,8 @@ php_scylladb_type_tuple_compare(zval* obj1, zval* obj2 )
 #if PHP_MAJOR_VERSION >= 8
   ZEND_COMPARE_OBJECTS_FALLBACK(obj1, obj2);
 #endif
-  php_scylladb_type* type1 = PHP_SCYLLADB_GET_TYPE(obj1);
-  php_scylladb_type* type2 = PHP_SCYLLADB_GET_TYPE(obj2);
+  auto type1 = PHP_SCYLLADB_GET_TYPE(obj1);
+  auto type2 = PHP_SCYLLADB_GET_TYPE(obj2);
 
   return php_scylladb_type_compare(type1, type2 );
 }
@@ -189,7 +189,7 @@ php_scylladb_type_tuple_compare(zval* obj1, zval* obj2 )
 void
 php_scylladb_type_tuple_free(zend_object* object )
 {
-  php_scylladb_type* self = php_scylladb_type_object_fetch(object);
+  auto self = php_scylladb_type_object_fetch(object);
 
   if (self->data_type)
     cass_data_type_free(self->data_type);
@@ -202,16 +202,15 @@ php_scylladb_type_tuple_free(zend_object* object )
 zend_object*
 php_scylladb_type_tuple_new(zend_class_entry* ce )
 {
-  php_scylladb_type* self = (php_scylladb_type *)ecalloc(1, sizeof(php_scylladb_type) + zend_object_properties_size(ce));
+  php_scylladb_type* self =
+      PHP_SCYLLADB_OBJ_ALLOCATE(php_scylladb_type, ce, &php_scylladb_type_tuple_handlers);
 
   self->type      = CASS_VALUE_TYPE_TUPLE;
   self->data_type = cass_data_type_new(self->type);
-  zend_hash_init(&self->data.tuple.types, 0, NULL, ZVAL_PTR_DTOR, 0);
+  zend_hash_init(&self->data.tuple.types, 0, nullptr, ZVAL_PTR_DTOR, 0);
 
-  zend_object_std_init(&self->zendObject, ce);
   php_scylladb_type_tuple_handlers.offset = XtOffsetOf(php_scylladb_type, zendObject);
   php_scylladb_type_tuple_handlers.free_obj = php_scylladb_type_tuple_free;
-  self->zendObject.handlers = (zend_object_handlers *)&php_scylladb_type_tuple_handlers;
   return &self->zendObject;
 }
 

--- a/src/Type/TypeFactory.c
+++ b/src/Type/TypeFactory.c
@@ -83,7 +83,7 @@ static char* php_scylladb_from_hex(const char* hex, size_t hex_length) {
   size_t size = hex_length / 2;
   char* result;
   if ((hex_length & 1) == 1) { /* Invalid if not divisible by 2 */
-    return NULL;
+    return nullptr;
   }
   result = (char*)emalloc(size + 1);
   for (i = 0; i < size; ++i) {
@@ -91,7 +91,7 @@ static char* php_scylladb_from_hex(const char* hex, size_t hex_length) {
     int half1 = hex_value(hex[i * 2 + 1]);
     if (half0 < 0 || half1 < 0) {
       efree(result);
-      return NULL;
+      return nullptr;
     }
     result[c++] = (char)(((uint8_t)half0 << 4) | (uint8_t)half1);
   }
@@ -125,7 +125,7 @@ static zval php_scylladb_tuple_from_node(struct node_s* node) {
   ztype = php_scylladb_type_tuple();
   type = PHP_SCYLLADB_GET_TYPE(&ztype);
 
-  for (current = node->first_child; current != NULL; current = current->next_sibling) {
+  for (current = node->first_child; current != nullptr; current = current->next_sibling) {
     zval sub_type = php_scylladb_create_type(current);
     php_scylladb_type_tuple_add(type, &sub_type);
   }
@@ -306,10 +306,10 @@ static inline int tuple_compare(php_scylladb_type* type1, php_scylladb_type* typ
   zend_hash_internal_pointer_reset_ex(&type1->data.tuple.types, &pos1);
   zend_hash_internal_pointer_reset_ex(&type2->data.tuple.types, &pos2);
 
-  while ((current1 = zend_hash_get_current_data_ex(&type1->data.tuple.types, &pos1)) != NULL &&
-         (current2 = zend_hash_get_current_data_ex(&type2->data.tuple.types, &pos2)) != NULL) {
-    php_scylladb_type* sub_type1 = PHP_SCYLLADB_GET_TYPE(current1);
-    php_scylladb_type* sub_type2 = PHP_SCYLLADB_GET_TYPE(current2);
+  while ((current1 = zend_hash_get_current_data_ex(&type1->data.tuple.types, &pos1)) != nullptr &&
+         (current2 = zend_hash_get_current_data_ex(&type2->data.tuple.types, &pos2)) != nullptr) {
+    auto sub_type1 = PHP_SCYLLADB_GET_TYPE(current1);
+    auto sub_type2 = PHP_SCYLLADB_GET_TYPE(current2);
     int result = php_scylladb_type_compare(sub_type1, sub_type2);
     if (result != 0) return result;
     zend_hash_move_forward_ex(&type1->data.tuple.types, &pos1);
@@ -338,15 +338,15 @@ static inline int user_type_compare(php_scylladb_type* type1, php_scylladb_type*
   zend_hash_internal_pointer_reset_ex(&type1->data.udt.types, &pos1);
   zend_hash_internal_pointer_reset_ex(&type2->data.udt.types, &pos2);
 
-  while (zend_hash_get_current_key_ex(&type1->data.udt.types, &key1, NULL, &pos1) ==
+  while (zend_hash_get_current_key_ex(&type1->data.udt.types, &key1, nullptr, &pos1) ==
              HASH_KEY_IS_STRING &&
-         zend_hash_get_current_key_ex(&type2->data.udt.types, &key2, NULL, &pos2) ==
+         zend_hash_get_current_key_ex(&type2->data.udt.types, &key2, nullptr, &pos2) ==
              HASH_KEY_IS_STRING &&
-         (current1 = zend_hash_get_current_data_ex(&type1->data.udt.types, &pos1)) != NULL &&
-         (current2 = zend_hash_get_current_data_ex(&type2->data.udt.types, &pos2)) != NULL) {
+         (current1 = zend_hash_get_current_data_ex(&type1->data.udt.types, &pos1)) != nullptr &&
+         (current2 = zend_hash_get_current_data_ex(&type2->data.udt.types, &pos2)) != nullptr) {
     int result;
-    php_scylladb_type* sub_type1 = PHP_SCYLLADB_GET_TYPE(current1);
-    php_scylladb_type* sub_type2 = PHP_SCYLLADB_GET_TYPE(current2);
+    auto sub_type1 = PHP_SCYLLADB_GET_TYPE(current1);
+    auto sub_type2 = PHP_SCYLLADB_GET_TYPE(current2);
     result = php5to7_string_compare(key1, key2);
     if (result != 0) return result;
     result = php_scylladb_type_compare(sub_type1, sub_type2);
@@ -419,7 +419,7 @@ static inline void tuple_string(php_scylladb_type* type, smart_str* string) {
 
   smart_str_appendl(string, "tuple<", 6);
   ZEND_HASH_FOREACH_VAL(&type->data.tuple.types, current) {
-    php_scylladb_type* sub_type = PHP_SCYLLADB_GET_TYPE(current);
+    auto sub_type = PHP_SCYLLADB_GET_TYPE(current);
     if (!first) smart_str_appendl(string, ", ", 2);
     first = 0;
     php_scylladb_type_string(sub_type, string);
@@ -442,7 +442,7 @@ static inline void user_type_string(php_scylladb_type* type, smart_str* string) 
   } else {
     smart_str_appendl(string, "userType<", 9);
     ZEND_HASH_FOREACH_STR_KEY_VAL(&type->data.udt.types, name, current) {
-      php_scylladb_type* sub_type = PHP_SCYLLADB_GET_TYPE(current);
+      auto sub_type = PHP_SCYLLADB_GET_TYPE(current);
       if (!first) smart_str_appendl(string, ", ", 2);
       first = 0;
       smart_str_appendl(string, ZSTR_VAL(name), ZSTR_LEN(name));
@@ -492,7 +492,7 @@ void php_scylladb_type_string(php_scylladb_type* type, smart_str* string) {
 static zval php_scylladb_type_scalar_new(CassValueType type) {
   zval ztype;
   object_init_ex(&ztype, php_scylladb_type_scalar_ce);
-  php_scylladb_type* scalar = PHP_SCYLLADB_GET_TYPE(&ztype);
+  auto scalar = PHP_SCYLLADB_GET_TYPE(&ztype);
   scalar->type = type;
   scalar->data_type = cass_data_type_new(type);
 
@@ -593,7 +593,7 @@ static void php_scylladb_text_init(INTERNAL_FUNCTION_PARAMETERS) {
   XX(inet, CASS_VALUE_TYPE_INET)
 
 void php_scylladb_scalar_init(INTERNAL_FUNCTION_PARAMETERS) {
-  php_scylladb_type* self = PHP_SCYLLADB_GET_TYPE(getThis());
+  auto self = PHP_SCYLLADB_GET_TYPE(getThis());
 
 #define XX_SCALAR(name, value)          \
   if (self->type == value) {            \
@@ -998,7 +998,7 @@ static int php_scylladb_parse_class_name(const char* validator, size_t validator
   struct node_s* node;
   struct node_s* child;
 
-  token_str = NULL;
+  token_str = nullptr;
   token_len = 0;
   state = STATE_CLASS;
   str = validator;
@@ -1019,7 +1019,7 @@ static int php_scylladb_parse_class_name(const char* validator, size_t validator
 
     if (state == STATE_AFTER_PARENS) {
       if (token == TOKEN_COMMA) {
-        if (node->parent == NULL) {
+        if (node->parent == nullptr) {
           EXPECTING_TOKEN("end of string");
         }
         state = STATE_CLASS;
@@ -1033,7 +1033,7 @@ static int php_scylladb_parse_class_name(const char* validator, size_t validator
         node = child;
         continue;
       } else if (token == TOKEN_PAREN_CLOSE) {
-        if (node->parent == NULL) {
+        if (node->parent == nullptr) {
           EXPECTING_TOKEN("end of string");
         }
 
@@ -1053,7 +1053,7 @@ static int php_scylladb_parse_class_name(const char* validator, size_t validator
         child = php_scylladb_parse_node_new();
         child->parent = node;
 
-        if (node->first_child == NULL) {
+        if (node->first_child == nullptr) {
           node->first_child = child;
         }
 
@@ -1255,9 +1255,9 @@ static zval php_scylladb_create_type(struct node_s* node) {
 
   if (type == CASS_VALUE_TYPE_CUSTOM) {
     zval ztype;
-    smart_str class_name = {NULL, 0};
+    smart_str class_name = {nullptr, 0};
     php_scylladb_node_dump_to(node, &class_name);
-    ztype = php_scylladb_type_custom((class_name.s ? class_name.s->val : NULL),
+    ztype = php_scylladb_type_custom((class_name.s ? class_name.s->val : nullptr),
                                    (class_name.s ? class_name.s->len : 0));
     smart_str_free(&class_name);
     return ztype;

--- a/src/Type/UserType.c
+++ b/src/Type/UserType.c
@@ -29,7 +29,7 @@ int php_scylladb_type_user_type_add(php_scylladb_type *type,
                                      const char *name, size_t name_length,
                                      zval *zsub_type )
 {
-  php_scylladb_type *sub_type = PHP_SCYLLADB_GET_TYPE(zsub_type);
+  auto sub_type = PHP_SCYLLADB_GET_TYPE(zsub_type);
   if (cass_data_type_add_sub_type_by_name_n(type->data_type,
                                             name, name_length,
                                             sub_type->data_type) != CASS_OK) {
@@ -148,7 +148,7 @@ ZEND_METHOD(Cassandra_Type_UserType, types)
 ZEND_METHOD(Cassandra_Type_UserType, __toString)
 {
   php_scylladb_type *self;
-  smart_str string = {NULL,0};
+  smart_str string = {nullptr,0};
 
   if (zend_parse_parameters_none() == FAILURE) {
     return;
@@ -167,7 +167,7 @@ ZEND_METHOD(Cassandra_Type_UserType, create)
 {
   php_scylladb_type *self;
   php_scylladb_user_type_value *user_type_value;
-  zval* args = NULL;
+  zval* args = nullptr;
   int argc = 0, i;
 
   ZEND_PARSE_PARAMETERS_START(0, -1)
@@ -202,7 +202,7 @@ ZEND_METHOD(Cassandra_Type_UserType, create)
 
         return;
       }
-      if ((sub_type = zend_hash_str_find(&self->data.udt.types, Z_STRVAL_P(name), Z_STRLEN_P(name))) == NULL) {
+      if ((sub_type = zend_hash_str_find(&self->data.udt.types, Z_STRVAL_P(name), Z_STRLEN_P(name))) == nullptr) {
         zend_throw_exception_ex(php_scylladb_invalid_argument_exception_ce,
                                 0 ,
                                 "Invalid name '%s'", Z_STRVAL_P(name));
@@ -247,9 +247,9 @@ php_scylladb_type_user_type_properties(
   zval types;
 
 #if PHP_MAJOR_VERSION >= 8
-  php_scylladb_type *self  = php_scylladb_type_object_fetch(object);
+  auto self = php_scylladb_type_object_fetch(object);
 #else
-  php_scylladb_type *self  = PHP_SCYLLADB_GET_TYPE(object);
+  auto self = PHP_SCYLLADB_GET_TYPE(object);
 #endif
   if (object->properties) {
     zend_array_release(object->properties);
@@ -270,8 +270,8 @@ php_scylladb_type_user_type_compare(zval *obj1, zval *obj2 )
 #if PHP_MAJOR_VERSION >= 8
   ZEND_COMPARE_OBJECTS_FALLBACK(obj1, obj2);
 #endif
-  php_scylladb_type* type1 = PHP_SCYLLADB_GET_TYPE(obj1);
-  php_scylladb_type* type2 = PHP_SCYLLADB_GET_TYPE(obj2);
+  auto type1 = PHP_SCYLLADB_GET_TYPE(obj1);
+  auto type2 = PHP_SCYLLADB_GET_TYPE(obj2);
 
   return php_scylladb_type_compare(type1, type2 );
 }
@@ -279,7 +279,7 @@ php_scylladb_type_user_type_compare(zval *obj1, zval *obj2 )
 void
 php_scylladb_type_user_type_free(zend_object *object )
 {
-  php_scylladb_type *self = php_scylladb_type_object_fetch(object);
+  auto self = php_scylladb_type_object_fetch(object);
 
   if (self->data_type) cass_data_type_free(self->data_type);
   if (self->data.udt.keyspace) efree(self->data.udt.keyspace);
@@ -293,17 +293,16 @@ php_scylladb_type_user_type_free(zend_object *object )
 zend_object*
 php_scylladb_type_user_type_new(zend_class_entry *ce )
 {
-  php_scylladb_type *self = (php_scylladb_type *)ecalloc(1, sizeof(php_scylladb_type) + zend_object_properties_size(ce));
+  php_scylladb_type *self =
+      PHP_SCYLLADB_OBJ_ALLOCATE(php_scylladb_type, ce, &php_scylladb_type_user_type_handlers);
 
   self->type = CASS_VALUE_TYPE_UDT;
-  self->data_type = NULL;
-  self->data.udt.keyspace = self->data.udt.type_name = NULL;
-  zend_hash_init(&self->data.udt.types, 0, NULL, ZVAL_PTR_DTOR, 0);
+  self->data_type = nullptr;
+  self->data.udt.keyspace = self->data.udt.type_name = nullptr;
+  zend_hash_init(&self->data.udt.types, 0, nullptr, ZVAL_PTR_DTOR, 0);
 
-  zend_object_std_init(&self->zendObject, ce);
   php_scylladb_type_user_type_handlers.offset = XtOffsetOf(php_scylladb_type, zendObject);
   php_scylladb_type_user_type_handlers.free_obj = php_scylladb_type_user_type_free;
-  self->zendObject.handlers = (zend_object_handlers *)&php_scylladb_type_user_type_handlers;
   return &self->zendObject;
 }
 

--- a/src/UserTypeValue.c
+++ b/src/UserTypeValue.c
@@ -42,7 +42,6 @@ php_scylladb_user_type_value_populate(php_scylladb_user_type_value *user_type_va
 {
   zend_string *name;
   php_scylladb_type *type;
-  zval *current;
   zval null;
 
 
@@ -50,11 +49,10 @@ php_scylladb_user_type_value_populate(php_scylladb_user_type_value *user_type_va
 
   type = PHP_SCYLLADB_GET_TYPE(&user_type_value->type);
 
-  ZEND_HASH_FOREACH_STR_KEY_VAL(&type->data.udt.types, name, current) {
-    zval *value = NULL;
+  ZEND_HASH_FOREACH_STR_KEY(&type->data.udt.types, name) {
+    zval *value = nullptr;
     size_t name_len = ZSTR_LEN(name);
-    (void) current;
-    if ((value = zend_hash_str_find(&user_type_value->values, ZSTR_VAL(name), name_len)) != NULL) {
+    if ((value = zend_hash_str_find(&user_type_value->values, ZSTR_VAL(name), name_len)) != nullptr) {
       add_assoc_zval_ex(array, ZSTR_VAL(name), name_len, value);
       Z_TRY_ADDREF_P(value);
     } else {
@@ -126,14 +124,14 @@ ZEND_METHOD(Cassandra_UserTypeValue, __construct)
 /* {{{ UserTypeValue::type() */
 ZEND_METHOD(Cassandra_UserTypeValue, type)
 {
-  php_scylladb_user_type_value *self = PHP_SCYLLADB_GET_USER_TYPE_VALUE(getThis());
+  auto self = PHP_SCYLLADB_GET_USER_TYPE_VALUE(getThis());
   RETURN_ZVAL(&self->type, 1, 0);
 }
 
 /* {{{ UserTypeValue::values() */
 ZEND_METHOD(Cassandra_UserTypeValue, values)
 {
-  php_scylladb_user_type_value *self = NULL;
+  php_scylladb_user_type_value *self = nullptr;
   self = PHP_SCYLLADB_GET_USER_TYPE_VALUE(getThis());
 
   array_init(return_value);
@@ -144,7 +142,7 @@ ZEND_METHOD(Cassandra_UserTypeValue, values)
 /* {{{ UserTypeValue::set(name, mixed) */
 ZEND_METHOD(Cassandra_UserTypeValue, set)
 {
-  php_scylladb_user_type_value *self = NULL;
+  php_scylladb_user_type_value *self = nullptr;
   php_scylladb_type *type;
   zval *sub_type;
   char *name;
@@ -159,7 +157,7 @@ ZEND_METHOD(Cassandra_UserTypeValue, set)
   self = PHP_SCYLLADB_GET_USER_TYPE_VALUE(getThis());
   type = PHP_SCYLLADB_GET_TYPE(&self->type);
 
-  if ((sub_type = zend_hash_str_find(&type->data.udt.types, name, name_length)) == NULL) {
+  if ((sub_type = zend_hash_str_find(&type->data.udt.types, name, name_length)) == nullptr) {
     zend_throw_exception_ex(php_scylladb_invalid_argument_exception_ce, 0 ,
                             "Invalid name '%s'", name);
     return;
@@ -177,7 +175,7 @@ ZEND_METHOD(Cassandra_UserTypeValue, set)
 /* {{{ UserTypeValue::get(name) */
 ZEND_METHOD(Cassandra_UserTypeValue, get)
 {
-  php_scylladb_user_type_value *self = NULL;
+  php_scylladb_user_type_value *self = nullptr;
   php_scylladb_type *type;
   zval *sub_type;
   char *name;
@@ -191,13 +189,13 @@ ZEND_METHOD(Cassandra_UserTypeValue, get)
   self = PHP_SCYLLADB_GET_USER_TYPE_VALUE(getThis());
   type = PHP_SCYLLADB_GET_TYPE(&self->type);
 
-  if ((sub_type = zend_hash_str_find(&type->data.udt.types, name, name_length)) == NULL) {
+  if ((sub_type = zend_hash_str_find(&type->data.udt.types, name, name_length)) == nullptr) {
     zend_throw_exception_ex(php_scylladb_invalid_argument_exception_ce, 0 ,
                             "Invalid name '%s'", name);
     return;
   }
 
-  if ((value = zend_hash_str_find(&self->values, name, name_length)) != NULL) {
+  if ((value = zend_hash_str_find(&self->values, name, name_length)) != nullptr) {
     RETURN_ZVAL(value, 1, 0);
   }
 }
@@ -222,9 +220,9 @@ ZEND_METHOD(Cassandra_UserTypeValue, current)
       PHP_SCYLLADB_GET_USER_TYPE_VALUE(getThis());
   php_scylladb_type *type =
       PHP_SCYLLADB_GET_TYPE(&self->type);
-  if (zend_hash_get_current_key_ex(&type->data.udt.types, &key, NULL, &self->pos) == HASH_KEY_IS_STRING) {
+  if (zend_hash_get_current_key_ex(&type->data.udt.types, &key, nullptr, &self->pos) == HASH_KEY_IS_STRING) {
     zval *value;
-    if ((value = zend_hash_str_find(&self->values, key->val, key->len)) != NULL) {
+    if ((value = zend_hash_str_find(&self->values, key->val, key->len)) != nullptr) {
       RETURN_ZVAL(value, 1, 0);
     }
   }
@@ -239,7 +237,7 @@ ZEND_METHOD(Cassandra_UserTypeValue, key)
       PHP_SCYLLADB_GET_USER_TYPE_VALUE(getThis());
   php_scylladb_type *type =
       PHP_SCYLLADB_GET_TYPE(&self->type);
-  if (zend_hash_get_current_key_ex(&type->data.udt.types, &key, NULL, &self->pos) == HASH_KEY_IS_STRING) {
+  if (zend_hash_get_current_key_ex(&type->data.udt.types, &key, nullptr, &self->pos) == HASH_KEY_IS_STRING) {
     RETURN_STR(key);
   }
 }
@@ -291,7 +289,7 @@ php_scylladb_user_type_value_properties(zend_object *object)
 {
   zval values;
 
-  php_scylladb_user_type_value *self = php_scylladb_user_type_value_object_fetch(object);
+  auto self = php_scylladb_user_type_value_object_fetch(object);
   if (object->properties) {
     zend_array_release(object->properties);
   }
@@ -342,8 +340,8 @@ php_scylladb_user_type_value_compare(zval *obj1, zval *obj2)
   zend_hash_internal_pointer_reset_ex(&user_type_value1->values, &pos1);
   zend_hash_internal_pointer_reset_ex(&user_type_value2->values, &pos2);
 
-  while ((current1 = zend_hash_get_current_data_ex(&user_type_value1->values, &pos1)) != NULL &&
-         (current2 = zend_hash_get_current_data_ex(&user_type_value2->values, &pos2)) != NULL) {
+  while ((current1 = zend_hash_get_current_data_ex(&user_type_value1->values, &pos1)) != nullptr &&
+         (current2 = zend_hash_get_current_data_ex(&user_type_value2->values, &pos2)) != nullptr) {
     result = php_scylladb_value_compare(current1,
                                          current2 );
     if (result != 0) return result;
@@ -359,7 +357,7 @@ php_scylladb_user_type_value_hash_value(zval *obj)
 {
   zval *current;
   unsigned hashv = 0;
-  php_scylladb_user_type_value *self = PHP_SCYLLADB_GET_USER_TYPE_VALUE(obj);
+  auto self = PHP_SCYLLADB_GET_USER_TYPE_VALUE(obj);
 
   if (!self->dirty) return self->hashv;
 
@@ -391,23 +389,20 @@ zend_object*
 php_scylladb_user_type_value_new(zend_class_entry *ce)
 {
   php_scylladb_user_type_value *self =
-      (php_scylladb_user_type_value *)ecalloc(1, sizeof(php_scylladb_user_type_value) + zend_object_properties_size(ce));
+      PHP_SCYLLADB_OBJ_ALLOCATE(php_scylladb_user_type_value, ce, &php_scylladb_user_type_value_handlers);
 
-  zend_hash_init(&self->values, 0, NULL, ZVAL_PTR_DTOR, 0);
+  zend_hash_init(&self->values, 0, nullptr, ZVAL_PTR_DTOR, 0);
   self->pos = HT_INVALID_IDX;
   self->dirty = 1;
   ZVAL_UNDEF(&self->type);
 
-  zend_object_std_init(&self->zendObject, ce);
   php_scylladb_user_type_value_handlers.std.offset = XtOffsetOf(php_scylladb_user_type_value, zendObject);
   php_scylladb_user_type_value_handlers.std.free_obj = php_scylladb_user_type_value_free;
-  self->zendObject.handlers = (zend_object_handlers *)&php_scylladb_user_type_value_handlers;
   return &self->zendObject;
 }
 
 
-void php_scylladb_user_type_value_post_register(zend_class_entry *ce)
+void php_scylladb_user_type_value_post_register([[maybe_unused]] zend_class_entry *ce)
 {
-    (void)ce;
     php_scylladb_user_type_value_handlers.std.offset = XtOffsetOf(php_scylladb_user_type_value, zendObject);
 }

--- a/src/Uuid.c
+++ b/src/Uuid.c
@@ -69,7 +69,7 @@ ZEND_METHOD(Cassandra_Uuid, __construct)
   ZEND_PARSE_PARAMETERS_END();
   // clang-format on
 
-  php_scylladb_uuid *self = PHP_SCYLLADB_GET_UUID(ZEND_THIS);
+  auto self = PHP_SCYLLADB_GET_UUID(ZEND_THIS);
 
   if (uuid == nullptr) {
     php_scylladb_uuid_generate_random(&self->uuid);
@@ -87,7 +87,7 @@ ZEND_METHOD(Cassandra_Uuid, __construct)
 ZEND_METHOD(Cassandra_Uuid, __toString)
 {
   char string[CASS_UUID_STRING_LENGTH];
-  php_scylladb_uuid *self = PHP_SCYLLADB_GET_UUID(ZEND_THIS);
+  auto self = PHP_SCYLLADB_GET_UUID(ZEND_THIS);
 
   cass_uuid_string(self->uuid, string);
 
@@ -107,7 +107,7 @@ ZEND_METHOD(Cassandra_Uuid, type)
 ZEND_METHOD(Cassandra_Uuid, uuid)
 {
   char string[CASS_UUID_STRING_LENGTH];
-  php_scylladb_uuid *self = PHP_SCYLLADB_GET_UUID(ZEND_THIS);
+  auto self = PHP_SCYLLADB_GET_UUID(ZEND_THIS);
 
   cass_uuid_string(self->uuid, string);
 
@@ -118,7 +118,7 @@ ZEND_METHOD(Cassandra_Uuid, uuid)
 /* {{{ Uuid::version() */
 ZEND_METHOD(Cassandra_Uuid, version)
 {
-  php_scylladb_uuid *self = PHP_SCYLLADB_GET_UUID(ZEND_THIS);
+  auto self = PHP_SCYLLADB_GET_UUID(ZEND_THIS);
 
   RETURN_LONG((long) cass_uuid_version(self->uuid));
 }
@@ -128,9 +128,9 @@ ZEND_METHOD(Cassandra_Uuid, version)
 HashTable *
 php_scylladb_uuid_gc(zend_object *object, zval** table, int *n)
 {
-  *table = NULL;
+  *table = nullptr;
   *n = 0;
-  return NULL;
+  return nullptr;
 }
 
 HashTable *
@@ -141,7 +141,7 @@ php_scylladb_uuid_properties(zend_object *object)
   zval uuid;
   zval version;
 
-  php_scylladb_uuid *self = php_scylladb_uuid_object_fetch(object);
+  auto self = php_scylladb_uuid_object_fetch(object);
   if (object->properties) {
     zend_array_release(object->properties);
   }
@@ -166,8 +166,8 @@ int
 php_scylladb_uuid_compare(zval *obj1, zval *obj2)
 {
   ZEND_COMPARE_OBJECTS_FALLBACK(obj1, obj2);
-  php_scylladb_uuid *uuid1 = NULL;
-  php_scylladb_uuid *uuid2 = NULL;
+  php_scylladb_uuid *uuid1 = nullptr;
+  php_scylladb_uuid *uuid2 = nullptr;
 
   if (Z_OBJCE_P(obj1) != Z_OBJCE_P(obj2))
     return strcmp(ZSTR_VAL(Z_OBJCE_P(obj1)->name), ZSTR_VAL(Z_OBJCE_P(obj2)->name)); /* different classes */
@@ -186,7 +186,7 @@ php_scylladb_uuid_compare(zval *obj1, zval *obj2)
 unsigned
 php_scylladb_uuid_hash_value(zval *obj)
 {
-  php_scylladb_uuid *self = PHP_SCYLLADB_GET_UUID(obj);
+  auto self = PHP_SCYLLADB_GET_UUID(obj);
   return php_scylladb_combine_hash(php_scylladb_bigint_hash(self->uuid.time_and_version),
                                     php_scylladb_bigint_hash(self->uuid.clock_seq_and_node));
 }
@@ -194,7 +194,7 @@ php_scylladb_uuid_hash_value(zval *obj)
 void
 php_scylladb_uuid_free(zend_object *object)
 {
-  php_scylladb_uuid *self = php_scylladb_uuid_object_fetch(object);
+  auto self = php_scylladb_uuid_object_fetch(object);
 
   zend_object_std_dtor(&self->zendObject);
 }
@@ -202,16 +202,13 @@ php_scylladb_uuid_free(zend_object *object)
 zend_object*
 php_scylladb_uuid_new(zend_class_entry *ce)
 {
-  php_scylladb_uuid *self = (php_scylladb_uuid *)ecalloc(1, sizeof(php_scylladb_uuid) + zend_object_properties_size(ce));
-
-  zend_object_std_init(&self->zendObject, ce);
-  self->zendObject.handlers = (zend_object_handlers *)&php_scylladb_uuid_handlers;
+  php_scylladb_uuid *self =
+      PHP_SCYLLADB_OBJ_ALLOCATE(php_scylladb_uuid, ce, &php_scylladb_uuid_handlers);
   return &self->zendObject;
 }
 
 
-void php_scylladb_uuid_post_register(zend_class_entry *ce)
+void php_scylladb_uuid_post_register([[maybe_unused]] zend_class_entry *ce)
 {
-    (void)ce;
     php_scylladb_uuid_handlers.std.offset = XtOffsetOf(php_scylladb_uuid, zendObject);
 }

--- a/src/UuidGen.h
+++ b/src/UuidGen.h
@@ -17,6 +17,6 @@
 
 #include <cassandra.h>
 
-void php_scylladb_uuid_generate_random(CassUuid* out);
-void php_scylladb_uuid_generate_time(CassUuid* out);
-void php_scylladb_uuid_generate_from_time(long timestamp, CassUuid* out);
+[[gnu::nonnull(1)]] void php_scylladb_uuid_generate_random(CassUuid* out);
+[[gnu::nonnull(1)]] void php_scylladb_uuid_generate_time(CassUuid* out);
+[[gnu::nonnull(2)]] void php_scylladb_uuid_generate_from_time(long timestamp, CassUuid* out);

--- a/src/php_scylladb.c
+++ b/src/php_scylladb.c
@@ -233,7 +233,7 @@ static void php_scylladb_log(const CassLogMessage *message, void *data) {
     fd = fopen(log, "a");
     if (fd) {
       time_t log_time;
-      struct tm log_tm = {0};
+      struct tm log_tm = {};
       char log_time_str[64];
       size_t needed = 0;
       char *tmp = nullptr;

--- a/third-party/sanitizers-cmake/.gitignore
+++ b/third-party/sanitizers-cmake/.gitignore
@@ -1,0 +1,3 @@
+# out-of-source build top-level folders.
+build/
+_build/

--- a/third-party/sanitizers-cmake/CMakeLists.txt
+++ b/third-party/sanitizers-cmake/CMakeLists.txt
@@ -1,0 +1,51 @@
+# This file is part of CMake-sanitizers.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+#
+# Copyright (c)
+#   2013-2015 Matt Arsenault
+#   2015      RWTH Aachen University, Federal Republic of Germany
+#
+
+
+#
+# project information
+#
+
+# minimum required cmake version
+cmake_minimum_required(VERSION 2.8.12)
+
+# project name
+project("CMake-sanitizers")
+
+
+
+#
+# cmake configuration
+#
+set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
+
+
+
+#
+# add tests
+#
+enable_testing()
+add_subdirectory(tests)

--- a/third-party/sanitizers-cmake/LICENSE
+++ b/third-party/sanitizers-cmake/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c)
+    2013 Matthew Arsenault
+    2015-2016 RWTH Aachen University, Federal Republic of Germany
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/third-party/sanitizers-cmake/README.md
+++ b/third-party/sanitizers-cmake/README.md
@@ -1,0 +1,73 @@
+# sanitizers-cmake
+
+ [![](https://img.shields.io/github/issues-raw/arsenm/sanitizers-cmake.svg?style=flat-square)](https://github.com/arsenm/sanitizers-cmake/issues)
+[![MIT](http://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](LICENSE)
+
+CMake module to enable sanitizers for binary targets.
+
+
+## Include into your project
+
+To use [FindSanitizers.cmake](cmake/FindSanitizers.cmake), simply add this repository as git submodule into your own repository
+```Shell
+mkdir externals
+git submodule add git@github.com:arsenm/sanitizers-cmake.git externals/sanitizers-cmake
+```
+and adding ```externals/sanitizers-cmake/cmake``` to your ```CMAKE_MODULE_PATH```
+```CMake
+set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/externals/sanitizers-cmake/cmake" ${CMAKE_MODULE_PATH})
+```
+
+If you don't use git or dislike submodules you can copy the files in [cmake directory](cmake) into your repository. *Be careful and keep updates in mind!*
+
+Now you can simply run ```find_package``` in your CMake files:
+```CMake
+find_package(Sanitizers)
+```
+
+
+## Usage
+
+You can enable the sanitizers with ``SANITIZE_ADDRESS``, ``SANITIZE_MEMORY``, ``SANITIZE_THREAD`` or ``SANITIZE_UNDEFINED`` options in your CMake configuration. You can do this by passing e.g. ``-DSANITIZE_ADDRESS=On`` on your command line or with your graphical interface.
+
+If sanitizers are supported by your compiler, the specified targets will be build with sanitizer support. If your compiler has no sanitizing capabilities (I asume intel compiler doesn't) you'll get a warning but CMake will continue processing and sanitizing will simply just be ignored.
+
+#### Compiler issues
+
+Different compilers may be using different implementations for sanitizers. If you'll try to sanitize targets with C and Fortran code but don't use gcc & gfortran but clang & gfortran, this will cause linking problems. To avoid this, such problems will be detected and sanitizing will be disabled for these targets.
+
+Even C only targets may cause problems in certain situations. Some problems have been seen with AddressSanitizer for preloading or dynamic linking. In such cases you may try the ``SANITIZE_LINK_STATIC`` to link sanitizers for gcc static.
+
+
+
+## Build targets with sanitizer support
+
+To enable sanitizer support you simply have to add ``add_sanitizers(<TARGET>)`` after defining your target. To provide a sanitizer blacklist file you can use the ``sanitizer_add_blacklist_file(<FILE>)`` function:
+```CMake
+find_package(Sanitizers)
+
+sanitizer_add_blacklist_file("blacklist.txt")
+
+add_executable(some_exe foo.c bar.c)
+add_sanitizers(some_exe)
+
+add_library(some_lib foo.c bar.c)
+add_sanitizers(some_lib)
+```
+
+## Run your application
+
+The sanitizers check your program, while it's running. In some situations (e.g. LD_PRELOAD your target) it might be required to preload the used AddressSanitizer library first. In this case you may use the ``asan-wrapper`` script defined in ``ASan_WRAPPER`` variable to execute your application with ``${ASan_WRAPPER} myexe arg1 ...``.
+
+
+## Contribute
+
+Anyone is welcome to contribute. Simply fork this repository, make your changes **in an own branch** and create a pull-request for your change. Please do only one change per pull-request.
+
+You found a bug? Please fill out an [issue](https://github.com/arsenm/sanitizers-cmake/issues) and include any data to reproduce the bug.
+
+
+#### Contributors
+
+* [Matt Arsenault](https://github.com/arsenm)
+* [Alexander Haase](https://github.com/alehaa)

--- a/third-party/sanitizers-cmake/cmake/FindASan.cmake
+++ b/third-party/sanitizers-cmake/cmake/FindASan.cmake
@@ -1,0 +1,62 @@
+# The MIT License (MIT)
+#
+# Copyright (c)
+#   2013 Matthew Arsenault
+#   2015-2016 RWTH Aachen University, Federal Republic of Germany
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+option(SANITIZE_ADDRESS "Enable AddressSanitizer for sanitized targets." Off)
+
+set(FLAG_CANDIDATES
+    # MSVC uses
+    "/fsanitize=address"
+
+    # Clang 3.2+ use this version. The no-omit-frame-pointer option is optional.
+    "-g -fsanitize=address -fno-omit-frame-pointer"
+    "-g -fsanitize=address"
+
+    # Older deprecated flag for ASan
+    "-g -faddress-sanitizer"
+)
+
+
+if (SANITIZE_ADDRESS AND (SANITIZE_THREAD OR SANITIZE_MEMORY))
+    message(FATAL_ERROR "AddressSanitizer is not compatible with "
+        "ThreadSanitizer or MemorySanitizer.")
+endif ()
+
+
+include(sanitize-helpers)
+
+if (SANITIZE_ADDRESS)
+    sanitizer_check_compiler_flags("${FLAG_CANDIDATES}" "AddressSanitizer"
+        "ASan")
+
+    find_program(ASan_WRAPPER "asan-wrapper" PATHS ${CMAKE_MODULE_PATH})
+	mark_as_advanced(ASan_WRAPPER)
+endif ()
+
+function (add_sanitize_address TARGET)
+    if (NOT SANITIZE_ADDRESS)
+        return()
+    endif ()
+
+    sanitizer_add_flags(${TARGET} "AddressSanitizer" "ASan")
+endfunction ()

--- a/third-party/sanitizers-cmake/cmake/FindMSan.cmake
+++ b/third-party/sanitizers-cmake/cmake/FindMSan.cmake
@@ -1,0 +1,60 @@
+# The MIT License (MIT)
+#
+# Copyright (c)
+#   2013 Matthew Arsenault
+#   2015-2016 RWTH Aachen University, Federal Republic of Germany
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+option(SANITIZE_MEMORY "Enable MemorySanitizer for sanitized targets." Off)
+
+set(FLAG_CANDIDATES
+    # MSVC uses
+    "/fsanitize=memory"
+    # GNU/Clang
+    "-g -fsanitize=memory"
+)
+
+
+include(sanitize-helpers)
+
+if (SANITIZE_MEMORY)
+    if (NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+        message(WARNING "MemorySanitizer disabled for target ${TARGET} because "
+            "MemorySanitizer is supported for Linux systems only.")
+        set(SANITIZE_MEMORY Off CACHE BOOL
+            "Enable MemorySanitizer for sanitized targets." FORCE)
+    elseif (NOT ${CMAKE_SIZEOF_VOID_P} EQUAL 8)
+        message(WARNING "MemorySanitizer disabled for target ${TARGET} because "
+            "MemorySanitizer is supported for 64bit systems only.")
+        set(SANITIZE_MEMORY Off CACHE BOOL
+            "Enable MemorySanitizer for sanitized targets." FORCE)
+    else ()
+        sanitizer_check_compiler_flags("${FLAG_CANDIDATES}" "MemorySanitizer"
+            "MSan")
+    endif ()
+endif ()
+
+function (add_sanitize_memory TARGET)
+    if (NOT SANITIZE_MEMORY)
+        return()
+    endif ()
+
+    sanitizer_add_flags(${TARGET} "MemorySanitizer" "MSan")
+endfunction ()

--- a/third-party/sanitizers-cmake/cmake/FindSanitizers.cmake
+++ b/third-party/sanitizers-cmake/cmake/FindSanitizers.cmake
@@ -1,0 +1,91 @@
+# The MIT License (MIT)
+#
+# Copyright (c)
+#   2013 Matthew Arsenault
+#   2015-2016 RWTH Aachen University, Federal Republic of Germany
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# If any of the used compiler is a GNU compiler, add a second option to static
+# link against the sanitizers.
+option(SANITIZE_LINK_STATIC "Try to link static against sanitizers." Off)
+
+# Highlight this module has been loaded.
+set(Sanitizers_FOUND TRUE)
+
+set(FIND_QUIETLY_FLAG "")
+if (DEFINED Sanitizers_FIND_QUIETLY)
+    set(FIND_QUIETLY_FLAG "QUIET")
+endif ()
+
+find_package(ASan ${FIND_QUIETLY_FLAG})
+find_package(TSan ${FIND_QUIETLY_FLAG})
+find_package(MSan ${FIND_QUIETLY_FLAG})
+find_package(UBSan ${FIND_QUIETLY_FLAG})
+
+function(sanitizer_add_blacklist_file FILE)
+    if(NOT IS_ABSOLUTE ${FILE})
+        set(FILE "${CMAKE_CURRENT_SOURCE_DIR}/${FILE}")
+    endif()
+    get_filename_component(FILE "${FILE}" REALPATH)
+
+    sanitizer_check_compiler_flags("-fsanitize-blacklist=${FILE}"
+        "SanitizerBlacklist" "SanBlist")
+endfunction()
+
+function(add_sanitizers)
+    # If no sanitizer is enabled, return immediately.
+    if (NOT (SANITIZE_ADDRESS OR SANITIZE_MEMORY OR SANITIZE_THREAD OR
+        SANITIZE_UNDEFINED))
+        return()
+    endif ()
+
+    foreach (TARGET ${ARGV})
+        # Check if this target will be compiled by exactly one compiler. Other-
+        # wise sanitizers can't be used and a warning should be printed once.
+        get_target_property(TARGET_TYPE ${TARGET} TYPE)
+        if (TARGET_TYPE STREQUAL "INTERFACE_LIBRARY")
+            message(WARNING "Can't use any sanitizers for target ${TARGET}, "
+                    "because it is an interface library and cannot be "
+                    "compiled directly.")
+            return()
+        endif ()
+        sanitizer_target_compilers(${TARGET} TARGET_COMPILER)
+        list(LENGTH TARGET_COMPILER NUM_COMPILERS)
+        if (NUM_COMPILERS GREATER 1)
+            message(WARNING "Can't use any sanitizers for target ${TARGET}, "
+                    "because it will be compiled by incompatible compilers. "
+                    "Target will be compiled without sanitizers.")
+            return()
+
+        elseif (NUM_COMPILERS EQUAL 0)
+            # If the target is compiled by no known compiler, give a warning.
+            message(WARNING "Sanitizers for target ${TARGET} may not be"
+                    " usable, because it uses no or an unknown compiler. "
+                    "This is a false warning for targets using only "
+                    "object lib(s) as input.")
+        endif ()
+
+        # Add sanitizers for target.
+        add_sanitize_address(${TARGET})
+        add_sanitize_thread(${TARGET})
+        add_sanitize_memory(${TARGET})
+        add_sanitize_undefined(${TARGET})
+    endforeach ()
+endfunction(add_sanitizers)

--- a/third-party/sanitizers-cmake/cmake/FindTSan.cmake
+++ b/third-party/sanitizers-cmake/cmake/FindTSan.cmake
@@ -1,0 +1,68 @@
+# The MIT License (MIT)
+#
+# Copyright (c)
+#   2013 Matthew Arsenault
+#   2015-2016 RWTH Aachen University, Federal Republic of Germany
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+option(SANITIZE_THREAD "Enable ThreadSanitizer for sanitized targets." Off)
+
+set(FLAG_CANDIDATES
+    # MSVC uses
+    "/fsanitize=thread"
+    # GNU/Clang
+    "-g -fsanitize=thread"
+)
+
+
+# ThreadSanitizer is not compatible with MemorySanitizer.
+if (SANITIZE_THREAD AND SANITIZE_MEMORY)
+    message(FATAL_ERROR "ThreadSanitizer is not compatible with "
+        "MemorySanitizer.")
+endif ()
+
+
+include(sanitize-helpers)
+
+if (SANITIZE_THREAD)
+  if (NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" AND
+      NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+        message(WARNING "ThreadSanitizer disabled for target ${TARGET} because "
+          "ThreadSanitizer is supported for Linux systems and macOS only.")
+        set(SANITIZE_THREAD Off CACHE BOOL
+            "Enable ThreadSanitizer for sanitized targets." FORCE)
+    elseif (NOT ${CMAKE_SIZEOF_VOID_P} EQUAL 8)
+        message(WARNING "ThreadSanitizer disabled for target ${TARGET} because "
+            "ThreadSanitizer is supported for 64bit systems only.")
+        set(SANITIZE_THREAD Off CACHE BOOL
+            "Enable ThreadSanitizer for sanitized targets." FORCE)
+    else ()
+        sanitizer_check_compiler_flags("${FLAG_CANDIDATES}" "ThreadSanitizer"
+            "TSan")
+    endif ()
+endif ()
+
+function (add_sanitize_thread TARGET)
+    if (NOT SANITIZE_THREAD)
+        return()
+    endif ()
+
+    sanitizer_add_flags(${TARGET} "ThreadSanitizer" "TSan")
+endfunction ()

--- a/third-party/sanitizers-cmake/cmake/FindUBSan.cmake
+++ b/third-party/sanitizers-cmake/cmake/FindUBSan.cmake
@@ -1,0 +1,49 @@
+# The MIT License (MIT)
+#
+# Copyright (c)
+#   2013 Matthew Arsenault
+#   2015-2016 RWTH Aachen University, Federal Republic of Germany
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+option(SANITIZE_UNDEFINED
+    "Enable UndefinedBehaviorSanitizer for sanitized targets." Off)
+
+set(FLAG_CANDIDATES
+    # MSVC uses
+    "/fsanitize=undefined"
+    # GNU/Clang
+    "-g -fsanitize=undefined"
+)
+
+
+include(sanitize-helpers)
+
+if (SANITIZE_UNDEFINED)
+    sanitizer_check_compiler_flags("${FLAG_CANDIDATES}"
+        "UndefinedBehaviorSanitizer" "UBSan")
+endif ()
+
+function (add_sanitize_undefined TARGET)
+    if (NOT SANITIZE_UNDEFINED)
+        return()
+    endif ()
+
+    sanitizer_add_flags(${TARGET} "UndefinedBehaviorSanitizer" "UBSan")
+endfunction ()

--- a/third-party/sanitizers-cmake/cmake/asan-wrapper
+++ b/third-party/sanitizers-cmake/cmake/asan-wrapper
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+# The MIT License (MIT)
+#
+# Copyright (c)
+#   2013 Matthew Arsenault
+#   2015-2016 RWTH Aachen University, Federal Republic of Germany
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# This script is a wrapper for AddressSanitizer. In some special cases you need
+# to preload AddressSanitizer to avoid error messages - e.g. if you're
+# preloading another library to your application. At the moment this script will
+# only do something, if we're running on a Linux platform. OSX might not be
+# affected.
+
+
+# Exit immediately, if platform is not Linux.
+if [ "$(uname)" != "Linux" ]
+then
+    exec $@
+fi
+
+
+# Get the used libasan of the application ($1). If a libasan was found, it will
+# be prepended to LD_PRELOAD.
+libasan=$(ldd $1 | grep libasan | sed "s/^[[:space:]]//" | cut -d' ' -f1)
+if [ -n "$libasan" ]
+then
+    if [ -n "$LD_PRELOAD" ]
+    then
+        export LD_PRELOAD="$libasan:$LD_PRELOAD"
+    else
+        export LD_PRELOAD="$libasan"
+    fi
+fi
+
+# Execute the application.
+exec $@

--- a/third-party/sanitizers-cmake/cmake/sanitize-helpers.cmake
+++ b/third-party/sanitizers-cmake/cmake/sanitize-helpers.cmake
@@ -1,0 +1,178 @@
+# The MIT License (MIT)
+#
+# Copyright (c)
+#   2013 Matthew Arsenault
+#   2015-2016 RWTH Aachen University, Federal Republic of Germany
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# Helper function to get the language of a source file.
+function (sanitizer_lang_of_source FILE RETURN_VAR)
+    get_filename_component(LONGEST_EXT "${FILE}" EXT)
+    # If extension is empty return. This can happen for extensionless headers
+    if("${LONGEST_EXT}" STREQUAL "")
+       set(${RETURN_VAR} "" PARENT_SCOPE)
+       return()
+    endif()
+    # Get shortest extension as some files can have dot in their names
+    string(REGEX REPLACE "^.*(\\.[^.]+)$" "\\1" FILE_EXT ${LONGEST_EXT})
+    string(TOLOWER "${FILE_EXT}" FILE_EXT)
+    string(SUBSTRING "${FILE_EXT}" 1 -1 FILE_EXT)
+
+    get_property(ENABLED_LANGUAGES GLOBAL PROPERTY ENABLED_LANGUAGES)
+    foreach (LANG ${ENABLED_LANGUAGES})
+        list(FIND CMAKE_${LANG}_SOURCE_FILE_EXTENSIONS "${FILE_EXT}" TEMP)
+        if (NOT ${TEMP} EQUAL -1)
+            set(${RETURN_VAR} "${LANG}" PARENT_SCOPE)
+            return()
+        endif ()
+    endforeach()
+
+    set(${RETURN_VAR} "" PARENT_SCOPE)
+endfunction ()
+
+
+# Helper function to get compilers used by a target.
+function (sanitizer_target_compilers TARGET RETURN_VAR)
+    # Check if all sources for target use the same compiler. If a target uses
+    # e.g. C and Fortran mixed and uses different compilers (e.g. clang and
+    # gfortran) this can trigger huge problems, because different compilers may
+    # use different implementations for sanitizers.
+    set(BUFFER "")
+    get_target_property(TSOURCES ${TARGET} SOURCES)
+    foreach (FILE ${TSOURCES})
+        # If expression was found, FILE is a generator-expression for an object
+        # library. Object libraries will be ignored.
+        string(REGEX MATCH "TARGET_OBJECTS:([^ >]+)" _file ${FILE})
+        if ("${_file}" STREQUAL "")
+            sanitizer_lang_of_source(${FILE} LANG)
+            if (LANG)
+                list(APPEND BUFFER ${CMAKE_${LANG}_COMPILER_ID})
+            endif ()
+        endif ()
+    endforeach ()
+
+    list(REMOVE_DUPLICATES BUFFER)
+    set(${RETURN_VAR} "${BUFFER}" PARENT_SCOPE)
+endfunction ()
+
+
+# Helper function to check compiler flags for language compiler.
+function (sanitizer_check_compiler_flag FLAG LANG VARIABLE)
+
+    if (${LANG} STREQUAL "C")
+        include(CheckCCompilerFlag)
+        check_c_compiler_flag("${FLAG}" ${VARIABLE})
+
+    elseif (${LANG} STREQUAL "CXX")
+        include(CheckCXXCompilerFlag)
+        check_cxx_compiler_flag("${FLAG}" ${VARIABLE})
+
+    elseif (${LANG} STREQUAL "Fortran")
+        # CheckFortranCompilerFlag was introduced in CMake 3.x. To be compatible
+        # with older Cmake versions, we will check if this module is present
+        # before we use it. Otherwise we will define Fortran coverage support as
+        # not available.
+        include(CheckFortranCompilerFlag OPTIONAL RESULT_VARIABLE INCLUDED)
+        if (INCLUDED)
+            check_fortran_compiler_flag("${FLAG}" ${VARIABLE})
+        elseif (NOT CMAKE_REQUIRED_QUIET)
+            message(STATUS "Performing Test ${VARIABLE}")
+            message(STATUS "Performing Test ${VARIABLE}"
+                " - Failed (Check not supported)")
+        endif ()
+    endif()
+
+endfunction ()
+
+
+# Helper function to test compiler flags.
+function (sanitizer_check_compiler_flags FLAG_CANDIDATES NAME PREFIX)
+    set(CMAKE_REQUIRED_QUIET ${${PREFIX}_FIND_QUIETLY})
+
+    get_property(ENABLED_LANGUAGES GLOBAL PROPERTY ENABLED_LANGUAGES)
+    foreach (LANG ${ENABLED_LANGUAGES})
+        # Sanitizer flags are not dependend on language, but the used compiler.
+        # So instead of searching flags foreach language, search flags foreach
+        # compiler used.
+        set(COMPILER ${CMAKE_${LANG}_COMPILER_ID})
+        if (COMPILER AND NOT DEFINED ${PREFIX}_${COMPILER}_FLAGS)
+            foreach (FLAG ${FLAG_CANDIDATES})
+                if(NOT CMAKE_REQUIRED_QUIET)
+                    message(STATUS "Try ${COMPILER} ${NAME} flag = [${FLAG}]")
+                endif()
+
+                set(CMAKE_REQUIRED_FLAGS "${FLAG}")
+                unset(${PREFIX}_FLAG_DETECTED CACHE)
+                sanitizer_check_compiler_flag("${FLAG}" ${LANG}
+                    ${PREFIX}_FLAG_DETECTED)
+
+                if (${PREFIX}_FLAG_DETECTED)
+                    # If compiler is a GNU compiler, search for static flag, if
+                    # SANITIZE_LINK_STATIC is enabled.
+                    if (SANITIZE_LINK_STATIC AND (${COMPILER} STREQUAL "GNU"))
+                        string(TOLOWER ${PREFIX} PREFIX_lower)
+                        sanitizer_check_compiler_flag(
+                            "-static-lib${PREFIX_lower}" ${LANG}
+                            ${PREFIX}_STATIC_FLAG_DETECTED)
+
+                        if (${PREFIX}_STATIC_FLAG_DETECTED)
+                            set(FLAG "-static-lib${PREFIX_lower} ${FLAG}")
+                        endif ()
+                    endif ()
+
+                    set(${PREFIX}_${COMPILER}_FLAGS "${FLAG}" CACHE STRING
+                        "${NAME} flags for ${COMPILER} compiler.")
+                    mark_as_advanced(${PREFIX}_${COMPILER}_FLAGS)
+                    break()
+                endif ()
+            endforeach ()
+
+            if (NOT ${PREFIX}_FLAG_DETECTED)
+                set(${PREFIX}_${COMPILER}_FLAGS "" CACHE STRING
+                    "${NAME} flags for ${COMPILER} compiler.")
+                mark_as_advanced(${PREFIX}_${COMPILER}_FLAGS)
+
+                message(WARNING "${NAME} is not available for ${COMPILER} "
+                        "compiler. Targets using this compiler will be "
+                        "compiled without ${NAME}.")
+            endif ()
+        endif ()
+    endforeach ()
+endfunction ()
+
+
+# Helper to assign sanitizer flags for TARGET.
+function (sanitizer_add_flags TARGET NAME PREFIX)
+    # Get list of compilers used by target and check, if sanitizer is available
+    # for this target. Other compiler checks like check for conflicting
+    # compilers will be done in add_sanitizers function.
+    sanitizer_target_compilers(${TARGET} TARGET_COMPILER)
+    list(LENGTH TARGET_COMPILER NUM_COMPILERS)
+    if ("${${PREFIX}_${TARGET_COMPILER}_FLAGS}" STREQUAL "")
+        return()
+    endif()
+
+    separate_arguments(flags_list UNIX_COMMAND "${${PREFIX}_${TARGET_COMPILER}_FLAGS} ${SanBlist_${TARGET_COMPILER}_FLAGS}")
+    target_compile_options(${TARGET} PUBLIC ${flags_list})
+
+    separate_arguments(flags_list UNIX_COMMAND "${${PREFIX}_${TARGET_COMPILER}_FLAGS}")
+    target_link_options(${TARGET} PUBLIC ${flags_list})
+
+endfunction ()

--- a/third-party/sanitizers-cmake/tests/CMakeLists.txt
+++ b/third-party/sanitizers-cmake/tests/CMakeLists.txt
@@ -1,0 +1,67 @@
+# This file is part of CMake-sanitizers.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+#
+# Copyright (c)
+#   2013-2015 Matt Arsenault
+#   2015      RWTH Aachen University, Federal Republic of Germany
+#
+
+# Function to add testcases.
+function(add_testcase TESTNAME SOURCEFILES)
+	# remove ${TESTNAME} from ${ARGV} to use ${ARGV} as ${SOURCEFILES}
+	list(REMOVE_AT ARGV 0)
+
+	# add a new executable
+	add_executable(${TESTNAME} ${ARGV})
+
+	# add a testcase for executable
+	add_test(${TESTNAME} ${TESTNAME})
+endfunction(add_testcase)
+
+# Function to add testcases with asan enabled.
+function(add_sanitized_testcase TESTNAME SOURCEFILES)
+	add_testcase(${TESTNAME} ${SOURCEFILES})
+	add_sanitizers(${TESTNAME})
+endfunction(add_sanitized_testcase)
+
+
+
+set(SANITIZE_ADDRESS TRUE)
+
+#
+# search for sanitizers
+#
+find_package(Sanitizers)
+
+
+#
+# add testcases
+#
+add_sanitized_testcase("asan_test_cpp" asan_test.cpp)
+add_sanitized_testcase("shortest_ext_test_cpp" shortest.ext.test.cpp)
+
+set_tests_properties(
+	"asan_test_cpp"
+	"shortest_ext_test_cpp"
+PROPERTIES
+	WILL_FAIL TRUE
+)
+

--- a/third-party/sanitizers-cmake/tests/asan_test.cpp
+++ b/third-party/sanitizers-cmake/tests/asan_test.cpp
@@ -1,0 +1,40 @@
+/* This file is part of CMake-sanitizers.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *
+ * Copyright (c)
+ *  2013-2015 Matt Arsenault
+ *  2015      RWTH Aachen University, Federal Republic of Germany
+ */
+
+
+int
+main(int argc, char **argv)
+{
+	// Allocate a new array and delete it.
+	int *array = new int[argc + 1];
+	array[argc] = 0;
+	delete[] array;
+
+	/* Access element of the deleted array. This will cause an memory error with
+	 * address sanitizer.
+	 */
+	return array[argc];
+}

--- a/third-party/sanitizers-cmake/tests/shortest.ext.test.cpp
+++ b/third-party/sanitizers-cmake/tests/shortest.ext.test.cpp
@@ -1,0 +1,40 @@
+/* This file is part of CMake-sanitizers.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *
+ * Copyright (c)
+ *  2013-2015 Matt Arsenault
+ *  2015      RWTH Aachen University, Federal Republic of Germany
+ */
+
+
+int
+main(int argc, char **argv)
+{
+	// Allocate a new array and delete it.
+	int *array = new int[argc + 1];
+	array[argc] = 0;
+	delete[] array;
+
+	/* Access element of the deleted array. This will cause an memory error with
+	 * address sanitizer.
+	 */
+	return array[argc];
+}

--- a/tools/gen_descriptor/gen_class_descriptor.php
+++ b/tools/gen_descriptor/gen_class_descriptor.php
@@ -338,7 +338,9 @@ EOF;
  * via cmake/GenStubs.cmake's php_scylladb_generate_arginfo() function.
  */
 
-#include <php.h>
+/* Include the umbrella header so any @cvalue identifier (CASS_*,
+ * PHP_SCYLLADB_VERSION, …) is visible to the arginfo register fn. */
+#include "php_scylladb.h"
 #include <Zend/zend_attributes.h>
 #include "$arginfoHeader"
 #include <Registry/Registry.h>


### PR DESCRIPTION
## Summary

Continues the C++ → C23 migration: adopts the language features the C23 standard added for safety (`nullptr`, `auto`, `constexpr`, `[[attributes]]`, `= {}`), hardens the public API with `[[gnu::nonnull]]` / `[[gnu::pure]]` / `[[gnu::const]]` / `[[nodiscard]]`, and pushes more correctness into the gen_stub layer so the generated arginfo files stop being a magic-number duplicator.

## Highlights

### Correctness (these fix latent bugs)

- **`@not-serializable` on 29 native-pointer-holding classes** (Cluster/Session/Statement/Future/Rows/TimestampGen/SSL/RetryPolicy/Database meta). Without this, default `serialize($cluster) → unserialize(...)` produces an object with no native handle; the next method call dereferences uninitialized memory. Now PHP refuses the operation explicitly.
- **`typeof` in `SAFE_STR` / `SAFE_ZEND_STRING`** — the prior `((a) ? a : "")` evaluated `a` twice; any side-effecting argument was UB.
- **`ulong` portability** — removed the project-local `typedef unsigned long ulong;` and migrated 8 call sites to `zend_ulong` (the PHP-canonical type). `ulong` isn't POSIX and needs `_BSD_SOURCE` on glibc.

### Stub-driven codegen

- **`@cvalue` for all enum-backed constants** in `Cassandra.stub.php` — `CONSISTENCY_*`, `VERIFY_*`, `BATCH_*`, `LOG_*`, `VERSION`. The generated arginfo emits `ZVAL_LONG(&val, CASS_CONSISTENCY_ANY)` instead of `ZVAL_LONG(&val, 0x0)`; values stay synchronized with cassandra.h automatically.
- **`@not-serializable`** wired into 29 stubs (see above).

### Attribute hardening

- `[[nodiscard, gnu::nonnull(...)]]` on public `*_instantiate` / `*_initialize` APIs (DateTime, RetryPolicy, SSLOptions, plus utility headers).
- `[[gnu::const]] exception_class(CassError)` — pure mapping, CSE-able.
- `[[gnu::pure]]` / `[[gnu::const]]` on the FNV cache-key helpers.
- `PHP_SCYLLADB_CLEANUP(fn)` macro wrapping `__attribute__((cleanup(...)))`. Adopted at 10 sites in `bind_argument_by_index` / `bind_argument_by_name` — removes the `CassError rc; ...; free(data); CHECK_RESULT(rc);` ladder and keeps exception safety.

### Language modernization

- `nullptr` instead of `NULL` across hand-written sources (~370 sites).
- `auto` (C23) where the type is spelled twice: `auto self = PHP_SCYLLADB_GET_X(zv);` (~370 sites across 49 files).
- `[[maybe_unused]]` on parameter declarations instead of `(void)param;` suppressions.
- `= {}` (C23) replacing `= {0}` at the 9 sites that had it.
- `static constexpr` for true compile-time constants where the value isn't consumed by the preprocessor (FNV table, default consistency).

### Dispatcher refactor

- `bind_argument_by_index` / `bind_argument_by_name`: `switch (Z_TYPE_P(value))` replaces the if-chain over primitives. One read, one jump table. Object branch unchanged.

### Build / lint policy

- `.clang-tidy` enables `modernize-use-nullptr`, `modernize-use-bool-literals`, `modernize-macro-to-enum`, plus a handful of `readability-*` checks now that the codebase is C23-ready.
- `cmake/TargetOptimizations.cmake`: C standard bumped to `c_std_23`; C++ stays at C++20 for residual `.cpp` files until ported.
- Dropped dead `#ifdef __cplusplus / extern "C"` guards in headers we own (no C++ TUs exist in `src/`). PHP-idiomatic `BEGIN_EXTERN_C` / `END_EXTERN_C` kept where the convention applies.

## What's deliberately NOT in this PR

- No mass zero-init of bare `zval x;` locals — they're immediately written by `ZVAL_NULL` / `array_init` / etc., which don't read prior state. Mass `= {}` would emit dead xors.
- No new `*_arginfo.h` files committed — they're gitignored and regenerated by `tools/gen_stub/gen_arginfo.sh` at build time.
- No `@frameless-function` / `@compile-time-eval` — apply only to global functions, of which we have none.

## Test plan

Build verification was not run locally; the toolchain needs libuv + cpp-driver + a compiled PHP source tree + a running ScyllaDB. CI will exercise the full matrix. Highest-attention items:

- [ ] `cmake --preset DebugPHP8.4NTS && cmake --build out/DebugPHP8.4NTS` — compiles clean across the matrix.
- [ ] `./scripts/run-scylladb.sh && composer install && php ./vendor/bin/pest` — the test suite covers the `bind_argument_*` paths that got the dispatcher refactor and the cleanup-attribute adoption.
- [ ] Spot-check: `var_dump(unserialize(serialize($cluster)))` should now throw `Serialization of 'Cassandra\DefaultCluster' is not allowed` instead of producing a half-constructed object.
- [ ] `[[gnu::nonnull]]` annotations may surface new compiler warnings at internal call sites where a `nullptr` flows in unconditionally — those are real bugs worth reviewing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)