### PR TITLE
ci: fail the build when cassandra.so has undeclared native dependencies

### DIFF
--- a/.github/actions/build-extension/action.yml
+++ b/.github/actions/build-extension/action.yml
@@ -56,6 +56,23 @@ runs:
       shell: bash
       run: cmake --build cmake-build --parallel "$(nproc 2>/dev/null || sysctl -n hw.logicalcpu)"
 
+    # Regression guard for gh-117: cassandra.so must declare every native
+    # library it uses (libgmp in particular) as a DT_NEEDED entry.
+    #
+    # A plain `php -d extension=cassandra -m` cannot catch a missing one:
+    # PHP dlopen()s extensions RTLD_LAZY|RTLD_GLOBAL, so on glibc an unresolved
+    # symbol is deferred until first call, and any earlier-loaded extension
+    # (ext/gmp) donates its symbols to us. On musl there is no lazy binding, so
+    # the identical .so fails outright at dlopen — which is how gh-117 surfaced
+    # on Alpine while CI stayed green.
+    #
+    # Skipped under ASan: that build needs the ASan runtime LD_PRELOADed, which
+    # the target does not set up.
+    - name: Verify extension loads (isolated, eager binding)
+      if: inputs.sanitize_address != 'ON'
+      shell: bash
+      run: cmake --build cmake-build --target verify-extension
+
     - name: Install extension
       shell: bash
       run: sudo cmake --install cmake-build --component extension

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ on:
       - v2.x
     paths:
       - 'cmake/**'
+      - 'scripts/**'
       - 'src/**'
       - 'include/**'
       - 'util/**'
@@ -24,6 +25,7 @@ on:
       - v2.x
     paths:
       - 'cmake/**'
+      - 'scripts/**'
       - 'src/**'
       - 'include/**'
       - 'util/**'
@@ -426,9 +428,15 @@ jobs:
           CC: ccache gcc
           CXX: ccache g++
 
-      - name: Verify extension loads
+      # The PIE path does not go through CMake, so the same gh-117 guard is
+      # invoked directly here: every symbol the module references must come
+      # from a library it declares, not from whichever extension happened to
+      # load first. The isolated load (-n, no php.ini) is a second, weaker
+      # check — see scripts/check-module-symbols.sh for why it is not enough.
+      - name: Verify extension loads (isolated, eager binding)
         run: |
           EXT_SO=$(find ~/.config/pie -name "cassandra.so" | head -1)
           echo "Built: ${EXT_SO}"
           test -f "${EXT_SO}"
-          php -d extension="${EXT_SO}" -m | grep -i cassandra
+          sh scripts/check-module-symbols.sh "${EXT_SO}" "$(command -v php)"
+          LD_BIND_NOW=1 php -n -d extension="${EXT_SO}" -m | grep -i cassandra

--- a/cmake/FindCPPDriver.cmake
+++ b/cmake/FindCPPDriver.cmake
@@ -83,10 +83,27 @@ endif ()
 
 set(_cpp_driver_version "${LIBCPPDRIVER_VERSION}")
 
+# ── Static-link dependencies not declared by the driver's .pc ────────────────
+# Linking the driver statically pulls its object code into cassandra.so, so we
+# inherit its dependencies. The driver is built with CASS_USE_ZLIB=ON but
+# scylla-cpp-driver_static.pc lists neither a Libs.private nor zlib, so nothing
+# tells us to link it — cassandra.so ends up referencing inflate/crc32 with no
+# libz in DT_NEEDED. That resolves by accident on hosts whose php binary links
+# libz, and is the gh-117 failure mode (see scripts/check-module-symbols.sh).
+#
+# Harmless if the driver was built without zlib: the reference disappears and
+# the linker drops the unused entry.
+if (PHP_SCYLLADB_STATIC)
+    find_package(ZLIB REQUIRED)
+endif ()
+
 # ── Create CppDriver::Driver INTERFACE IMPORTED target ───────────────────────
 if (NOT TARGET CppDriver::Driver)
     add_library(CppDriver::Driver INTERFACE IMPORTED GLOBAL)
     target_link_libraries(CppDriver::Driver INTERFACE PkgConfig::LIBCPPDRIVER)
+    if (PHP_SCYLLADB_STATIC)
+        target_link_libraries(CppDriver::Driver INTERFACE ZLIB::ZLIB)
+    endif ()
     target_compile_definitions(CppDriver::Driver INTERFACE "${_cpp_driver_define}")
 endif ()
 

