### PR TITLE
Prepare for PHP 8.6: drop removed internal APIs, add 8.6 build presets

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -13,10 +13,10 @@
                 "ENABLE_SANITIZERS": "ON",
                 "SANITIZE_UNDEFINED": "ON",
                 "SANITIZE_ADDRESS": "ON",
-                "PHP_DRIVER_BACKEND": "scylla-cpp",
+                "PHP_SCYLLADB_BACKEND": "scylla-cpp",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.3",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "ON"
             }
         },
@@ -32,10 +32,10 @@
                 "ENABLE_SANITIZERS": "ON",
                 "SANITIZE_UNDEFINED": "ON",
                 "SANITIZE_ADDRESS": "ON",
-                "PHP_DRIVER_BACKEND": "scylla-cpp",
+                "PHP_SCYLLADB_BACKEND": "scylla-cpp",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.3",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "OFF"
             }
         },
@@ -51,10 +51,10 @@
                 "ENABLE_SANITIZERS": "ON",
                 "SANITIZE_UNDEFINED": "ON",
                 "SANITIZE_ADDRESS": "ON",
-                "PHP_DRIVER_BACKEND": "cassandra",
+                "PHP_SCYLLADB_BACKEND": "cassandra",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.3",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "ON"
             }
         },
@@ -70,10 +70,10 @@
                 "ENABLE_SANITIZERS": "ON",
                 "SANITIZE_UNDEFINED": "ON",
                 "SANITIZE_ADDRESS": "ON",
-                "PHP_DRIVER_BACKEND": "cassandra",
+                "PHP_SCYLLADB_BACKEND": "cassandra",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.3",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "OFF"
             }
         },
@@ -89,10 +89,10 @@
                 "ENABLE_SANITIZERS": "ON",
                 "SANITIZE_UNDEFINED": "ON",
                 "SANITIZE_ADDRESS": "ON",
-                "PHP_DRIVER_BACKEND": "scylla-rust",
+                "PHP_SCYLLADB_BACKEND": "scylla-rust",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.3",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "ON"
             }
         },
@@ -108,10 +108,10 @@
                 "ENABLE_SANITIZERS": "ON",
                 "SANITIZE_UNDEFINED": "ON",
                 "SANITIZE_ADDRESS": "ON",
-                "PHP_DRIVER_BACKEND": "scylla-rust",
+                "PHP_SCYLLADB_BACKEND": "scylla-rust",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.3",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "OFF"
             }
         },
@@ -127,10 +127,10 @@
                 "ENABLE_SANITIZERS": "OFF",
                 "SANITIZE_UNDEFINED": "OFF",
                 "SANITIZE_ADDRESS": "OFF",
-                "PHP_DRIVER_BACKEND": "scylla-cpp",
+                "PHP_SCYLLADB_BACKEND": "scylla-cpp",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.3",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "ON"
             }
         },
@@ -146,10 +146,10 @@
                 "ENABLE_SANITIZERS": "OFF",
                 "SANITIZE_UNDEFINED": "OFF",
                 "SANITIZE_ADDRESS": "OFF",
-                "PHP_DRIVER_BACKEND": "scylla-cpp",
+                "PHP_SCYLLADB_BACKEND": "scylla-cpp",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.3",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "OFF"
             }
         },
@@ -165,10 +165,10 @@
                 "ENABLE_SANITIZERS": "OFF",
                 "SANITIZE_UNDEFINED": "OFF",
                 "SANITIZE_ADDRESS": "OFF",
-                "PHP_DRIVER_BACKEND": "cassandra",
+                "PHP_SCYLLADB_BACKEND": "cassandra",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.3",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "ON"
             }
         },
@@ -184,10 +184,10 @@
                 "ENABLE_SANITIZERS": "OFF",
                 "SANITIZE_UNDEFINED": "OFF",
                 "SANITIZE_ADDRESS": "OFF",
-                "PHP_DRIVER_BACKEND": "cassandra",
+                "PHP_SCYLLADB_BACKEND": "cassandra",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.3",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "OFF"
             }
         },
@@ -203,10 +203,10 @@
                 "ENABLE_SANITIZERS": "OFF",
                 "SANITIZE_UNDEFINED": "OFF",
                 "SANITIZE_ADDRESS": "OFF",
-                "PHP_DRIVER_BACKEND": "scylla-rust",
+                "PHP_SCYLLADB_BACKEND": "scylla-rust",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.3",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "ON"
             }
         },
@@ -222,10 +222,10 @@
                 "ENABLE_SANITIZERS": "OFF",
                 "SANITIZE_UNDEFINED": "OFF",
                 "SANITIZE_ADDRESS": "OFF",
-                "PHP_DRIVER_BACKEND": "scylla-rust",
+                "PHP_SCYLLADB_BACKEND": "scylla-rust",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.3",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "OFF"
             }
         },
@@ -241,10 +241,10 @@
                 "ENABLE_SANITIZERS": "OFF",
                 "SANITIZE_UNDEFINED": "OFF",
                 "SANITIZE_ADDRESS": "OFF",
-                "PHP_DRIVER_BACKEND": "scylla-cpp",
+                "PHP_SCYLLADB_BACKEND": "scylla-cpp",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.3",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "ON"
             }
         },
@@ -260,10 +260,10 @@
                 "ENABLE_SANITIZERS": "OFF",
                 "SANITIZE_UNDEFINED": "OFF",
                 "SANITIZE_ADDRESS": "OFF",
-                "PHP_DRIVER_BACKEND": "scylla-cpp",
+                "PHP_SCYLLADB_BACKEND": "scylla-cpp",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.3",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "OFF"
             }
         },
@@ -279,10 +279,10 @@
                 "ENABLE_SANITIZERS": "OFF",
                 "SANITIZE_UNDEFINED": "OFF",
                 "SANITIZE_ADDRESS": "OFF",
-                "PHP_DRIVER_BACKEND": "cassandra",
+                "PHP_SCYLLADB_BACKEND": "cassandra",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.3",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "ON"
             }
         },
@@ -298,10 +298,10 @@
                 "ENABLE_SANITIZERS": "OFF",
                 "SANITIZE_UNDEFINED": "OFF",
                 "SANITIZE_ADDRESS": "OFF",
-                "PHP_DRIVER_BACKEND": "cassandra",
+                "PHP_SCYLLADB_BACKEND": "cassandra",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.3",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "OFF"
             }
         },
@@ -317,10 +317,10 @@
                 "ENABLE_SANITIZERS": "OFF",
                 "SANITIZE_UNDEFINED": "OFF",
                 "SANITIZE_ADDRESS": "OFF",
-                "PHP_DRIVER_BACKEND": "scylla-rust",
+                "PHP_SCYLLADB_BACKEND": "scylla-rust",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.3",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "ON"
             }
         },
@@ -336,10 +336,10 @@
                 "ENABLE_SANITIZERS": "OFF",
                 "SANITIZE_UNDEFINED": "OFF",
                 "SANITIZE_ADDRESS": "OFF",
-                "PHP_DRIVER_BACKEND": "scylla-rust",
+                "PHP_SCYLLADB_BACKEND": "scylla-rust",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.3",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "OFF"
             }
         },
@@ -355,10 +355,10 @@
                 "ENABLE_SANITIZERS": "ON",
                 "SANITIZE_UNDEFINED": "ON",
                 "SANITIZE_ADDRESS": "ON",
-                "PHP_DRIVER_BACKEND": "scylla-cpp",
+                "PHP_SCYLLADB_BACKEND": "scylla-cpp",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.4",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "ON"
             }
         },
@@ -374,10 +374,10 @@
                 "ENABLE_SANITIZERS": "ON",
                 "SANITIZE_UNDEFINED": "ON",
                 "SANITIZE_ADDRESS": "ON",
-                "PHP_DRIVER_BACKEND": "scylla-cpp",
+                "PHP_SCYLLADB_BACKEND": "scylla-cpp",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.4",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "OFF"
             }
         },
@@ -393,10 +393,10 @@
                 "ENABLE_SANITIZERS": "ON",
                 "SANITIZE_UNDEFINED": "ON",
                 "SANITIZE_ADDRESS": "ON",
-                "PHP_DRIVER_BACKEND": "cassandra",
+                "PHP_SCYLLADB_BACKEND": "cassandra",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.4",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "ON"
             }
         },
@@ -412,10 +412,10 @@
                 "ENABLE_SANITIZERS": "ON",
                 "SANITIZE_UNDEFINED": "ON",
                 "SANITIZE_ADDRESS": "ON",
-                "PHP_DRIVER_BACKEND": "cassandra",
+                "PHP_SCYLLADB_BACKEND": "cassandra",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.4",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "OFF"
             }
         },
@@ -431,10 +431,10 @@
                 "ENABLE_SANITIZERS": "ON",
                 "SANITIZE_UNDEFINED": "ON",
                 "SANITIZE_ADDRESS": "ON",
-                "PHP_DRIVER_BACKEND": "scylla-rust",
+                "PHP_SCYLLADB_BACKEND": "scylla-rust",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.4",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "ON"
             }
         },
