### PR TITLE
fix(RetryPolicy): correct class entry and policy leak in *_instantiate helpers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -265,11 +265,20 @@ jobs:
         ports:
           - 9042:9042
 
+    # 8.5 only, deliberately. This job LD_PRELOADs the ASan runtime into a
+    # stock (non-instrumented) setup-php binary, and PHP <= 8.4 dlopen()s
+    # shared extensions with RTLD_DEEPBIND, which the sanitizer runtime
+    # refuses to work with (google/sanitizers#611). With abort_on_error=1
+    # that is a SIGABRT during startup — on opcache.so, then mysqlnd.so, and
+    # ultimately on cassandra.so itself — so the 8.4 leg aborted before it
+    # could run a single test and had been permanently red while guarding
+    # nothing. It is not fixable by disabling individual extensions: the
+    # extension under test is itself a shared object. 8.5 does not pass
+    # RTLD_DEEPBIND and runs the full suite clean.
     strategy:
       fail-fast: false
       matrix:
         php:
-          - "8.4"
           - "8.5"
 
     steps:
@@ -330,21 +339,6 @@ jobs:
       - name: Install Composer dependencies
         run: |
           composer install --no-ansi --no-interaction --no-progress --prefer-dist
-
-      # PHP dlopen()s zend_extensions with RTLD_DEEPBIND, which the ASan runtime
-      # refuses to work with (google/sanitizers#611). Combined with
-      # abort_on_error=1 below that kills the process before a single test runs,
-      # so the job "failed" without ever exercising the extension. setup-php
-      # enables opcache on 8.4 but not 8.5 — that is the whole difference
-      # between the two matrix legs. opcache is irrelevant to what this job
-      # guards, so drop it rather than weaken ASAN_OPTIONS.
-      - name: Disable opcache (incompatible with the ASan runtime)
-        run: |
-          sudo rm -fv /etc/php/${{ matrix.php }}/cli/conf.d/*opcache*.ini
-          php -r 'if (extension_loaded("Zend OPcache")) {
-            fwrite(STDERR, "opcache is still loaded; ASan will abort at startup\n");
-            exit(1);
-          }'
 
       - name: Run tests under AddressSanitizer
         # The extension is ASan-instrumented but the setup-php binary is not, so

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -331,6 +331,21 @@ jobs:
         run: |
           composer install --no-ansi --no-interaction --no-progress --prefer-dist
 
+      # PHP dlopen()s zend_extensions with RTLD_DEEPBIND, which the ASan runtime
+      # refuses to work with (google/sanitizers#611). Combined with
+      # abort_on_error=1 below that kills the process before a single test runs,
+      # so the job "failed" without ever exercising the extension. setup-php
+      # enables opcache on 8.4 but not 8.5 — that is the whole difference
+      # between the two matrix legs. opcache is irrelevant to what this job
+      # guards, so drop it rather than weaken ASAN_OPTIONS.
+      - name: Disable opcache (incompatible with the ASan runtime)
+        run: |
+          sudo rm -fv /etc/php/${{ matrix.php }}/cli/conf.d/*opcache*.ini
+          php -r 'if (extension_loaded("Zend OPcache")) {
+            fwrite(STDERR, "opcache is still loaded; ASan will abort at startup\n");
+            exit(1);
+          }'
+
       - name: Run tests under AddressSanitizer
         # The extension is ASan-instrumented but the setup-php binary is not, so
         # the ASan runtime is LD_PRELOADed and USE_ZEND_ALLOC=0 routes Zend

--- a/src/RetryPolicy/DefaultPolicy.c
+++ b/src/RetryPolicy/DefaultPolicy.c
@@ -22,17 +22,11 @@ extern zend_object_handlers php_scylladb_retry_policy_default_policy_handlers;
 
 PHP_SCYLLADB_API php_scylladb_retry_policy *php_scylladb_retry_policy_default_policy_instantiate(zval *dst)
 {
-  zval val;
-
-  if (object_init_ex(&val, php_scylladb_retry_policy_default_policy_ce) == FAILURE) {
+  if (object_init_ex(dst, php_scylladb_retry_policy_default_policy_ce) == FAILURE) {
     return nullptr;
   }
 
-  ZVAL_OBJ(dst, Z_OBJ(val));
-
-  php_scylladb_retry_policy *obj = PHP_SCYLLADB_OBJ_FETCH(php_scylladb_retry_policy, Z_OBJ_P(dst));
-  obj->policy = cass_retry_policy_default_new();
-  return obj;
+  return PHP_SCYLLADB_OBJ_FETCH(php_scylladb_retry_policy, Z_OBJ_P(dst));
 }
 
 

--- a/src/RetryPolicy/DowngradingConsistency.c
+++ b/src/RetryPolicy/DowngradingConsistency.c
@@ -22,17 +22,11 @@ extern zend_object_handlers php_scylladb_retry_policy_downgrading_consistency_ha
 
 PHP_SCYLLADB_API php_scylladb_retry_policy *php_scylladb_retry_policy_downgrading_consistency_instantiate(zval *dst)
 {
-  zval val;
-
-  if (object_init_ex(&val, php_scylladb_retry_policy_default_policy_ce) == FAILURE) {
+  if (object_init_ex(dst, php_scylladb_retry_policy_downgrading_consistency_ce) == FAILURE) {
     return nullptr;
   }
 
-  ZVAL_OBJ(dst, Z_OBJ(val));
-
-  php_scylladb_retry_policy *obj = PHP_SCYLLADB_OBJ_FETCH(php_scylladb_retry_policy, Z_OBJ_P(dst));
-  obj->policy = cass_retry_policy_downgrading_consistency_new();
-  return obj;
+  return PHP_SCYLLADB_OBJ_FETCH(php_scylladb_retry_policy, Z_OBJ_P(dst));
 }
 
 void php_scylladb_retry_policy_downgrading_consistency_free(zend_object *object)

--- a/src/RetryPolicy/Fallthrough.c
+++ b/src/RetryPolicy/Fallthrough.c
@@ -30,17 +30,11 @@ extern zend_object_handlers php_scylladb_retry_policy_fallthrough_handlers;
 
 PHP_SCYLLADB_API php_scylladb_retry_policy *php_scylladb_retry_policy_fallthrough_instantiate(zval *dst)
 {
-  zval val;
-
-  if (object_init_ex(&val, php_scylladb_retry_policy_default_policy_ce) == FAILURE) {
+  if (object_init_ex(dst, php_scylladb_retry_policy_fallthrough_ce) == FAILURE) {
     return nullptr;
   }
 
-  ZVAL_OBJ(dst, Z_OBJ(val));
-
-  php_scylladb_retry_policy *obj = PHP_SCYLLADB_OBJ_FETCH(php_scylladb_retry_policy, Z_OBJ_P(dst));
-  obj->policy = cass_retry_policy_fallthrough_new();
-  return obj;
+  return PHP_SCYLLADB_OBJ_FETCH(php_scylladb_retry_policy, Z_OBJ_P(dst));
 }
 
 void php_scylladb_retry_policy_fallthrough_free(zend_object *object)

--- a/src/RetryPolicy/Logging.c
+++ b/src/RetryPolicy/Logging.c
@@ -63,13 +63,13 @@ php_scylladb_retry_policy_logging_new(zend_class_entry *ce)
 
 PHP_SCYLLADB_API php_scylladb_retry_policy *php_scylladb_retry_policy_logging_instantiate(zval *dst, php_scylladb_retry_policy *retry_policy)
 {
-  zval val;
-
-  if (object_init_ex(&val, php_scylladb_retry_policy_default_policy_ce) == FAILURE) {
+  if (retry_policy->policy == nullptr) {
     return nullptr;
   }
 
-  ZVAL_OBJ(dst, Z_OBJ(val));
+  if (object_init_ex(dst, php_scylladb_retry_policy_logging_ce) == FAILURE) {
+    return nullptr;
+  }
 
   php_scylladb_retry_policy *obj = PHP_SCYLLADB_OBJ_FETCH(php_scylladb_retry_policy, Z_OBJ_P(dst));
   obj->policy = cass_retry_policy_logging_new(retry_policy->policy);


### PR DESCRIPTION
## What

Fixes two bugs in each of the four `php_scylladb_retry_policy_*_instantiate()` helpers declared in `include/RetryPolicy/RetryPolicy.h`, plus an unrelated CI failure that was blocking this branch (see **CI** below).

### 1. Leaked `CassRetryPolicy`

`object_init_ex()` runs the class's `create_object` handler (e.g. `php_scylladb_retry_policy_default_policy_new`), which **already** assigns `self->policy = cass_retry_policy_default_new()`. The instantiate function then overwrote `obj->policy` with a second freshly created policy — the first one's refcount never dropped to 0.

### 2. Wrong class entry

`DowngradingConsistency.c`, `Fallthrough.c` and `Logging.c` all passed `php_scylladb_retry_policy_default_policy_ce` to `object_init_ex()` instead of their own. The returned PHP object was a `DefaultPolicy` — wrong class, wrong handlers — while `->policy` held a downgrading/fallthrough/logging `CassRetryPolicy`. On free that runs `php_scylladb_retry_policy_default_policy_free` over a foreign policy.

## How

Each helper now passes its own `*_ce` and lets `create_object` own the policy:

```c
if (object_init_ex(dst, php_scylladb_retry_policy_<kind>_ce) == FAILURE) {
  return nullptr;
}
return PHP_SCYLLADB_OBJ_FETCH(php_scylladb_retry_policy, Z_OBJ_P(dst));
```

`Logging` is the exception — its `create_object` sets `policy = nullptr`, so it must still assign `cass_retry_policy_logging_new(retry_policy->policy)`.

The `zval val` temporary plus `ZVAL_OBJ(dst, Z_OBJ(val))` is gone; `object_init_ex()` writes into `dst` directly.

## Beyond the reported bugs

`php_scylladb_retry_policy_logging_instantiate()` now rejects a child whose `->policy` is `nullptr`. `Logging::__construct` is the only thing that sets `policy` on a Logging object, so a `newInstanceWithoutConstructor()` instance passed as the child would have handed `nullptr` to `cass_retry_policy_logging_new()`. The `gnu::nonnull(1, 2)` attribute only constrains the pointers, not what they point at.

## CI

**This part is unrelated to the RetryPolicy change and can be split out if you'd prefer** — the workflow commits cherry-pick cleanly onto `trunk`.

`ASan: PHP 8.4-nts / scylladb` has been failing on `trunk` without executing a single test:

```
==9714==You are trying to dlopen /usr/lib/php/20240924/opcache.so with RTLD_DEEPBIND
flag which is incompatible with sanitizer runtime
9714 Aborted (core dumped)     → exit 134
```

The job LD_PRELOADs the ASan runtime into a stock, un-instrumented setup-php binary. PHP <= 8.4 `dlopen()`s shared extensions with `RTLD_DEEPBIND`, which the sanitizer runtime refuses to work with ([google/sanitizers#611](https://github.com/google/sanitizers/issues/611)); `abort_on_error=1` turns that into a SIGABRT at startup.

Disabling opcache is *not* a fix — I tried it first and the abort simply moved to `mysqlnd.so`, and would have moved again to `cassandra.so`. The extension under test is itself a shared object, so no amount of pruning `conf.d` makes the 8.4 leg able to load it.

PHP 8.5 does not pass `RTLD_DEEPBIND`, which is the entire difference between the two matrix legs. The ASan matrix is now 8.5-only, with the reasoning recorded in the workflow. **Tradeoff:** this gives up ASan coverage on 8.4 — coverage the repo never actually had, since that leg has been aborting. Restoring it means building PHP 8.4 with `-fsanitize=address` in CI instead of using setup-php's binary; happy to open a follow-up issue.

`PHP 8.3-ts / scylladb` also failed on the first run — 862 passed, 0 failures, then exit 2 with no output after the summary. It passed on both subsequent runs and on the two preceding `trunk` runs. Treated as a flake, not diagnosed.

## Verification

- Local build clean: `cmake --preset DebugPHP8.4NTS && cmake --build out/DebugPHP8.4NTS` — 309/309, no new warnings.
- All four classes construct and destruct without crashing under `gc_collect_cycles()`.
- CI green: 28/28 checks passing, including `ASan: PHP 8.5-nts / scylladb` with **861 passed (12368 assertions)** and no sanitizer reports.
- **Not verified:** the `_instantiate` helpers themselves. They are unreachable from PHP, so nothing short of a C-level test can exercise them — the fix is reviewed by inspection against the `create_object` handlers in the same files.

## For the reviewer

**These helpers have no in-tree callers.** They are declared, defined and exported as `PHP_SCYLLADB_API`, and nothing calls them — which is exactly how a wrong class entry survived in three of four files. Deleting them and their declarations is a defensible alternative to this PR; I fixed rather than deleted because removing exported symbols could break an out-of-tree consumer. Happy to convert this to a deletion if you'd prefer.