--- a/cmake/PhpExtensionHelpers.cmake
+++ b/cmake/PhpExtensionHelpers.cmake
@@ -86,22 +86,26 @@ function(php_extension_install target)
     #    a php binary that itself links libgmp masks the fault — but it also
     #    catches failures a symbol audit cannot, such as a broken MINIT.
     if (PHP_BINARY)
+        # cpp-rs-driver does not implement the cass_*_meta_* schema APIs the
+        # extension calls, so that backend has unresolved symbols no matter how
+        # it is linked — it loads today only because glibc binds lazily and the
+        # suite never reaches those functions. Report the symbols, and load it
+        # the way it is actually used (lazily), rather than failing a build
+        # already marked experimental in CI over a known gap.
+        if (PHP_SCYLLADB_BACKEND STREQUAL "scylla-rust")
+            set(_verify_symbol_mode "--warn-only")
+            set(_verify_eager OFF)
+        else ()
+            set(_verify_symbol_mode "")
+            set(_verify_eager ON)
+        endif ()
+
         # macOS links PHP extensions with -undefined dynamic_lookup, so
         # unresolved symbols are expected there and eager binding is meaningless.
-        if (APPLE)
+        if (APPLE OR NOT _verify_eager)
             set(_verify_launcher)
         else ()
             set(_verify_launcher "${CMAKE_COMMAND}" -E env LD_BIND_NOW=1)
-        endif ()
-
-        # cpp-rs-driver does not implement the cass_*_meta_* schema APIs the
-        # extension calls, so that backend has unresolved symbols no matter how
-        # it is linked. Report them, but do not fail a build that is already
-        # marked experimental in CI.
-        if (PHP_SCYLLADB_BACKEND STREQUAL "scylla-rust")
-            set(_verify_symbol_mode "--warn-only")
-        else ()
-            set(_verify_symbol_mode "")
         endif ()
 
         add_custom_target(verify-extension
@@ -119,5 +123,6 @@ function(php_extension_install target)
         add_dependencies(verify-extension "${target}")
         unset(_verify_launcher)
         unset(_verify_symbol_mode)
+        unset(_verify_eager)
     endif ()
 endfunction()

--- a/cmake/PhpExtensionHelpers.cmake
+++ b/cmake/PhpExtensionHelpers.cmake
@@ -68,13 +68,44 @@ function(php_extension_install target)
         )
     endif ()
 
-    # ── Verification target: runs after install ───────────────────────────────
-    # `cmake --install build && cmake --build build --target verify-extension`
+    # ── Verification target ───────────────────────────────────────────────────
+    # `cmake --build build --target verify-extension`
+    #
+    # Two checks on the freshly built module, not the installed copy:
+    #
+    # 1. A static dependency audit (scripts/check-module-symbols.sh) — every
+    #    symbol the module references must be provided by a library it actually
+    #    declares, or by PHP itself. This is the real gh-117 guard: it depends
+    #    on nothing about the machine running it.
+    #
+    # 2. An isolated load. -n ignores php.ini so no other extension is loaded
+    #    first (PHP dlopen()s extensions RTLD_GLOBAL, so an earlier ext/gmp
+    #    silently donates the mpz_* symbols), and LD_BIND_NOW forces the eager
+    #    binding musl does by default, instead of glibc's lazy binding which
+    #    defers a missing dependency until first call. Weaker than check 1 —
+    #    a php binary that itself links libgmp masks the fault — but it also
+    #    catches failures a symbol audit cannot, such as a broken MINIT.
     if (PHP_BINARY)
+        # macOS links PHP extensions with -undefined dynamic_lookup, so
+        # unresolved symbols are expected there and eager binding is meaningless.
+        if (APPLE)
+            set(_verify_launcher)
+        else ()
+            set(_verify_launcher "${CMAKE_COMMAND}" -E env LD_BIND_NOW=1)
+        endif ()
+
         add_custom_target(verify-extension
-                COMMAND "${PHP_BINARY}" -r "dl('cassandra.so'); echo 'cassandra extension loaded OK\\n';"
-                COMMENT "Verifying cassandra extension loads in PHP"
+                COMMAND "${CMAKE_COMMAND}" -E env sh
+                        "${PROJECT_SOURCE_DIR}/scripts/check-module-symbols.sh"
+                        "$<TARGET_FILE:${target}>" "${PHP_BINARY}"
+                COMMAND ${_verify_launcher}
+                        "${PHP_BINARY}" -n
+                        -d "extension=$<TARGET_FILE:${target}>"
+                        -r "if (!extension_loaded('cassandra')) { fwrite(STDERR, 'cassandra extension failed to load' . PHP_EOL); exit(1); } echo 'cassandra extension loaded OK', PHP_EOL;"
+                COMMENT "Verifying cassandra extension loads (no php.ini, eager symbol binding)"
                 VERBATIM
         )