@@ -450,10 +450,10 @@
                 "ENABLE_SANITIZERS": "ON",
                 "SANITIZE_UNDEFINED": "ON",
                 "SANITIZE_ADDRESS": "ON",
-                "PHP_DRIVER_BACKEND": "scylla-rust",
+                "PHP_SCYLLADB_BACKEND": "scylla-rust",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.4",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "OFF"
             }
         },
@@ -469,10 +469,10 @@
                 "ENABLE_SANITIZERS": "OFF",
                 "SANITIZE_UNDEFINED": "OFF",
                 "SANITIZE_ADDRESS": "OFF",
-                "PHP_DRIVER_BACKEND": "scylla-cpp",
+                "PHP_SCYLLADB_BACKEND": "scylla-cpp",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.4",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "ON"
             }
         },
@@ -488,10 +488,10 @@
                 "ENABLE_SANITIZERS": "OFF",
                 "SANITIZE_UNDEFINED": "OFF",
                 "SANITIZE_ADDRESS": "OFF",
-                "PHP_DRIVER_BACKEND": "scylla-cpp",
+                "PHP_SCYLLADB_BACKEND": "scylla-cpp",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.4",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "OFF"
             }
         },
@@ -507,10 +507,10 @@
                 "ENABLE_SANITIZERS": "OFF",
                 "SANITIZE_UNDEFINED": "OFF",
                 "SANITIZE_ADDRESS": "OFF",
-                "PHP_DRIVER_BACKEND": "cassandra",
+                "PHP_SCYLLADB_BACKEND": "cassandra",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.4",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "ON"
             }
         },
@@ -526,10 +526,10 @@
                 "ENABLE_SANITIZERS": "OFF",
                 "SANITIZE_UNDEFINED": "OFF",
                 "SANITIZE_ADDRESS": "OFF",
-                "PHP_DRIVER_BACKEND": "cassandra",
+                "PHP_SCYLLADB_BACKEND": "cassandra",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.4",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "OFF"
             }
         },
@@ -545,10 +545,10 @@
                 "ENABLE_SANITIZERS": "OFF",
                 "SANITIZE_UNDEFINED": "OFF",
                 "SANITIZE_ADDRESS": "OFF",
-                "PHP_DRIVER_BACKEND": "scylla-rust",
+                "PHP_SCYLLADB_BACKEND": "scylla-rust",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.4",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "ON"
             }
         },
@@ -564,10 +564,10 @@
                 "ENABLE_SANITIZERS": "OFF",
                 "SANITIZE_UNDEFINED": "OFF",
                 "SANITIZE_ADDRESS": "OFF",
-                "PHP_DRIVER_BACKEND": "scylla-rust",
+                "PHP_SCYLLADB_BACKEND": "scylla-rust",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.4",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "OFF"
             }
         },
@@ -583,10 +583,10 @@
                 "ENABLE_SANITIZERS": "OFF",
                 "SANITIZE_UNDEFINED": "OFF",
                 "SANITIZE_ADDRESS": "OFF",
-                "PHP_DRIVER_BACKEND": "scylla-cpp",
+                "PHP_SCYLLADB_BACKEND": "scylla-cpp",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.4",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "ON"
             }
         },
@@ -602,10 +602,10 @@
                 "ENABLE_SANITIZERS": "OFF",
                 "SANITIZE_UNDEFINED": "OFF",
                 "SANITIZE_ADDRESS": "OFF",
-                "PHP_DRIVER_BACKEND": "scylla-cpp",
+                "PHP_SCYLLADB_BACKEND": "scylla-cpp",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.4",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "OFF"
             }
         },
@@ -621,10 +621,10 @@
                 "ENABLE_SANITIZERS": "OFF",
                 "SANITIZE_UNDEFINED": "OFF",
                 "SANITIZE_ADDRESS": "OFF",
-                "PHP_DRIVER_BACKEND": "cassandra",
+                "PHP_SCYLLADB_BACKEND": "cassandra",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.4",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "ON"
             }
         },
@@ -640,10 +640,10 @@
                 "ENABLE_SANITIZERS": "OFF",
                 "SANITIZE_UNDEFINED": "OFF",
                 "SANITIZE_ADDRESS": "OFF",
-                "PHP_DRIVER_BACKEND": "cassandra",
+                "PHP_SCYLLADB_BACKEND": "cassandra",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.4",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "OFF"
             }
         },
@@ -659,10 +659,10 @@
                 "ENABLE_SANITIZERS": "OFF",
                 "SANITIZE_UNDEFINED": "OFF",
                 "SANITIZE_ADDRESS": "OFF",
-                "PHP_DRIVER_BACKEND": "scylla-rust",
+                "PHP_SCYLLADB_BACKEND": "scylla-rust",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.4",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "ON"
             }
         },
@@ -678,10 +678,10 @@
                 "ENABLE_SANITIZERS": "OFF",
                 "SANITIZE_UNDEFINED": "OFF",
                 "SANITIZE_ADDRESS": "OFF",
-                "PHP_DRIVER_BACKEND": "scylla-rust",
+                "PHP_SCYLLADB_BACKEND": "scylla-rust",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.4",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "OFF"
             }
         },
@@ -697,10 +697,10 @@
                 "ENABLE_SANITIZERS": "ON",
                 "SANITIZE_UNDEFINED": "ON",
                 "SANITIZE_ADDRESS": "ON",
-                "PHP_DRIVER_BACKEND": "scylla-cpp",
+                "PHP_SCYLLADB_BACKEND": "scylla-cpp",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.5",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "ON"
             }
         },
@@ -716,10 +716,10 @@
                 "ENABLE_SANITIZERS": "ON",
                 "SANITIZE_UNDEFINED": "ON",
                 "SANITIZE_ADDRESS": "ON",
-                "PHP_DRIVER_BACKEND": "scylla-cpp",
+                "PHP_SCYLLADB_BACKEND": "scylla-cpp",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.5",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "OFF"
             }
         },
@@ -735,10 +735,10 @@
                 "ENABLE_SANITIZERS": "ON",
                 "SANITIZE_UNDEFINED": "ON",
                 "SANITIZE_ADDRESS": "ON",
-                "PHP_DRIVER_BACKEND": "cassandra",
+                "PHP_SCYLLADB_BACKEND": "cassandra",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.5",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "ON"
             }
         },
@@ -754,10 +754,10 @@
                 "ENABLE_SANITIZERS": "ON",
                 "SANITIZE_UNDEFINED": "ON",
                 "SANITIZE_ADDRESS": "ON",
-                "PHP_DRIVER_BACKEND": "cassandra",
+                "PHP_SCYLLADB_BACKEND": "cassandra",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.5",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "OFF"
             }
         },
@@ -773,10 +773,10 @@
                 "ENABLE_SANITIZERS": "ON",
                 "SANITIZE_UNDEFINED": "ON",
                 "SANITIZE_ADDRESS": "ON",
-                "PHP_DRIVER_BACKEND": "scylla-rust",
+                "PHP_SCYLLADB_BACKEND": "scylla-rust",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.5",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "ON"
             }
         },
@@ -792,10 +792,10 @@
                 "ENABLE_SANITIZERS": "ON",
                 "SANITIZE_UNDEFINED": "ON",
                 "SANITIZE_ADDRESS": "ON",
-                "PHP_DRIVER_BACKEND": "scylla-rust",
+                "PHP_SCYLLADB_BACKEND": "scylla-rust",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.5",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "OFF"
             }
         },
@@ -811,10 +811,10 @@
                 "ENABLE_SANITIZERS": "OFF",
                 "SANITIZE_UNDEFINED": "OFF",
                 "SANITIZE_ADDRESS": "OFF",
-                "PHP_DRIVER_BACKEND": "scylla-cpp",
+                "PHP_SCYLLADB_BACKEND": "scylla-cpp",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.5",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "ON"
             }
         },
@@ -830,10 +830,10 @@
                 "ENABLE_SANITIZERS": "OFF",
                 "SANITIZE_UNDEFINED": "OFF",
                 "SANITIZE_ADDRESS": "OFF",
-                "PHP_DRIVER_BACKEND": "scylla-cpp",
+                "PHP_SCYLLADB_BACKEND": "scylla-cpp",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.5",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "OFF"
             }
         },
@@ -849,10 +849,10 @@
                 "ENABLE_SANITIZERS": "OFF",
                 "SANITIZE_UNDEFINED": "OFF",
                 "SANITIZE_ADDRESS": "OFF",
-                "PHP_DRIVER_BACKEND": "cassandra",
+                "PHP_SCYLLADB_BACKEND": "cassandra",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.5",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "ON"
             }
         },
@@ -868,10 +868,10 @@
                 "ENABLE_SANITIZERS": "OFF",
                 "SANITIZE_UNDEFINED": "OFF",
                 "SANITIZE_ADDRESS": "OFF",
-                "PHP_DRIVER_BACKEND": "cassandra",
+                "PHP_SCYLLADB_BACKEND": "cassandra",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.5",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "OFF"
             }
         },
@@ -887,10 +887,10 @@
                 "ENABLE_SANITIZERS": "OFF",
                 "SANITIZE_UNDEFINED": "OFF",
                 "SANITIZE_ADDRESS": "OFF",
-                "PHP_DRIVER_BACKEND": "scylla-rust",
+                "PHP_SCYLLADB_BACKEND": "scylla-rust",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.5",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "ON"
             }
         },
@@ -906,10 +906,10 @@
                 "ENABLE_SANITIZERS": "OFF",
                 "SANITIZE_UNDEFINED": "OFF",
                 "SANITIZE_ADDRESS": "OFF",
-                "PHP_DRIVER_BACKEND": "scylla-rust",
+                "PHP_SCYLLADB_BACKEND": "scylla-rust",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.5",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "OFF"
             }
         },
@@ -925,10 +925,10 @@
                 "ENABLE_SANITIZERS": "OFF",
                 "SANITIZE_UNDEFINED": "OFF",
                 "SANITIZE_ADDRESS": "OFF",
-                "PHP_DRIVER_BACKEND": "scylla-cpp",
+                "PHP_SCYLLADB_BACKEND": "scylla-cpp",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.5",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "ON"
             }
         },
@@ -944,10 +944,10 @@
                 "ENABLE_SANITIZERS": "OFF",
                 "SANITIZE_UNDEFINED": "OFF",
                 "SANITIZE_ADDRESS": "OFF",
-                "PHP_DRIVER_BACKEND": "scylla-cpp",
+                "PHP_SCYLLADB_BACKEND": "scylla-cpp",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.5",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "OFF"
             }
         },
@@ -963,10 +963,10 @@
                 "ENABLE_SANITIZERS": "OFF",
                 "SANITIZE_UNDEFINED": "OFF",
                 "SANITIZE_ADDRESS": "OFF",
-                "PHP_DRIVER_BACKEND": "cassandra",
+                "PHP_SCYLLADB_BACKEND": "cassandra",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.5",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "ON"
             }
         },
@@ -982,10 +982,10 @@
                 "ENABLE_SANITIZERS": "OFF",
                 "SANITIZE_UNDEFINED": "OFF",
                 "SANITIZE_ADDRESS": "OFF",
-                "PHP_DRIVER_BACKEND": "cassandra",
+                "PHP_SCYLLADB_BACKEND": "cassandra",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.5",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "OFF"
             }
         },
@@ -1001,10 +1001,10 @@
                 "ENABLE_SANITIZERS": "OFF",
                 "SANITIZE_UNDEFINED": "OFF",
                 "SANITIZE_ADDRESS": "OFF",
-                "PHP_DRIVER_BACKEND": "scylla-rust",
+                "PHP_SCYLLADB_BACKEND": "scylla-rust",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.5",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "ON"
             }
         },
@@ -1020,10 +1020,352 @@
                 "ENABLE_SANITIZERS": "OFF",
                 "SANITIZE_UNDEFINED": "OFF",
                 "SANITIZE_ADDRESS": "OFF",
-                "PHP_DRIVER_BACKEND": "scylla-rust",
+                "PHP_SCYLLADB_BACKEND": "scylla-rust",
                 "PHP_VERSION_FOR_PHP_CONFIG": "8.5",
                 "LINK_LIBUV_STATIC": "ON",