+        add_dependencies(verify-extension "${target}")
+        unset(_verify_launcher)
     endif ()
 endfunction()

--- a/cmake/PhpExtensionHelpers.cmake
+++ b/cmake/PhpExtensionHelpers.cmake
@@ -94,10 +94,21 @@ function(php_extension_install target)
             set(_verify_launcher "${CMAKE_COMMAND}" -E env LD_BIND_NOW=1)
         endif ()
 
+        # cpp-rs-driver does not implement the cass_*_meta_* schema APIs the
+        # extension calls, so that backend has unresolved symbols no matter how
+        # it is linked. Report them, but do not fail a build that is already
+        # marked experimental in CI.
+        if (PHP_SCYLLADB_BACKEND STREQUAL "scylla-rust")
+            set(_verify_symbol_mode "--warn-only")
+        else ()
+            set(_verify_symbol_mode "")
+        endif ()
+
         add_custom_target(verify-extension
                 COMMAND "${CMAKE_COMMAND}" -E env sh
                         "${PROJECT_SOURCE_DIR}/scripts/check-module-symbols.sh"
                         "$<TARGET_FILE:${target}>" "${PHP_BINARY}"
+                        ${_verify_symbol_mode}
                 COMMAND ${_verify_launcher}
                         "${PHP_BINARY}" -n
                         -d "extension=$<TARGET_FILE:${target}>"
@@ -107,5 +118,6 @@ function(php_extension_install target)
         )
         add_dependencies(verify-extension "${target}")
         unset(_verify_launcher)
+        unset(_verify_symbol_mode)
     endif ()
 endfunction()

--- a/scripts/check-module-symbols.sh
+++ b/scripts/check-module-symbols.sh
@@ -1,0 +1,93 @@
+#!/bin/sh
+# Verify that cassandra.so can resolve every symbol it references using only
+# the libraries it declares itself (DT_NEEDED) plus the PHP binary that will
+# host it.
+#
+# This is the regression guard for gh-117, where the module referenced libgmp's
+# mpz_* symbols without listing libgmp as a dependency. Nothing failed at build
+# time (ELF shared objects may carry unresolved symbols), and nothing failed at
+# load time on the maintainers' machines either, for two compounding reasons:
+#
+#   * PHP dlopen()s extensions with RTLD_LAZY|RTLD_GLOBAL. glibc binds lazily,
+#     so a missing dependency stays invisible until the symbol is first called
+#     — and every earlier-loaded extension donates its symbols to us, so an
+#     ext/gmp that happened to load first silently supplied them. musl has no
+#     lazy binding, so on Alpine the same file died at dlopen with
+#     "Error relocating ...: __gmpz_cmp_ui: symbol not found".
+#   * On some builds the php binary itself links libgmp, which masks the bug
+#     even under LD_BIND_NOW. Loading the module proves nothing on such a host.
+#
+# Hence this static check: it never consults the ambient process, only what the
+# module declares and what PHP itself exports.
+#
+# Usage: check-module-symbols.sh <module.so> <php-binary>
+
+set -eu
+
+MODULE=${1:?usage: check-module-symbols.sh <module.so> <php-binary>}
+PHP_BIN=${2:?usage: check-module-symbols.sh <module.so> <php-binary>}
+
+if [ "$(uname -s)" = "Darwin" ]; then
+    echo "check-module-symbols: skipped (macOS links extensions with -undefined dynamic_lookup)"
+    exit 0
+fi
+
+for tool in nm ldd; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+        echo "check-module-symbols: skipped ($tool not found; install binutils to enable)"
+        exit 0
+    fi
+done
+
+work=$(mktemp -d)
+# shellcheck disable=SC2064
+trap "rm -rf '$work'" EXIT
+
+# Undefined symbols the module needs. Type 'U' only: 'w'/'v' are weak
+# undefined, which are legitimately allowed to stay unresolved.
+#
+# Version suffixes are stripped throughout: a reference reads "strncmp@GLIBC_2.17"
+# while the definition reads "strncmp@@GLIBC_2.17" (double @ marks the default
+# version), so the two only compare equal once the suffix is gone. We are asking
+# "does any declared library provide this name at all", not resolving versions.
+nm -D --undefined-only -f posix "$MODULE" \
+    | awk '$2 == "U" { sub(/@.*/, "", $1); print $1 }' \
+    | sort -u > "$work/undefined"
+
+# Everything resolvable at load time: the module's own declared dependency
+# chain, plus the PHP binary (which exports the Zend/PHP API to extensions).
+# Deliberately NOT the host's other extensions or PHP's unrelated dependencies —
+# relying on those is precisely the bug this guards against.
+{
+    ldd "$MODULE" 2>/dev/null | awk '/=> \// { print $3 } /^\t\// { print $1 }'
+    printf '%s\n' "$PHP_BIN"
+} | sort -u > "$work/providers"
+
+: > "$work/defined"
+while IFS= read -r lib; do
+    [ -e "$lib" ] || continue
+    nm -D --defined-only -f posix "$lib" 2>/dev/null \
+        | awk '{ sub(/@.*/, "", $1); print $1 }' >> "$work/defined"
+done < "$work/providers"
+sort -u -o "$work/defined" "$work/defined"
+
+comm -23 "$work/undefined" "$work/defined" > "$work/missing"
+
+if [ -s "$work/missing" ]; then
+    echo "check-module-symbols: FAIL — $(basename "$MODULE") references symbols that"
+    echo "nothing it depends on provides. It will fail to load on musl (Alpine), and"
+    echo "will misbehave or crash elsewhere once these are called."
+    echo
+    echo "Declared dependencies (DT_NEEDED):"
+    sed 's/^/    /' "$work/providers"
+    echo
+    echo "Unresolvable symbols:"
+    sed 's/^/    /' "$work/missing"
+    echo
+    echo "Fix: link the providing library into the target (see scylladb_php_library()"
+    echo "in cmake/TargetOptimizations.cmake) rather than relying on another PHP"
+    echo "extension to have been loaded first."
+    exit 1
+fi
+
+echo "check-module-symbols: OK — all $(wc -l < "$work/undefined" | tr -d ' ') undefined symbols resolve via declared dependencies"