-                "PHP_DRIVER_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
+                "PHP_THREAD_SAFE": "OFF"
+            }
+        },
+        {
+            "name": "DebugPHP8.6ZTS",
+            "displayName": "DebugPHP8.6ZTS",
+            "description": "",
+            "generator": "Ninja",
+            "binaryDir": "./out/DebugPHP8.6ZTS",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
+                "CMAKE_INSTALL_PREFIX": "./out/DebugPHP8.6ZTS/install",
+                "ENABLE_SANITIZERS": "ON",
+                "SANITIZE_UNDEFINED": "ON",
+                "SANITIZE_ADDRESS": "ON",
+                "PHP_SCYLLADB_BACKEND": "scylla-cpp",
+                "PHP_VERSION_FOR_PHP_CONFIG": "8.6",
+                "LINK_LIBUV_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
+                "PHP_THREAD_SAFE": "ON"
+            }
+        },
+        {
+            "name": "DebugPHP8.6NTS",
+            "displayName": "DebugPHP8.6NTS",
+            "description": "",
+            "generator": "Ninja",
+            "binaryDir": "./out/DebugPHP8.6NTS",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
+                "CMAKE_INSTALL_PREFIX": "./out/DebugPHP8.6NTS/install",
+                "ENABLE_SANITIZERS": "ON",
+                "SANITIZE_UNDEFINED": "ON",
+                "SANITIZE_ADDRESS": "ON",
+                "PHP_SCYLLADB_BACKEND": "scylla-cpp",
+                "PHP_VERSION_FOR_PHP_CONFIG": "8.6",
+                "LINK_LIBUV_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
+                "PHP_THREAD_SAFE": "OFF"
+            }
+        },
+        {
+            "name": "DebugPHP8.6ZTSCassandra",
+            "displayName": "DebugPHP8.6ZTSCassandra",
+            "description": "",
+            "generator": "Ninja",
+            "binaryDir": "./out/DebugPHP8.6ZTSCassandra",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
+                "CMAKE_INSTALL_PREFIX": "./out/DebugPHP8.6ZTSCassandra/install",
+                "ENABLE_SANITIZERS": "ON",
+                "SANITIZE_UNDEFINED": "ON",
+                "SANITIZE_ADDRESS": "ON",
+                "PHP_SCYLLADB_BACKEND": "cassandra",
+                "PHP_VERSION_FOR_PHP_CONFIG": "8.6",
+                "LINK_LIBUV_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
+                "PHP_THREAD_SAFE": "ON"
+            }
+        },
+        {
+            "name": "DebugPHP8.6NTSCassandra",
+            "displayName": "DebugPHP8.6NTSCassandra",
+            "description": "",
+            "generator": "Ninja",
+            "binaryDir": "./out/DebugPHP8.6NTSCassandra",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
+                "CMAKE_INSTALL_PREFIX": "./out/DebugPHP8.6NTSCassandra/install",
+                "ENABLE_SANITIZERS": "ON",
+                "SANITIZE_UNDEFINED": "ON",
+                "SANITIZE_ADDRESS": "ON",
+                "PHP_SCYLLADB_BACKEND": "cassandra",
+                "PHP_VERSION_FOR_PHP_CONFIG": "8.6",
+                "LINK_LIBUV_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
+                "PHP_THREAD_SAFE": "OFF"
+            }
+        },
+        {
+            "name": "DebugPHP8.6ZTSScyllaRust",
+            "displayName": "DebugPHP8.6ZTSScyllaRust",
+            "description": "",
+            "generator": "Ninja",
+            "binaryDir": "./out/DebugPHP8.6ZTSScyllaRust",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
+                "CMAKE_INSTALL_PREFIX": "./out/DebugPHP8.6ZTSScyllaRust/install",
+                "ENABLE_SANITIZERS": "ON",
+                "SANITIZE_UNDEFINED": "ON",
+                "SANITIZE_ADDRESS": "ON",
+                "PHP_SCYLLADB_BACKEND": "scylla-rust",
+                "PHP_VERSION_FOR_PHP_CONFIG": "8.6",
+                "LINK_LIBUV_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
+                "PHP_THREAD_SAFE": "ON"
+            }
+        },
+        {
+            "name": "DebugPHP8.6NTSScyllaRust",
+            "displayName": "DebugPHP8.6NTSScyllaRust",
+            "description": "",
+            "generator": "Ninja",
+            "binaryDir": "./out/DebugPHP8.6NTSScyllaRust",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
+                "CMAKE_INSTALL_PREFIX": "./out/DebugPHP8.6NTSScyllaRust/install",
+                "ENABLE_SANITIZERS": "ON",
+                "SANITIZE_UNDEFINED": "ON",
+                "SANITIZE_ADDRESS": "ON",
+                "PHP_SCYLLADB_BACKEND": "scylla-rust",
+                "PHP_VERSION_FOR_PHP_CONFIG": "8.6",
+                "LINK_LIBUV_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
+                "PHP_THREAD_SAFE": "OFF"
+            }
+        },
+        {
+            "name": "ReleasePHP8.6ZTS",
+            "displayName": "ReleasePHP8.6ZTS",
+            "description": "",
+            "generator": "Ninja",
+            "binaryDir": "./out/ReleasePHP8.6ZTS",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release",
+                "CMAKE_INSTALL_PREFIX": "./out/ReleasePHP8.6ZTS/install",
+                "ENABLE_SANITIZERS": "OFF",
+                "SANITIZE_UNDEFINED": "OFF",
+                "SANITIZE_ADDRESS": "OFF",
+                "PHP_SCYLLADB_BACKEND": "scylla-cpp",
+                "PHP_VERSION_FOR_PHP_CONFIG": "8.6",
+                "LINK_LIBUV_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
+                "PHP_THREAD_SAFE": "ON"
+            }
+        },
+        {
+            "name": "ReleasePHP8.6NTS",
+            "displayName": "ReleasePHP8.6NTS",
+            "description": "",
+            "generator": "Ninja",
+            "binaryDir": "./out/ReleasePHP8.6NTS",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release",
+                "CMAKE_INSTALL_PREFIX": "./out/ReleasePHP8.6NTS/install",
+                "ENABLE_SANITIZERS": "OFF",
+                "SANITIZE_UNDEFINED": "OFF",
+                "SANITIZE_ADDRESS": "OFF",
+                "PHP_SCYLLADB_BACKEND": "scylla-cpp",
+                "PHP_VERSION_FOR_PHP_CONFIG": "8.6",
+                "LINK_LIBUV_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
+                "PHP_THREAD_SAFE": "OFF"
+            }
+        },
+        {
+            "name": "ReleasePHP8.6ZTSCassandra",
+            "displayName": "ReleasePHP8.6ZTSCassandra",
+            "description": "",
+            "generator": "Ninja",
+            "binaryDir": "./out/ReleasePHP8.6ZTSCassandra",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release",
+                "CMAKE_INSTALL_PREFIX": "./out/ReleasePHP8.6ZTSCassandra/install",
+                "ENABLE_SANITIZERS": "OFF",
+                "SANITIZE_UNDEFINED": "OFF",
+                "SANITIZE_ADDRESS": "OFF",
+                "PHP_SCYLLADB_BACKEND": "cassandra",
+                "PHP_VERSION_FOR_PHP_CONFIG": "8.6",
+                "LINK_LIBUV_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
+                "PHP_THREAD_SAFE": "ON"
+            }
+        },
+        {
+            "name": "ReleasePHP8.6NTSCassandra",
+            "displayName": "ReleasePHP8.6NTSCassandra",
+            "description": "",
+            "generator": "Ninja",
+            "binaryDir": "./out/ReleasePHP8.6NTSCassandra",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release",
+                "CMAKE_INSTALL_PREFIX": "./out/ReleasePHP8.6NTSCassandra/install",
+                "ENABLE_SANITIZERS": "OFF",
+                "SANITIZE_UNDEFINED": "OFF",
+                "SANITIZE_ADDRESS": "OFF",
+                "PHP_SCYLLADB_BACKEND": "cassandra",
+                "PHP_VERSION_FOR_PHP_CONFIG": "8.6",
+                "LINK_LIBUV_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
+                "PHP_THREAD_SAFE": "OFF"
+            }
+        },
+        {
+            "name": "ReleasePHP8.6ZTSScyllaRust",
+            "displayName": "ReleasePHP8.6ZTSScyllaRust",
+            "description": "",
+            "generator": "Ninja",
+            "binaryDir": "./out/ReleasePHP8.6ZTSScyllaRust",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release",
+                "CMAKE_INSTALL_PREFIX": "./out/ReleasePHP8.6ZTSScyllaRust/install",
+                "ENABLE_SANITIZERS": "OFF",
+                "SANITIZE_UNDEFINED": "OFF",
+                "SANITIZE_ADDRESS": "OFF",
+                "PHP_SCYLLADB_BACKEND": "scylla-rust",
+                "PHP_VERSION_FOR_PHP_CONFIG": "8.6",
+                "LINK_LIBUV_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
+                "PHP_THREAD_SAFE": "ON"
+            }
+        },
+        {
+            "name": "ReleasePHP8.6NTSScyllaRust",
+            "displayName": "ReleasePHP8.6NTSScyllaRust",
+            "description": "",
+            "generator": "Ninja",
+            "binaryDir": "./out/ReleasePHP8.6NTSScyllaRust",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release",
+                "CMAKE_INSTALL_PREFIX": "./out/ReleasePHP8.6NTSScyllaRust/install",
+                "ENABLE_SANITIZERS": "OFF",
+                "SANITIZE_UNDEFINED": "OFF",
+                "SANITIZE_ADDRESS": "OFF",
+                "PHP_SCYLLADB_BACKEND": "scylla-rust",
+                "PHP_VERSION_FOR_PHP_CONFIG": "8.6",
+                "LINK_LIBUV_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
+                "PHP_THREAD_SAFE": "OFF"
+            }
+        },
+        {
+            "name": "RelWithDebInfoPHP8.6ZTS",
+            "displayName": "RelWithDebInfoPHP8.6ZTS",
+            "description": "",
+            "generator": "Ninja",
+            "binaryDir": "./out/RelWithDebInfoPHP8.6ZTS",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+                "CMAKE_INSTALL_PREFIX": "./out/RelWithDebInfoPHP8.6ZTS/install",
+                "ENABLE_SANITIZERS": "OFF",
+                "SANITIZE_UNDEFINED": "OFF",
+                "SANITIZE_ADDRESS": "OFF",
+                "PHP_SCYLLADB_BACKEND": "scylla-cpp",
+                "PHP_VERSION_FOR_PHP_CONFIG": "8.6",
+                "LINK_LIBUV_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
+                "PHP_THREAD_SAFE": "ON"
+            }
+        },
+        {
+            "name": "RelWithDebInfoPHP8.6NTS",
+            "displayName": "RelWithDebInfoPHP8.6NTS",
+            "description": "",
+            "generator": "Ninja",
+            "binaryDir": "./out/RelWithDebInfoPHP8.6NTS",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+                "CMAKE_INSTALL_PREFIX": "./out/RelWithDebInfoPHP8.6NTS/install",
+                "ENABLE_SANITIZERS": "OFF",
+                "SANITIZE_UNDEFINED": "OFF",
+                "SANITIZE_ADDRESS": "OFF",
+                "PHP_SCYLLADB_BACKEND": "scylla-cpp",
+                "PHP_VERSION_FOR_PHP_CONFIG": "8.6",
+                "LINK_LIBUV_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
+                "PHP_THREAD_SAFE": "OFF"
+            }
+        },
+        {
+            "name": "RelWithDebInfoPHP8.6ZTSCassandra",
+            "displayName": "RelWithDebInfoPHP8.6ZTSCassandra",
+            "description": "",
+            "generator": "Ninja",
+            "binaryDir": "./out/RelWithDebInfoPHP8.6ZTSCassandra",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+                "CMAKE_INSTALL_PREFIX": "./out/RelWithDebInfoPHP8.6ZTSCassandra/install",
+                "ENABLE_SANITIZERS": "OFF",
+                "SANITIZE_UNDEFINED": "OFF",
+                "SANITIZE_ADDRESS": "OFF",
+                "PHP_SCYLLADB_BACKEND": "cassandra",
+                "PHP_VERSION_FOR_PHP_CONFIG": "8.6",
+                "LINK_LIBUV_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
+                "PHP_THREAD_SAFE": "ON"
+            }
+        },
+        {
+            "name": "RelWithDebInfoPHP8.6NTSCassandra",
+            "displayName": "RelWithDebInfoPHP8.6NTSCassandra",
+            "description": "",
+            "generator": "Ninja",
+            "binaryDir": "./out/RelWithDebInfoPHP8.6NTSCassandra",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+                "CMAKE_INSTALL_PREFIX": "./out/RelWithDebInfoPHP8.6NTSCassandra/install",
+                "ENABLE_SANITIZERS": "OFF",
+                "SANITIZE_UNDEFINED": "OFF",
+                "SANITIZE_ADDRESS": "OFF",
+                "PHP_SCYLLADB_BACKEND": "cassandra",
+                "PHP_VERSION_FOR_PHP_CONFIG": "8.6",
+                "LINK_LIBUV_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
+                "PHP_THREAD_SAFE": "OFF"
+            }
+        },
+        {
+            "name": "RelWithDebInfoPHP8.6ZTSScyllaRust",
+            "displayName": "RelWithDebInfoPHP8.6ZTSScyllaRust",
+            "description": "",
+            "generator": "Ninja",
+            "binaryDir": "./out/RelWithDebInfoPHP8.6ZTSScyllaRust",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+                "CMAKE_INSTALL_PREFIX": "./out/RelWithDebInfoPHP8.6ZTSScyllaRust/install",
+                "ENABLE_SANITIZERS": "OFF",
+                "SANITIZE_UNDEFINED": "OFF",
+                "SANITIZE_ADDRESS": "OFF",
+                "PHP_SCYLLADB_BACKEND": "scylla-rust",
+                "PHP_VERSION_FOR_PHP_CONFIG": "8.6",
+                "LINK_LIBUV_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
+                "PHP_THREAD_SAFE": "ON"
+            }
+        },
+        {
+            "name": "RelWithDebInfoPHP8.6NTSScyllaRust",
+            "displayName": "RelWithDebInfoPHP8.6NTSScyllaRust",
+            "description": "",
+            "generator": "Ninja",
+            "binaryDir": "./out/RelWithDebInfoPHP8.6NTSScyllaRust",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+                "CMAKE_INSTALL_PREFIX": "./out/RelWithDebInfoPHP8.6NTSScyllaRust/install",
+                "ENABLE_SANITIZERS": "OFF",
+                "SANITIZE_UNDEFINED": "OFF",
+                "SANITIZE_ADDRESS": "OFF",
+                "PHP_SCYLLADB_BACKEND": "scylla-rust",
+                "PHP_VERSION_FOR_PHP_CONFIG": "8.6",
+                "LINK_LIBUV_STATIC": "ON",
+                "PHP_SCYLLADB_STATIC": "ON",
                 "PHP_THREAD_SAFE": "OFF"
             }
         }