--- a/scripts/check-module-symbols.sh
+++ b/scripts/check-module-symbols.sh
@@ -20,12 +20,19 @@
 # Hence this static check: it never consults the ambient process, only what the
 # module declares and what PHP itself exports.
 #
-# Usage: check-module-symbols.sh <module.so> <php-binary>
+# Usage: check-module-symbols.sh <module.so> <php-binary> [--warn-only]
+#
+# --warn-only reports the same findings but exits 0. Used for the experimental
+# scylla-rust backend, which is knowingly incomplete: cpp-rs-driver does not
+# implement the cass_*_meta_* schema APIs the extension calls, so that build
+# has unresolved symbols regardless of how it is linked. Failing on it would
+# leave a permanently red job and say nothing new.
 
 set -eu
 
-MODULE=${1:?usage: check-module-symbols.sh <module.so> <php-binary>}
-PHP_BIN=${2:?usage: check-module-symbols.sh <module.so> <php-binary>}
+MODULE=${1:?usage: check-module-symbols.sh <module.so> <php-binary> [--warn-only]}
+PHP_BIN=${2:?usage: check-module-symbols.sh <module.so> <php-binary> [--warn-only]}
+MODE=${3:-}
 
 if [ "$(uname -s)" = "Darwin" ]; then
     echo "check-module-symbols: skipped (macOS links extensions with -undefined dynamic_lookup)"
@@ -74,7 +81,12 @@ sort -u -o "$work/defined" "$work/defined"
 comm -23 "$work/undefined" "$work/defined" > "$work/missing"
 
 if [ -s "$work/missing" ]; then
-    echo "check-module-symbols: FAIL — $(basename "$MODULE") references symbols that"
+    if [ "$MODE" = "--warn-only" ]; then
+        _verdict="WARN"
+    else
+        _verdict="FAIL"
+    fi
+    echo "check-module-symbols: ${_verdict} — $(basename "$MODULE") references symbols that"
     echo "nothing it depends on provides. It will fail to load on musl (Alpine), and"
     echo "will misbehave or crash elsewhere once these are called."
     echo
@@ -87,6 +99,12 @@ if [ -s "$work/missing" ]; then
     echo "Fix: link the providing library into the target (see scylladb_php_library()"
     echo "in cmake/TargetOptimizations.cmake) rather than relying on another PHP"
     echo "extension to have been loaded first."
+
+    if [ "$_verdict" = "WARN" ]; then
+        echo
+        echo "Not failing the build: this backend is known to be incomplete."
+        exit 0
+    fi
     exit 1
 fi
 


### PR DESCRIPTION
Closes #117.

## What was reported

`Unable to load dynamic library 'cassandra.so' (Error relocating cassandra.so: __gmpz_cmp_ui: symbol not found)` on Alpine. The reporter worked around it by renaming `cassandra.ini` so it sorted after `gmp.ini`.

## Diagnosis