--- a/generate-presets.php
+++ b/generate-presets.php
@@ -14,6 +14,7 @@ enum PHPVersion: string
     case PHP83 = '8.3';
     case PHP84 = '8.4';
     case PHP85 = '8.5';
+    case PHP86 = '8.6';
 }
 
 enum PHPTS: string

--- a/include/php_scylladb_object.h
+++ b/include/php_scylladb_object.h
@@ -11,7 +11,7 @@
  *   Recover a pointer to the user struct from the embedded zend_object*.
  *
  * PHP_SCYLLADB_OBJ_ALLOCATE(T, ce, handlers):
- *   Allocate a user struct (size = sizeof(T), offset = XtOffsetOf(T, zendObject)),
+ *   Allocate a user struct (size = sizeof(T), offset = offsetof(T, zendObject)),
  *   zero-init the user-fields prefix, call zend_object_std_init /
  *   object_properties_init on the embedded zend_object, and wire its
  *   handlers. Returns the user struct.
@@ -20,7 +20,7 @@
 #include <php.h>
 
 #define PHP_SCYLLADB_OBJ_FETCH(T, obj) \
-    ((T *)((char *)(obj) - XtOffsetOf(T, zendObject)))
+    ((T *)((char *)(obj) - offsetof(T, zendObject)))
 
 [[nodiscard]] static zend_always_inline void *php_scylladb_obj_allocate(
     size_t size, size_t obj_offset, zend_class_entry *ce, void *handlers)
@@ -56,4 +56,4 @@
 }
 
 #define PHP_SCYLLADB_OBJ_ALLOCATE(T, ce, handlers) \
-    ((T *)php_scylladb_obj_allocate(sizeof(T), XtOffsetOf(T, zendObject), (ce), (handlers)))
+    ((T *)php_scylladb_obj_allocate(sizeof(T), offsetof(T, zendObject), (ce), (handlers)))

--- a/scripts/compile-php.sh
+++ b/scripts/compile-php.sh
@@ -154,8 +154,14 @@ CONFIG_ARGS=(
     --enable-sockets
     --enable-mbstring
     --disable-short-tags
-    --with-pic
 )
+
+# PHP 8.6 renamed --with-pic to --enable-pic; the old spelling now hard-errors.
+if [[ "$(printf '%s\n8.6\n' "$PHP_VERSION" | sort -V | head -1)" == "8.6" ]]; then
+    CONFIG_ARGS+=(--enable-pic)
+else
+    CONFIG_ARGS+=(--with-pic)
+fi
 
 if [[ "$(uname -s)" == "Darwin" ]] && command -v brew >/dev/null 2>&1; then
     BREW_PREFIX="$(brew --prefix)"

--- a/src/Blob.c
+++ b/src/Blob.c
@@ -202,5 +202,5 @@ zend_object* php_scylladb_blob_new(zend_class_entry *ce) {
 
 void php_scylladb_blob_post_register([[maybe_unused]] zend_class_entry *ce)
 {
-    php_scylladb_blob_handlers.std.offset = XtOffsetOf(php_scylladb_blob, zendObject);
+    php_scylladb_blob_handlers.std.offset = offsetof(php_scylladb_blob, zendObject);
 }

--- a/src/Collection.c
+++ b/src/Collection.c
@@ -410,7 +410,7 @@ php_scylladb_collection_new(zend_class_entry *ce)
   self->dirty = 1;
   ZVAL_UNDEF(&self->type);
 
-  php_scylladb_collection_handlers.std.offset = XtOffsetOf(php_scylladb_collection, zendObject);
+  php_scylladb_collection_handlers.std.offset = offsetof(php_scylladb_collection, zendObject);
   php_scylladb_collection_handlers.std.free_obj = php_scylladb_collection_free;
   return &self->zendObject;
 }
@@ -418,5 +418,5 @@ php_scylladb_collection_new(zend_class_entry *ce)
 
 void php_scylladb_collection_post_register([[maybe_unused]] zend_class_entry *ce)
 {
-    php_scylladb_collection_handlers.std.offset = XtOffsetOf(php_scylladb_collection, zendObject);
+    php_scylladb_collection_handlers.std.offset = offsetof(php_scylladb_collection, zendObject);
 }

--- a/src/Collection.c
+++ b/src/Collection.c
@@ -50,7 +50,7 @@ static int
 php_scylladb_collection_get(php_scylladb_collection *collection, zend_ulong index, zval *zvalue)
 {
   zval *value;
-  if ((value = zend_hash_index_find(&collection->values, (zend_ulong)(index))) != nullptr) {
+  if ((value = zend_hash_index_find(&collection->values, index)) != nullptr) {
     *zvalue = *value;
     return 1;
   }

--- a/src/Database/DefaultAggregate.c
+++ b/src/Database/DefaultAggregate.c
@@ -263,7 +263,7 @@ php_scylladb_default_aggregate_new(zend_class_entry *ce )
   ZVAL_UNDEF(&self->schema);
   self->meta = nullptr;
 
-  php_scylladb_default_aggregate_handlers.offset = XtOffsetOf(php_scylladb_aggregate, zendObject);
+  php_scylladb_default_aggregate_handlers.offset = offsetof(php_scylladb_aggregate, zendObject);
   php_scylladb_default_aggregate_handlers.free_obj = php_scylladb_default_aggregate_free;
   return &self->zendObject;
 }

--- a/src/Database/DefaultColumn.c
+++ b/src/Database/DefaultColumn.c
@@ -260,7 +260,7 @@ php_scylladb_default_column_new(zend_class_entry *ce )
   ZVAL_UNDEF(&self->name);
   ZVAL_UNDEF(&self->type);
 
-  php_scylladb_default_column_handlers.offset = XtOffsetOf(php_scylladb_column, zendObject);
+  php_scylladb_default_column_handlers.offset = offsetof(php_scylladb_column, zendObject);
   php_scylladb_default_column_handlers.free_obj = php_scylladb_default_column_free;
   return &self->zendObject;
 }

--- a/src/Database/DefaultFunction.c
+++ b/src/Database/DefaultFunction.c
@@ -250,7 +250,7 @@ php_scylladb_default_function_new(zend_class_entry *ce )
   ZVAL_UNDEF(&self->schema);
   self->meta = nullptr;
 
-  php_scylladb_default_function_handlers.offset = XtOffsetOf(php_scylladb_function, zendObject);
+  php_scylladb_default_function_handlers.offset = offsetof(php_scylladb_function, zendObject);
   php_scylladb_default_function_handlers.free_obj = php_scylladb_default_function_free;
   return &self->zendObject;
 }

--- a/src/Database/DefaultIndex.c
+++ b/src/Database/DefaultIndex.c
@@ -129,7 +129,7 @@ void php_scylladb_index_build_option(php_scylladb_index *index)
       if (cass_value_get_string(value, &value_str, &value_str_length) != CASS_OK) {
         continue;
       }
-      add_assoc_stringl_ex(&index->options, key_str, key_str_length, (char *)(value_str), (size_t)(value_str_length));
+      add_assoc_stringl_ex(&index->options, key_str, key_str_length, (char *)(value_str), value_str_length);
     }
   }
 }

--- a/src/Database/DefaultIndex.c
+++ b/src/Database/DefaultIndex.c
@@ -267,7 +267,7 @@ php_scylladb_default_index_new(zend_class_entry *ce )
   ZVAL_UNDEF(&self->schema);
   self->meta = nullptr;
 
-  php_scylladb_default_index_handlers.offset = XtOffsetOf(php_scylladb_index, zendObject);
+  php_scylladb_default_index_handlers.offset = offsetof(php_scylladb_index, zendObject);
   php_scylladb_default_index_handlers.free_obj = php_scylladb_default_index_free;
   return &self->zendObject;
 }

--- a/src/Database/DefaultKeyspace.c
+++ b/src/Database/DefaultKeyspace.c
@@ -468,7 +468,7 @@ zend_object* php_scylladb_default_keyspace_new(zend_class_entry *ce) {
   self->meta = nullptr;
   ZVAL_UNDEF(&self->schema);
 
-  php_scylladb_default_keyspace_handlers.offset = XtOffsetOf(php_scylladb_keyspace, zendObject);
+  php_scylladb_default_keyspace_handlers.offset = offsetof(php_scylladb_keyspace, zendObject);
   php_scylladb_default_keyspace_handlers.free_obj = php_scylladb_default_keyspace_free;
   return &self->zendObject;
 }

--- a/src/Database/DefaultMaterializedView.c
+++ b/src/Database/DefaultMaterializedView.c
@@ -595,7 +595,7 @@ php_scylladb_default_materialized_view_new(zend_class_entry *ce )
   self->meta   = nullptr;
   ZVAL_UNDEF(&self->schema);
 
-  php_scylladb_default_materialized_view_handlers.offset = XtOffsetOf(php_scylladb_materialized_view, zendObject);
+  php_scylladb_default_materialized_view_handlers.offset = offsetof(php_scylladb_materialized_view, zendObject);
   php_scylladb_default_materialized_view_handlers.free_obj = php_scylladb_default_materialized_view_free;
   return &self->zendObject;
 }

--- a/src/Database/DefaultSchema.c
+++ b/src/Database/DefaultSchema.c
@@ -133,7 +133,7 @@ php_scylladb_default_schema_new(zend_class_entry *ce )
 
   self->schema_meta = nullptr;
 
-  php_scylladb_default_schema_handlers.offset = XtOffsetOf(php_scylladb_schema, zendObject);
+  php_scylladb_default_schema_handlers.offset = offsetof(php_scylladb_schema, zendObject);
   php_scylladb_default_schema_handlers.free_obj = php_scylladb_default_schema_free;
   return &self->zendObject;
 }

--- a/src/Database/DefaultTable.c
+++ b/src/Database/DefaultTable.c
@@ -691,7 +691,7 @@ php_scylladb_default_table_new(zend_class_entry *ce )
   self->meta   = nullptr;
   ZVAL_UNDEF(&self->schema);
 
-  php_scylladb_default_table_handlers.offset = XtOffsetOf(php_scylladb_table, zendObject);
+  php_scylladb_default_table_handlers.offset = offsetof(php_scylladb_table, zendObject);
   php_scylladb_default_table_handlers.free_obj = php_scylladb_default_table_free;
   return &self->zendObject;
 }

--- a/src/Database/Rows.c
+++ b/src/Database/Rows.c
@@ -457,7 +457,7 @@ zend_object *php_scylladb_rows_new(zend_class_entry *ce)
     ZVAL_UNDEF(&self->next_rows);
     ZVAL_UNDEF(&self->future_next_page);
 
-  php_scylladb_rows_handlers.offset = XtOffsetOf(php_scylladb_rows, zendObject);
+  php_scylladb_rows_handlers.offset = offsetof(php_scylladb_rows, zendObject);
   php_scylladb_rows_handlers.free_obj = php_scylladb_rows_free;
   return &self->zendObject;
 }