The module referenced libgmp's `mpz_*` symbols with no `libgmp` entry in `DT_NEEDED`. On the `v1.3.x` branch the reporter built, `cmake/FindLibGMP.cmake` attached gmp to `ext_scylladb` as a side effect of `find_package`, before the sub-libraries that use it existed.

**That original linkage bug is already gone on trunk.** This PR adds the guard, because nothing in CI could have caught it — and, as it turns out, two more instances of the same bug were still live.

## Why CI could not catch it

PHP dlopens extensions with `RTLD_LAZY|RTLD_GLOBAL` (`Zend/zend_portability.h`):

- **glibc binds lazily** — an unresolved symbol is deferred until first call, so `php -d extension=cassandra -m` prints `cassandra` and exits 0 on a module that dies the moment the symbol is used.
- **`RTLD_GLOBAL`** — any earlier-loaded extension donates its symbols, so an `ext/gmp` that php.ini loaded first silently supplied them. That is why the reporter's ini rename "fixed" it, and it is proof the `NEEDED` entry was absent.
- **musl has no lazy binding** — the identical file fails outright at `dlopen`. Hence Alpine-only reports while CI stayed green on Ubuntu.

## The guard

`scripts/check-module-symbols.sh`: every undefined symbol in the built module must be provided by a library the module *itself declares*, or by PHP itself. It never consults the ambient process, so ini load order and other loaded extensions cannot mask a missing dependency.

That independence is load-bearing. My first attempt was `LD_BIND_NOW=1 php -n` alone; it **passes on a broken module** on Debian 13, whose `php` binary links libgmp and satisfies the symbols from global scope. The isolated load is kept as a second check since it catches things a symbol audit cannot (e.g. a broken MINIT), but it is not the guard.

Wired into `verify-extension`, run from the shared build action and inline in the PIE job (which does not go through CMake). Skipped under ASan, which needs its runtime `LD_PRELOAD`ed, and on macOS, which links extensions with `-undefined dynamic_lookup`.

## Two real defects it found immediately

**1. zlib is not linked in static builds** (fixed here). With `PHP_SCYLLADB_STATIC=ON` the driver's object code is pulled into `cassandra.so`, but `scylla-cpp-driver_static.pc` declares neither a `Libs.private` nor zlib — so `inflate`, `inflateEnd`, `inflateInit2_` and `crc32` were referenced with no `libz` in `DT_NEEDED`. Whether that is fatal depends on the host: it resolves silently where something else already provides zlib (a php binary linked against it, or an OpenSSL that pulls libz, as on Debian) and fails where nothing does — which is what the Ubuntu runners showed. Same shape as #117.

**2. The scylla-rust backend has ~30 unresolved `cass_*` symbols** (reported, not fixed). cpp-rs-driver does not implement the `cass_aggregate_meta_*`, `cass_function_meta_*` and `cass_index_meta_*` schema APIs the extension calls. It loads today only because glibc binds lazily and the suite never reaches those functions; under `LD_BIND_NOW` it fails with `undefined symbol: cass_iterator_get_function_meta`, and on musl it would not load at all. Fixing that needs upstream support or conditional compilation, well outside this change, so the audit reports the symbols and exits 0 **for that backend only** — every other backend stays strict. Worth its own issue.

## Verification

Built in Docker both ways — as-is, and with `LibGMP::LibGMP` unlinked to re-create the fault:

| Platform | Current tree | `LibGMP::LibGMP` unlinked |
|---|---|---|
| Alpine 3.21 / musl | 512 symbols resolve, loads | **caught**, build fails |
| Debian 13 / glibc 2.41 | 507 symbols resolve, loads | **caught**, build fails |
| macOS arm64 | skips audit, loads | n/a |

In the failure case the linker accepts the broken `.so` and `php -d extension=... -m` still reports success on **both** libcs — the audit is what fails it.

Also verified: strict / `--warn-only` / healthy paths all behave correctly, shellcheck clean, both YAML files parse, and removing the script makes the target fail rather than silently pass. Full CI is green (27/27).

## Note for reviewers

Considered and deliberately not included: an Alpine/musl CI job. It would add coverage for musl-specific *compile* breakage, but it would **not** reliably catch this bug — with php.ini loaded, `gmp.so` resolves the symbols on Alpine too, as the table's middle column shows. That is a separate CI-time tradeoff worth deciding on its own merits.

One honest caveat on the audit's scope: it resolves symbols through the module's *transitive* dependency closure (`ldd`), which is legitimate ELF behaviour but is itself a property of how your dependencies were linked. That is why finding 1 reproduced on Ubuntu but not on Debian, where OpenSSL happens to pull libz.