--- a/src/DateTime/Date.c
+++ b/src/DateTime/Date.c
@@ -235,5 +235,5 @@ zend_object *php_scylladb_date_new(zend_class_entry *ce) {
 
 void php_scylladb_date_post_register([[maybe_unused]] zend_class_entry *ce)
 {
-    php_scylladb_date_handlers.std.offset = XtOffsetOf(php_scylladb_date, zendObject);
+    php_scylladb_date_handlers.std.offset = offsetof(php_scylladb_date, zendObject);
 }

--- a/src/DateTime/Duration.c
+++ b/src/DateTime/Duration.c
@@ -302,5 +302,5 @@ php_scylladb_duration_new(zend_class_entry *ce )
 
 void php_scylladb_duration_post_register([[maybe_unused]] zend_class_entry *ce)
 {
-    php_scylladb_duration_handlers.std.offset = XtOffsetOf(php_scylladb_duration, zendObject);
+    php_scylladb_duration_handlers.std.offset = offsetof(php_scylladb_duration, zendObject);
 }

--- a/src/DateTime/Time.c
+++ b/src/DateTime/Time.c
@@ -229,5 +229,5 @@ zend_object *php_scylladb_time_new(zend_class_entry *ce) {
 
 void php_scylladb_time_post_register([[maybe_unused]] zend_class_entry *ce)
 {
-    php_scylladb_time_handlers.std.offset = XtOffsetOf(php_scylladb_time, zendObject);
+    php_scylladb_time_handlers.std.offset = offsetof(php_scylladb_time, zendObject);
 }

--- a/src/DateTime/Timestamp.c
+++ b/src/DateTime/Timestamp.c
@@ -292,5 +292,5 @@ zend_object *php_scylladb_timestamp_new(zend_class_entry *ce) {
 
 void php_scylladb_timestamp_post_register([[maybe_unused]] zend_class_entry *ce)
 {
-    php_scylladb_timestamp_handlers.std.offset = XtOffsetOf(php_scylladb_timestamp, zendObject);
+    php_scylladb_timestamp_handlers.std.offset = offsetof(php_scylladb_timestamp, zendObject);
 }

--- a/src/DateTime/Timestamp.c
+++ b/src/DateTime/Timestamp.c
@@ -137,7 +137,7 @@ ZEND_METHOD(Cassandra_Timestamp, microtime) {
   }
 
   long sec = (long)(self->timestamp / 1000);
-  double usec = (double)(((double)self->timestamp - (double)(sec * 1000)) / 1000.00);
+  double usec = ((double)self->timestamp - (double)(sec * 1000)) / 1000.00;
 
   char ret[128];
   memset(ret, 0, sizeof(ret));

--- a/src/DateTime/Timeuuid.c
+++ b/src/DateTime/Timeuuid.c
@@ -199,7 +199,7 @@ zend_object* php_scylladb_timeuuid_new(zend_class_entry *ce) {
   php_scylladb_uuid *self =
       PHP_SCYLLADB_OBJ_ALLOCATE(php_scylladb_uuid, ce, &php_scylladb_timeuuid_handlers);
 
-  php_scylladb_timeuuid_handlers.std.offset = XtOffsetOf(php_scylladb_uuid, zendObject);
+  php_scylladb_timeuuid_handlers.std.offset = offsetof(php_scylladb_uuid, zendObject);
   php_scylladb_timeuuid_handlers.std.free_obj = php_scylladb_timeuuid_free;
   return &self->zendObject;
 }
@@ -207,5 +207,5 @@ zend_object* php_scylladb_timeuuid_new(zend_class_entry *ce) {
 
 void php_scylladb_timeuuid_post_register([[maybe_unused]] zend_class_entry *ce)
 {
-    php_scylladb_timeuuid_handlers.std.offset = XtOffsetOf(php_scylladb_uuid, zendObject);
+    php_scylladb_timeuuid_handlers.std.offset = offsetof(php_scylladb_uuid, zendObject);
 }

--- a/src/Inet.c
+++ b/src/Inet.c
@@ -170,5 +170,5 @@ php_scylladb_inet_new(zend_class_entry *ce)
 
 void php_scylladb_inet_post_register([[maybe_unused]] zend_class_entry *ce)
 {
-    php_scylladb_inet_handlers.std.offset = XtOffsetOf(php_scylladb_inet, zendObject);
+    php_scylladb_inet_handlers.std.offset = offsetof(php_scylladb_inet, zendObject);
 }

--- a/src/Map.c
+++ b/src/Map.c
@@ -565,7 +565,7 @@ php_scylladb_map_new(zend_class_entry *ce)
   self->dirty = 1;
   ZVAL_UNDEF(&self->type);
 
-  php_scylladb_map_handlers.std.offset = XtOffsetOf(php_scylladb_map, zendObject);
+  php_scylladb_map_handlers.std.offset = offsetof(php_scylladb_map, zendObject);
   php_scylladb_map_handlers.std.free_obj = php_scylladb_map_free;
   return &self->zendObject;
 }
@@ -573,5 +573,5 @@ php_scylladb_map_new(zend_class_entry *ce)
 
 void php_scylladb_map_post_register([[maybe_unused]] zend_class_entry *ce)
 {
-    php_scylladb_map_handlers.std.offset = XtOffsetOf(php_scylladb_map, zendObject);
+    php_scylladb_map_handlers.std.offset = offsetof(php_scylladb_map, zendObject);
 }

--- a/src/Numbers/Bigint.c
+++ b/src/Numbers/Bigint.c
@@ -517,5 +517,5 @@ zend_object* php_scylladb_bigint_new(zend_class_entry *ce)
 
 void php_scylladb_bigint_post_register([[maybe_unused]] zend_class_entry *ce)
 {
-    php_scylladb_bigint_handlers.std.offset = XtOffsetOf(php_scylladb_numeric, zendObject);
+    php_scylladb_bigint_handlers.std.offset = offsetof(php_scylladb_numeric, zendObject);
 }

--- a/src/Numbers/Decimal.c
+++ b/src/Numbers/Decimal.c
@@ -653,5 +653,5 @@ zend_object* php_scylladb_decimal_new(zend_class_entry *ce)
 
 void php_scylladb_decimal_post_register([[maybe_unused]] zend_class_entry *ce)
 {
-    php_scylladb_decimal_handlers.std.offset = XtOffsetOf(php_scylladb_numeric, zendObject);
+    php_scylladb_decimal_handlers.std.offset = offsetof(php_scylladb_numeric, zendObject);
 }

--- a/src/Numbers/Decimal.c
+++ b/src/Numbers/Decimal.c
@@ -60,9 +60,13 @@ static void to_mpf(mpf_t result, php_scylladb_numeric *decimal)
  * E = exponent
  * M = mantissa
  */
-#define DOUBLE_MANTISSA_BITS 52
+enum : uint8_t
+{
+    DOUBLE_MANTISSA_BITS = 52,
+    DOUBLE_EXPONENT_BITS = 11,
+};
+
 #define DOUBLE_MANTISSA_MASK (cass_int64_t)((1LL << DOUBLE_MANTISSA_BITS) - 1)
-#define DOUBLE_EXPONENT_BITS 11
 #define DOUBLE_EXPONENT_MASK (cass_int64_t)((1LL << DOUBLE_EXPONENT_BITS) - 1)
 
 static void from_double(php_scylladb_numeric *result, double value)

--- a/src/Numbers/Float.c
+++ b/src/Numbers/Float.c
@@ -487,5 +487,5 @@ php_scylladb_float_new(zend_class_entry *ce )
 
 void php_scylladb_float_post_register([[maybe_unused]] zend_class_entry *ce)
 {
-    php_scylladb_float_handlers.std.offset = XtOffsetOf(php_scylladb_numeric, zendObject);
+    php_scylladb_float_handlers.std.offset = offsetof(php_scylladb_numeric, zendObject);
 }

--- a/src/Numbers/Smallint.c
+++ b/src/Numbers/Smallint.c
@@ -555,5 +555,5 @@ zend_object* php_scylladb_smallint_new(zend_class_entry *ce )
 
 void php_scylladb_smallint_post_register([[maybe_unused]] zend_class_entry *ce)
 {
-    php_scylladb_smallint_handlers.std.offset = XtOffsetOf(php_scylladb_numeric, zendObject);
+    php_scylladb_smallint_handlers.std.offset = offsetof(php_scylladb_numeric, zendObject);
 }

--- a/src/Numbers/Tinyint.c
+++ b/src/Numbers/Tinyint.c
@@ -553,5 +553,5 @@ zend_object* php_scylladb_tinyint_new(zend_class_entry *ce )
 
 void php_scylladb_tinyint_post_register([[maybe_unused]] zend_class_entry *ce)
 {
-    php_scylladb_tinyint_handlers.std.offset = XtOffsetOf(php_scylladb_numeric, zendObject);
+    php_scylladb_tinyint_handlers.std.offset = offsetof(php_scylladb_numeric, zendObject);
 }

--- a/src/Numbers/Varint.c
+++ b/src/Numbers/Varint.c
@@ -500,5 +500,5 @@ zend_object* php_scylladb_varint_new(zend_class_entry *ce )
 
 void php_scylladb_varint_post_register([[maybe_unused]] zend_class_entry *ce)
 {
-    php_scylladb_varint_handlers.std.offset = XtOffsetOf(php_scylladb_numeric, zendObject);
+    php_scylladb_varint_handlers.std.offset = offsetof(php_scylladb_numeric, zendObject);
 }

--- a/src/Set.c
+++ b/src/Set.c
@@ -407,12 +407,12 @@ php_scylladb_set_new(zend_class_entry* ce)
   self->dirty                                       = 1;
   ZVAL_UNDEF(&self->type);
 
-  php_scylladb_set_handlers.std.offset = XtOffsetOf(php_scylladb_set, zendObject);
+  php_scylladb_set_handlers.std.offset = offsetof(php_scylladb_set, zendObject);
   php_scylladb_set_handlers.std.free_obj = php_scylladb_set_free;
   return &self->zendObject;
 }
 
 void php_scylladb_set_post_register([[maybe_unused]] zend_class_entry *ce)
 {
-    php_scylladb_set_handlers.std.offset = XtOffsetOf(php_scylladb_set, zendObject);
+    php_scylladb_set_handlers.std.offset = offsetof(php_scylladb_set, zendObject);
 }

--- a/src/TimestampGenerator/Monotonic.c
+++ b/src/TimestampGenerator/Monotonic.c
@@ -45,5 +45,5 @@ php_scylladb_timestamp_generator_monotonic_new(zend_class_entry *ce)
 
 void php_scylladb_timestamp_generator_monotonic_post_register([[maybe_unused]] zend_class_entry *ce)
 {
-    php_scylladb_timestamp_generator_monotonic_handlers.offset = XtOffsetOf(php_scylladb_timestamp_gen, zendObject);
+    php_scylladb_timestamp_generator_monotonic_handlers.offset = offsetof(php_scylladb_timestamp_gen, zendObject);
 }

--- a/src/TimestampGenerator/ServerSide.c
+++ b/src/TimestampGenerator/ServerSide.c
@@ -45,5 +45,5 @@ php_scylladb_timestamp_generator_server_side_new(zend_class_entry *ce)
 
 void php_scylladb_timestamp_generator_server_side_post_register([[maybe_unused]] zend_class_entry *ce)
 {
-    php_scylladb_timestamp_generator_server_side_handlers.offset = XtOffsetOf(php_scylladb_timestamp_gen, zendObject);
+    php_scylladb_timestamp_generator_server_side_handlers.offset = offsetof(php_scylladb_timestamp_gen, zendObject);
 }

--- a/src/Tuple.c
+++ b/src/Tuple.c
@@ -389,7 +389,7 @@ php_scylladb_tuple_new(zend_class_entry *ce)
   self->dirty = 1;
   ZVAL_UNDEF(&self->type);
 
-  php_scylladb_tuple_handlers.std.offset = XtOffsetOf(php_scylladb_tuple, zendObject);
+  php_scylladb_tuple_handlers.std.offset = offsetof(php_scylladb_tuple, zendObject);
   php_scylladb_tuple_handlers.std.free_obj = php_scylladb_tuple_free;
   return &self->zendObject;
 }
@@ -397,5 +397,5 @@ php_scylladb_tuple_new(zend_class_entry *ce)
 
 void php_scylladb_tuple_post_register([[maybe_unused]] zend_class_entry *ce)
 {
-    php_scylladb_tuple_handlers.std.offset = XtOffsetOf(php_scylladb_tuple, zendObject);
+    php_scylladb_tuple_handlers.std.offset = offsetof(php_scylladb_tuple, zendObject);
 }

--- a/src/Tuple.c
+++ b/src/Tuple.c
@@ -50,7 +50,7 @@ php_scylladb_tuple_populate(php_scylladb_tuple *tuple, zval *array)
 
   ZEND_HASH_FOREACH_NUM_KEY(&type->data.tuple.types, index) {
     zval *value = nullptr;
-    if ((value = zend_hash_index_find(&tuple->values, (zend_ulong)(index))) != nullptr) {
+    if ((value = zend_hash_index_find(&tuple->values, index)) != nullptr) {
       if (add_next_index_zval(array, value) == SUCCESS)
         Z_TRY_ADDREF_P(value);
       else
@@ -208,7 +208,7 @@ ZEND_METHOD(Cassandra_Tuple, current)
 
   if (zend_hash_get_current_key_ex(&type->data.tuple.types, nullptr, &index, &self->pos) == HASH_KEY_IS_LONG) {
     zval *value;
-    if ((value = zend_hash_index_find(&self->values, (zend_ulong)(index))) != nullptr) {
+    if ((value = zend_hash_index_find(&self->values, index)) != nullptr) {
       RETURN_ZVAL(value, 1, 0);
     }
   }

--- a/src/Type/Collection.c
+++ b/src/Type/Collection.c
@@ -167,7 +167,7 @@ zend_object* php_scylladb_type_collection_new(
   self->data_type = cass_data_type_new(self->type);
   ZVAL_UNDEF(&self->data.collection.value_type);
 
-  php_scylladb_type_collection_handlers.offset = XtOffsetOf(php_scylladb_type, zendObject);
+  php_scylladb_type_collection_handlers.offset = offsetof(php_scylladb_type, zendObject);
   php_scylladb_type_collection_handlers.free_obj = php_scylladb_type_collection_free;
   return &self->zendObject;
 }

--- a/src/Type/Custom.c
+++ b/src/Type/Custom.c
@@ -116,7 +116,7 @@ zend_object *php_scylladb_type_custom_new(zend_class_entry *ce) {
   self->data_type = cass_data_type_new(self->type);
   self->data.custom.class_name = nullptr;
 
-  php_scylladb_type_custom_handlers.offset = XtOffsetOf(php_scylladb_type, zendObject);
+  php_scylladb_type_custom_handlers.offset = offsetof(php_scylladb_type, zendObject);
   php_scylladb_type_custom_handlers.free_obj = php_scylladb_type_custom_free;
   return &self->zendObject;
 }

--- a/src/Type/Map.c
+++ b/src/Type/Map.c
@@ -203,7 +203,7 @@ php_scylladb_type_map_new(zend_class_entry *ce )
   ZVAL_UNDEF(&self->data.map.key_type);
   ZVAL_UNDEF(&self->data.map.value_type);
 
-  php_scylladb_type_map_handlers.offset = XtOffsetOf(php_scylladb_type, zendObject);
+  php_scylladb_type_map_handlers.offset = offsetof(php_scylladb_type, zendObject);
   php_scylladb_type_map_handlers.free_obj = php_scylladb_type_map_free;
   return &self->zendObject;
 }

--- a/src/Type/Scalar.c
+++ b/src/Type/Scalar.c
@@ -116,7 +116,7 @@ zend_object* php_scylladb_type_scalar_new(zend_class_entry *ce) {
   self->type = CASS_VALUE_TYPE_UNKNOWN;
   self->data_type = nullptr;
 
-  php_scylladb_type_scalar_handlers.offset = XtOffsetOf(php_scylladb_type, zendObject);
+  php_scylladb_type_scalar_handlers.offset = offsetof(php_scylladb_type, zendObject);
   php_scylladb_type_scalar_handlers.free_obj = php_scylladb_type_scalar_free;
   return &self->zendObject;
 }

--- a/src/Type/Set.c
+++ b/src/Type/Set.c
@@ -176,7 +176,7 @@ php_scylladb_type_set_new(zend_class_entry *ce )
   self->data_type = cass_data_type_new(self->type);
   ZVAL_UNDEF(&self->data.set.value_type);
 
-  php_scylladb_type_set_handlers.offset = XtOffsetOf(php_scylladb_type, zendObject);
+  php_scylladb_type_set_handlers.offset = offsetof(php_scylladb_type, zendObject);
   php_scylladb_type_set_handlers.free_obj = php_scylladb_type_set_free;
   return &self->zendObject;
 }

--- a/src/Type/Tuple.c
+++ b/src/Type/Tuple.c
@@ -218,7 +218,7 @@ php_scylladb_type_tuple_new(zend_class_entry* ce )
   self->data_type = cass_data_type_new(self->type);
   zend_hash_init(&self->data.tuple.types, 0, nullptr, ZVAL_PTR_DTOR, 0);
 
-  php_scylladb_type_tuple_handlers.offset = XtOffsetOf(php_scylladb_type, zendObject);
+  php_scylladb_type_tuple_handlers.offset = offsetof(php_scylladb_type, zendObject);
   php_scylladb_type_tuple_handlers.free_obj = php_scylladb_type_tuple_free;
   return &self->zendObject;
 }

--- a/src/Type/UserType.c
+++ b/src/Type/UserType.c
@@ -308,7 +308,7 @@ php_scylladb_type_user_type_new(zend_class_entry *ce )
   self->data.udt.keyspace = self->data.udt.type_name = nullptr;
   zend_hash_init(&self->data.udt.types, 0, nullptr, ZVAL_PTR_DTOR, 0);
 
-  php_scylladb_type_user_type_handlers.offset = XtOffsetOf(php_scylladb_type, zendObject);
+  php_scylladb_type_user_type_handlers.offset = offsetof(php_scylladb_type, zendObject);
   php_scylladb_type_user_type_handlers.free_obj = php_scylladb_type_user_type_free;
   return &self->zendObject;
 }

--- a/src/Type/ValueHash.c
+++ b/src/Type/ValueHash.c
@@ -97,7 +97,10 @@ php_scylladb_value_compare(zval* zvalue1, zval* zvalue2)
   case IS_FALSE:
     return Z_TYPE_P(zvalue2) == IS_FALSE ? 0 : -1;
   case IS_STRING:
-    return zend_binary_zval_strcmp(zvalue1, zvalue2);
+    return zend_binary_strcmp(Z_STRVAL_P(zvalue1),
+                              Z_STRLEN_P(zvalue1),
+                              Z_STRVAL_P(zvalue2),
+                              Z_STRLEN_P(zvalue2));
   case IS_OBJECT:
     return Z_OBJ_P(zvalue1)->handlers->compare(zvalue1, zvalue2);
   default:

--- a/src/UserTypeValue.c
+++ b/src/UserTypeValue.c
@@ -404,7 +404,7 @@ php_scylladb_user_type_value_new(zend_class_entry *ce)
   self->dirty = 1;
   ZVAL_UNDEF(&self->type);
 
-  php_scylladb_user_type_value_handlers.std.offset = XtOffsetOf(php_scylladb_user_type_value, zendObject);
+  php_scylladb_user_type_value_handlers.std.offset = offsetof(php_scylladb_user_type_value, zendObject);
   php_scylladb_user_type_value_handlers.std.free_obj = php_scylladb_user_type_value_free;
   return &self->zendObject;
 }
@@ -412,5 +412,5 @@ php_scylladb_user_type_value_new(zend_class_entry *ce)
 
 void php_scylladb_user_type_value_post_register([[maybe_unused]] zend_class_entry *ce)
 {
-    php_scylladb_user_type_value_handlers.std.offset = XtOffsetOf(php_scylladb_user_type_value, zendObject);
+    php_scylladb_user_type_value_handlers.std.offset = offsetof(php_scylladb_user_type_value, zendObject);
 }

--- a/src/Uuid.c
+++ b/src/Uuid.c
@@ -210,5 +210,5 @@ php_scylladb_uuid_new(zend_class_entry *ce)
 
 void php_scylladb_uuid_post_register([[maybe_unused]] zend_class_entry *ce)
 {
-    php_scylladb_uuid_handlers.std.offset = XtOffsetOf(php_scylladb_uuid, zendObject);
+    php_scylladb_uuid_handlers.std.offset = offsetof(php_scylladb_uuid, zendObject);
 }

--- a/tools/gen_descriptor/gen_class_descriptor.php
+++ b/tools/gen_descriptor/gen_class_descriptor.php
@@ -441,7 +441,7 @@ function emit_class_descriptor(array $cls): array
     $handlerWiring = "  memcpy(&$handlersVar$stdAccess, zend_get_std_object_handlers(), sizeof(zend_object_handlers));\n";
     if (!empty($cls['struct'])) {
         $struct = $cls['struct'];
-        $handlerWiring .= "  $handlersVar$stdAccess.offset = XtOffsetOf($struct, zendObject);\n";
+        $handlerWiring .= "  $handlersVar$stdAccess.offset = offsetof($struct, zendObject);\n";
     }
     $handlerWiring .= "  if (&php_scylladb_{$snake}_free)       $handlersVar$stdAccess.free_obj       = php_scylladb_{$snake}_free;\n";
     $handlerWiring .= "  if (&php_scylladb_{$snake}_properties) $handlersVar$stdAccess.get_properties = php_scylladb_{$snake}_properties;\n";


### PR DESCRIPTION
Checked [php-src `UPGRADING.INTERNALS`](https://github.com/php/php-src/blob/master/UPGRADING.INTERNALS) against this codebase and fixed everything 8.6 breaks.

## What changed

### `XtOffsetOf()` → `offsetof()`
> The `XtOffsetOf()` alias of C's `offsetof()` macro has been removed. Use `offsetof()` directly.

101 call sites across `src/` and `include/` — every object-handler `.offset` assignment and every `PHP_SCYLLADB_GET_*` fetch macro. Also fixed `tools/gen_descriptor/gen_class_descriptor.php`, which would otherwise re-emit the removed macro into every `*_descriptor.c` on the next build.

### `zend_binary_zval_strcmp()` → `zend_binary_strcmp()`
> The `zend_binary_zval_strcmp()` and `zend_binary_zval_strncmp()` functions have been removed, because they are unsafe by relying on the zvals having a specific type.

One site, `src/Type/ValueHash.c`. The enclosing `switch (Z_TYPE_P(...))` already establishes `IS_STRING`, so the operands are unwrapped explicitly with `Z_STRVAL_P`/`Z_STRLEN_P`. No behaviour change.

### `--with-pic` → `--enable-pic`
> `--with-pic` has been changed to `--enable-pic`; the old flag now errors.

`scripts/compile-php.sh` selects the flag by version, so `-v 8.5` and `-v 8.6` both work.

### PHP 8.6 presets
`PHP86` added to the `PHPVersion` enum in `generate-presets.php`; `CMakePresets.json` regenerated (+18 presets: 3 build types × 3 backends × ZTS/NTS).

## Reviewer notes

- **No version guards.** All three API changes are spelled the same way on 8.3–8.5 — `XtOffsetOf` was always just an alias, and `zend_binary_strcmp` has existed throughout — so there is no `#ifdef PHP_VERSION_ID` anywhere in this diff.
- **`CMakePresets.json` has unrelated churn.** The committed file was already stale relative to its generator: it still carried `PHP_DRIVER_STATIC` / `PHP_DRIVER_BACKEND`, renamed to `PHP_SCYLLADB_*` in the generator some time ago. Regenerating picks that up (108 of the deleted lines). Pre-existing drift, not introduced here.
- **Not in scope.** `CLAUDE.md` and `.claude/skills/` still document `XtOffsetOf` as the canonical pattern in 9 places, and there is no CI matrix row for 8.6 yet. Both left for follow-ups.
- Nothing else in `UPGRADING.INTERNALS` applies — the codebase has no `zend_parse_parameters()`, `ZVAL_IS_NULL`, `INI_STR/INT/BOOL`, `zval_dtor`, `WRONG_PARAM_COUNT`, `Z_GC_*`, `Z_COPYABLE`, `EMPTY_SWITCH_DEFAULT_CASE`, `ZEND_RESULT_CODE`, `php_error_docref1/2`, or underscore-prefixed stream calls. The `ext/session`, `ext/uri`, `ext/xml`, mysqlnd and intl changes don't touch us, and `cmake/TargetOptimizations.cmake` already passes `-undefined dynamic_lookup` on Darwin, matching the new libtool behaviour.

## Verification

Built and tested against PHP 8.5 NTS debug (`DebugPHP8.5NTS`), since 8.6 isn't released yet — this PR is forward-compat only and cannot be end-to-end verified on 8.6 today.

- `cmake --build out/DebugPHP8.5NTS` — clean, 228/228, no new warnings
- `pest --testsuite=Unit` — **803 passed** (12058 assertions), 27 skipped, 1 failed

The single failure is `UuidTest > it produces unique UUIDs across separate processes`, a known pre-existing cross-process environment issue on this machine, unrelated to these changes.