### PR TITLE
docs: add a VitePress documentation site published to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,11 +27,11 @@ jobs:
       run:
         working-directory: website
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0 # lastUpdated needs the git history
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: npm
@@ -41,10 +41,10 @@ jobs:
 
       - run: npm run build
 
-      - uses: actions/configure-pages@v5
+      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
         if: github.ref == 'refs/heads/trunk' && github.event_name != 'pull_request'
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         if: github.ref == 'refs/heads/trunk' && github.event_name != 'pull_request'
         with:
           path: website/.vitepress/dist
@@ -62,4 +62,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,65 @@
+name: Documentation
+
+on:
+  push:
+    branches: [trunk]
+    paths:
+      - 'website/**'
+      - '.github/workflows/docs.yml'
+  pull_request:
+    paths:
+      - 'website/**'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pages-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: website
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # lastUpdated needs the git history
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+
+      - run: npm ci
+
+      - run: npm run build
+
+      - uses: actions/configure-pages@v5
+        if: github.ref == 'refs/heads/trunk' && github.event_name != 'pull_request'
+
+      - uses: actions/upload-pages-artifact@v3
+        if: github.ref == 'refs/heads/trunk' && github.event_name != 'pull_request'
+        with:
+          path: website/.vitepress/dist
+
+  deploy:
+    name: Deploy
+    if: github.ref == 'refs/heads/trunk' && github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,10 +44,26 @@ jobs:
       - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
         if: github.ref == 'refs/heads/trunk' && github.event_name != 'pull_request'
 
-      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+      # actions/upload-pages-artifact is composite and calls an unpinned
+      # actions/upload-artifact@v4, which the org SHA-pin policy rejects.
+      # These two steps are what it does internally.
+      - name: Archive artifact
+        if: github.ref == 'refs/heads/trunk' && github.event_name != 'pull_request'
+        run: |
+          tar --dereference --hard-dereference \
+            --directory .vitepress/dist \
+            -cf "$RUNNER_TEMP/artifact.tar" \
+            --exclude=.git \
+            --exclude=.github \
+            .
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: github.ref == 'refs/heads/trunk' && github.event_name != 'pull_request'
         with:
-          path: website/.vitepress/dist
+          name: github-pages
+          path: ${{ runner.temp }}/artifact.tar
+          retention-days: 1
+          if-no-files-found: error
 
   deploy:
     name: Deploy

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,8 @@ permissions:
 
 concurrency:
   group: pages-${{ github.ref }}
-  cancel-in-progress: true
+  # Never cancel a deploy that is already talking to the Pages API.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:
@@ -47,8 +48,9 @@ jobs:
       # actions/upload-pages-artifact is composite and calls an unpinned
       # actions/upload-artifact@v4, which the org SHA-pin policy rejects.
       # These two steps are what it does internally.
+      # Runs on pull requests too, so a mistake here fails the PR and not the
+      # first deploy after the merge.
       - name: Archive artifact
-        if: github.ref == 'refs/heads/trunk' && github.event_name != 'pull_request'
         run: |
           tar --dereference --hard-dereference \
             --directory .vitepress/dist \

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 [![PHP](https://img.shields.io/badge/PHP-8.2%20%7C%208.3%20%7C%208.4%20%7C%208.5-8892BF)](https://www.php.net)
 [![ScyllaDB](https://img.shields.io/badge/ScyllaDB-Developers-4C388C)](https://discord.gg/B6rutCXvgp)
 
+**[Read the documentation →](https://he4rt.github.io/scylladb-php-driver/)**
+
 </div>
 
 A high-performance PHP extension for [ScyllaDB](https://www.scylladb.com) and [Apache Cassandra](https://cassandra.apache.org) 3.0+, built on top of the [ScyllaDB C/C++ Driver](https://github.com/scylladb/cpp-driver). Communicates exclusively over the native CQL binary protocol.

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+.vitepress/dist/
+.vitepress/cache/
+
+# The repository root ignores `config.*` for the autotools build.
+!.vitepress/config.mts

--- a/website/.vitepress/config.mts
+++ b/website/.vitepress/config.mts
@@ -1,0 +1,140 @@
+import { defineConfig } from 'vitepress'
+
+const repo = 'https://github.com/he4rt/scylladb-php-driver'
+
+export default defineConfig({
+  title: 'ScyllaDB PHP Driver',
+  description:
+    'A high-performance PHP extension for ScyllaDB and Apache Cassandra, built on the native CQL binary protocol.',
+  lang: 'en-US',
+  base: '/scylladb-php-driver/',
+  cleanUrls: true,
+  lastUpdated: true,
+  appearance: 'dark',
+  ignoreDeadLinks: false,
+
+  head: [
+    ['link', { rel: 'icon', type: 'image/svg+xml', href: '/scylladb-php-driver/logo.svg' }],
+    ['meta', { name: 'theme-color', content: '#6D4AFF' }],
+    ['meta', { property: 'og:type', content: 'website' }],
+    ['meta', { property: 'og:title', content: 'ScyllaDB PHP Driver' }],
+    [
+      'meta',
+      {
+        property: 'og:description',
+        content: 'A high-performance PHP extension for ScyllaDB and Apache Cassandra.',
+      },
+    ],
+  ],
+
+  markdown: {
+    theme: { light: 'github-light', dark: 'houston' },
+    lineNumbers: false,
+  },
+
+  sitemap: {
+    hostname: 'https://he4rt.github.io/scylladb-php-driver/',
+  },
+
+  themeConfig: {
+    logo: '/logo.svg',
+    siteTitle: 'ScyllaDB PHP',
+
+    nav: [
+      { text: 'Guide', link: '/guide/introduction', activeMatch: '/guide/' },
+      { text: 'Reference', link: '/reference/cluster-builder', activeMatch: '/reference/' },
+      {
+        text: 'Resources',
+        items: [
+          { text: 'Packagist', link: 'https://packagist.org/packages/codelieutenant/scylla-driver' },
+          { text: 'Changelog', link: `${repo}/blob/trunk/CHANGELOG.md` },
+          { text: 'Contributing', link: `${repo}/blob/trunk/CONTRIBUTING.md` },
+          { text: 'Discord', link: 'https://discord.gg/B6rutCXvgp' },
+        ],
+      },
+    ],
+
+    sidebar: {
+      '/guide/': [
+        {
+          text: 'Getting started',
+          collapsed: false,
+          items: [
+            { text: 'Introduction', link: '/guide/introduction' },
+            { text: 'Installation', link: '/guide/installation' },
+            { text: 'Quick start', link: '/guide/quickstart' },
+          ],
+        },
+        {
+          text: 'Connecting',
+          collapsed: false,
+          items: [
+            { text: 'Clusters and sessions', link: '/guide/connecting' },
+            { text: 'Authentication', link: '/guide/authentication' },
+            { text: 'TLS and SSL', link: '/guide/tls' },
+            { text: 'Load balancing and routing', link: '/guide/load-balancing' },
+            { text: 'Connection pool and timeouts', link: '/guide/connection-tuning' },
+            { text: 'Retry policies', link: '/guide/retry-policies' },
+          ],
+        },
+        {
+          text: 'Working with data',
+          collapsed: false,
+          items: [
+            { text: 'Queries and statements', link: '/guide/queries' },
+            { text: 'Results and paging', link: '/guide/results' },
+            { text: 'Data types', link: '/guide/data-types' },
+            { text: 'Collections and UDTs', link: '/guide/collections' },
+            { text: 'Batches', link: '/guide/batches' },
+            { text: 'Asynchronous queries', link: '/guide/async' },
+            { text: 'Schema metadata', link: '/guide/schema-metadata' },
+          ],
+        },
+        {
+          text: 'Operating',
+          collapsed: false,
+          items: [
+            { text: 'Error handling', link: '/guide/error-handling' },
+            { text: 'Performance', link: '/guide/performance' },
+            { text: 'Metrics and logging', link: '/guide/observability' },
+            { text: 'Troubleshooting', link: '/guide/troubleshooting' },
+          ],
+        },
+      ],
+      '/reference/': [
+        {
+          text: 'API reference',
+          collapsed: false,
+          items: [
+            { text: 'Cluster\\Builder', link: '/reference/cluster-builder' },
+            { text: 'Cluster and Session', link: '/reference/session' },
+            { text: 'Statements', link: '/reference/statements' },
+            { text: 'Rows and Futures', link: '/reference/rows-futures' },
+            { text: 'Value classes', link: '/reference/values' },
+            { text: 'Type factory', link: '/reference/types' },
+            { text: 'Constants', link: '/reference/constants' },
+            { text: 'Exceptions', link: '/reference/exceptions' },
+          ],
+        },
+      ],
+    },
+
+    socialLinks: [{ icon: 'github', link: repo }],
+
+    editLink: {
+      pattern: `${repo}/edit/trunk/website/:path`,
+      text: 'Edit this page on GitHub',
+    },
+
+    search: {
+      provider: 'local',
+    },
+
+    outline: { level: [2, 3], label: 'On this page' },
+
+    footer: {
+      message: 'Released under the Apache License 2.0.',
+      copyright: 'Copyright © DataStax, Inc. and contributors.',
+    },
+  },
+})

--- a/website/.vitepress/theme/index.ts
+++ b/website/.vitepress/theme/index.ts
@@ -1,0 +1,5 @@
+import DefaultTheme from 'vitepress/theme'
+import type { Theme } from 'vitepress'
+import './style.css'
+
+export default DefaultTheme satisfies Theme

--- a/website/.vitepress/theme/style.css
+++ b/website/.vitepress/theme/style.css
@@ -1,0 +1,187 @@
+/**
+ * ScyllaDB PHP driver — theme overrides.
+ * Palette: ScyllaDB violet -> cyan, on a near-black neutral ramp.
+ */
+
+:root {
+  --vp-c-brand-1: #5b3fd9;
+  --vp-c-brand-2: #4a32b8;
+  --vp-c-brand-3: #6d4aff;
+  --vp-c-brand-soft: rgba(109, 74, 255, 0.14);
+
+  --vp-c-tip-1: var(--vp-c-brand-1);
+  --vp-c-tip-2: var(--vp-c-brand-2);
+  --vp-c-tip-3: var(--vp-c-brand-3);
+  --vp-c-tip-soft: var(--vp-c-brand-soft);
+
+  --vp-code-block-bg: #f6f6f9;
+
+  --vp-home-hero-name-color: transparent;
+  --vp-home-hero-name-background: linear-gradient(110deg, #6d4aff 10%, #a855f7 45%, #06b6d4 100%);
+  --vp-home-hero-image-background-image: linear-gradient(
+    -45deg,
+    rgba(109, 74, 255, 0.55),
+    rgba(6, 182, 212, 0.45)
+  );
+  --vp-home-hero-image-filter: blur(48px);
+
+  --vp-button-brand-bg: var(--vp-c-brand-3);
+  --vp-button-brand-hover-bg: #5a3aff;
+  --vp-button-brand-active-bg: #4e2ff5;
+  --vp-button-brand-border: transparent;
+}
+
+.dark {
+  --vp-c-brand-1: #a78bfa;
+  --vp-c-brand-2: #c4b5fd;
+  --vp-c-brand-3: #7c5cff;
+  --vp-c-brand-soft: rgba(124, 92, 255, 0.2);
+
+  --vp-c-bg: #0c0c11;
+  --vp-c-bg-alt: #08080c;
+  --vp-c-bg-soft: #131320;
+  --vp-c-bg-elv: #14141f;
+
+  --vp-code-block-bg: #0a0a12;
+  --vp-c-divider: rgba(140, 140, 180, 0.16);
+  --vp-c-gutter: rgba(140, 140, 180, 0.16);
+}
+
+/* Hero ---------------------------------------------------------------- */
+
+.VPHero .name {
+  letter-spacing: -0.02em;
+}
+
+.VPHero .tagline {
+  max-width: 46ch;
+}
+
+@media (min-width: 640px) {
+  .VPHome {
+    position: relative;
+  }
+
+  .VPHome::before {
+    content: '';
+    position: absolute;
+    inset: -20% 0 auto 0;
+    height: 620px;
+    pointer-events: none;
+    z-index: -1;
+    background:
+      radial-gradient(60% 55% at 22% 22%, rgba(109, 74, 255, 0.22), transparent 70%),
+      radial-gradient(45% 45% at 80% 12%, rgba(6, 182, 212, 0.16), transparent 70%);
+  }
+}
+
+/* Feature cards ------------------------------------------------------- */
+
+.VPFeature {
+  border: 1px solid var(--vp-c-divider);
+  background: var(--vp-c-bg-soft);
+  transition:
+    border-color 0.25s,
+    transform 0.25s,
+    box-shadow 0.25s;
+}
+
+.VPFeature:hover {
+  border-color: var(--vp-c-brand-3);
+  transform: translateY(-2px);
+  box-shadow: 0 12px 32px -18px rgba(109, 74, 255, 0.9);
+}
+
+.VPFeature .icon {
+  background: linear-gradient(135deg, rgba(109, 74, 255, 0.18), rgba(6, 182, 212, 0.14));
+  border: 1px solid var(--vp-c-divider);
+}
+
+/* Content ------------------------------------------------------------- */
+
+/* Reference tables carry long PHP signatures, so give the doc column more
+   room than the VitePress default. */
+
+:root {
+  --vp-layout-max-width: 1560px;
+}
+
+@media (min-width: 1280px) {
+  .VPContent .VPDoc.has-aside .content-container {
+    max-width: 760px;
+  }
+}
+
+@media (min-width: 1600px) {
+  .VPContent .VPDoc.has-aside .content-container {
+    max-width: 940px;
+  }
+}
+
+.vp-doc h2 {
+  border-top: 1px solid var(--vp-c-divider);
+  padding-top: 26px;
+  letter-spacing: -0.01em;
+}
+
+/* Keep VitePress's `display: block; overflow-x: auto` so wide tables scroll
+   inside their own box instead of widening the page. */
+
+.vp-doc table {
+  font-size: 14.5px;
+}
+
+.vp-doc th {
+  font-size: 13px;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--vp-c-text-2);
+  background: var(--vp-c-bg-soft);
+}
+
+.vp-doc tr {
+  background: transparent;
+}
+
+.vp-doc td code,
+.vp-doc th code {
+  font-size: 13px;
+}
+
+.vp-doc td:first-child {
+  min-width: 14rem;
+}
+
+.vp-doc div[class*='language-'] {
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 10px;
+}
+
+/* A compact key/value grid used for option tables that do not fit a table. */
+
+.opt-grid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  margin: 20px 0;
+}
+
+.opt-grid > div {
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 10px;
+  padding: 14px 16px;
+  background: var(--vp-c-bg-soft);
+}
+
+.opt-grid strong {
+  display: block;
+  font-size: 14px;
+  margin-bottom: 4px;
+}
+
+.opt-grid p {
+  margin: 0;
+  font-size: 13.5px;
+  color: var(--vp-c-text-2);
+  line-height: 1.55;
+}

--- a/website/README.md
+++ b/website/README.md
@@ -1,0 +1,53 @@
+# Documentation site
+
+The user documentation, published to GitHub Pages at
+<https://he4rt.github.io/scylladb-php-driver/>.
+
+Built with [VitePress](https://vitepress.dev).
+
+## Develop
+
+```bash
+cd website
+npm install
+npm run dev      # http://localhost:5173/scylladb-php-driver/
+```
+
+## Build
+
+```bash
+npm run build    # output in .vitepress/dist
+npm run preview  # serve the built site
+```
+
+The build fails on a dead internal link, because `ignoreDeadLinks` is `false`. Run
+`npm run build` before you open a pull request.
+
+## Structure
+
+```
+website/
+├── .vitepress/
+│   ├── config.mts        # nav, sidebar, search, site metadata
+│   └── theme/
+│       ├── index.ts      # extends the default theme
+│       └── style.css     # palette and layout overrides
+├── public/logo.svg
+├── index.md              # home page
+├── guide/                # task-oriented pages
+└── reference/            # API reference pages
+```
+
+## Add a page
+
+1. Create the Markdown file under `guide/` or `reference/`.
+2. Add it to the matching `sidebar` array in `.vitepress/config.mts`.
+3. Run `npm run build` to check the links.
+
+## Publish
+
+`.github/workflows/docs.yml` builds every push to `trunk` that touches `website/`, then deploys to
+GitHub Pages. Pull requests build but do not deploy.
+
+The repository needs **Settings → Pages → Build and deployment → Source: GitHub Actions** for the
+deployment step to work.

--- a/website/guide/async.md
+++ b/website/guide/async.md
@@ -1,0 +1,223 @@
+# Asynchronous queries
+
+Every blocking call has an asynchronous twin that returns a future. The request starts at once. The
+result arrives when you ask for it.
+
+| Blocking | Asynchronous | Future class |
+| --- | --- | --- |
+| `Cluster::connect()` | `Cluster::connectAsync()` | `Cassandra\FutureSession` |
+| `Session::execute()` | `Session::executeAsync()` | `Cassandra\FutureRows` |
+| `Session::prepare()` | `Session::prepareAsync()` | `Cassandra\FuturePreparedStatement` |
+| `Session::close()` | `Session::closeAsync()` | `Cassandra\FutureClose` |
+| `Rows::nextPage()` | `Rows::nextPageAsync()` | `Cassandra\Future` |
+
+All of them implement `Cassandra\Future`:
+
+```php
+interface Future
+{
+    public function get(int|float|null $timeout = null): mixed;
+}
+```
+
+`get()` blocks until the result arrives, then returns it. It throws the same exceptions the blocking
+call would throw. Calling `get()` twice returns the same result.
+
+## The basic pattern
+
+```php
+$future = $session->executeAsync($statement, ['arguments' => [$id]]);
+
+// Do other work here. The query is already travelling.
+
+$rows = $future->get();
+```
+
+One future on its own buys little. The gain comes from starting many at once.
+
+## Running queries in parallel
+
+```php
+$statement = $session->prepare('SELECT * FROM users WHERE id = ?');
+
+$futures = [];
+foreach ($ids as $id) {
+    $futures[(string) $id] = $session->executeAsync($statement, ['arguments' => [$id]]);
+}
+
+$users = [];
+foreach ($futures as $key => $future) {
+    $users[$key] = $future->get()->first();
+}
+```
+
+The whole set costs about as much as the slowest single query, not the sum. Each request goes to a
+replica that owns the data, so the load spreads across the cluster.
+
+::: warning Bound the number in flight
+Starting ten thousand futures at once fills the client request queue and the server. Work in
+windows.
+:::
+
+```php
+$window   = 128;
+$inFlight = [];
+$results  = [];
+
+foreach ($ids as $id) {
+    $inFlight[] = $session->executeAsync($statement, ['arguments' => [$id]]);
+
+    if (count($inFlight) >= $window) {
+        foreach ($inFlight as $future) {
+            $results[] = $future->get();
+        }
+        $inFlight = [];
+    }
+}
+
+foreach ($inFlight as $future) {
+    $results[] = $future->get();
+}
+```
+
+A window between 64 and 256 suits most workloads. Measure with your own data.
+
+## Timeouts
+
+`get()` takes a timeout in seconds:
+
+```php
+try {
+    $rows = $future->get(2.5);
+} catch (Cassandra\Exception\TimeoutException $e) {
+    // The result did not arrive in time. The request may still complete on the server.
+}
+```
+
+Without an argument, `get()` waits for the request timeout configured on the cluster. See
+[connection pool and timeouts](/guide/connection-tuning).
+
+## Errors
+
+A failed query throws from `get()`, not from `executeAsync()`. Wrap the collection loop:
+
+```php
+$futures = array_map(
+    fn ($id) => $session->executeAsync($statement, ['arguments' => [$id]]),
+    $ids,
+);
+
+$results = [];
+$errors  = [];
+
+foreach ($futures as $i => $future) {
+    try {
+        $results[$i] = $future->get();
+    } catch (Cassandra\Exception $e) {
+        $errors[$i] = $e;
+    }
+}
+```
+
+One failed future does not affect the others.
+
+## Connecting asynchronously
+
+```php
+$futureSession = $cluster->connectAsync('shop');
+
+// Load configuration, warm a cache, open other connections.
+
+$session = $futureSession->get(10.0);
+```
+
+Useful at process start, where the connection handshake and other startup work can overlap.
+
+## Preparing asynchronously
+
+Prepare a whole statement set at boot in parallel:
+
+```php
+$cql = [
+    'findById'    => 'SELECT * FROM users WHERE id = ?',
+    'findByEmail' => 'SELECT * FROM users_by_email WHERE email = ?',
+    'insert'      => 'INSERT INTO users (id, email) VALUES (?, ?)',
+];
+
+$futures = array_map(fn ($q) => $session->prepareAsync($q), $cql);
+$prepared = array_map(fn ($f) => $f->get(), $futures);
+
+$rows = $session->execute($prepared['findById'], ['arguments' => [$id]]);
+```
+
+## Pipelined paging
+
+`nextPageAsync()` fetches the next page while the current one is being processed:
+
+```php
+$rows = $session->execute($statement, ['page_size' => 1000]);
+
+while (true) {
+    $next = $rows->isLastPage() ? null : $rows->nextPageAsync();
+
+    foreach ($rows as $row) {
+        process($row);
+    }
+
+    if ($next === null) {
+        break;
+    }
+
+    $rows = $next->get();
+}
+```
+
+## A read-then-write pipeline
+
+```php
+$read  = $session->prepare('SELECT id, email FROM users WHERE id = ?');
+$write = $session->prepare('UPDATE users SET normalized_email = ? WHERE id = ?');
+
+$window = 100;
+$reads  = [];
+
+foreach ($ids as $id) {
+    $reads[] = $session->executeAsync($read, ['arguments' => [$id]]);
+
+    if (count($reads) < $window) {
+        continue;
+    }
+
+    $writes = [];
+    foreach ($reads as $future) {
+        $row = $future->get()->first();
+        if ($row === null) {
+            continue;
+        }
+        $writes[] = $session->executeAsync($write, [
+            'arguments' => [strtolower($row['email']), $row['id']],
+        ]);
+    }
+
+    foreach ($writes as $future) {
+        $future->get();
+    }
+
+    $reads = [];
+}
+```
+
+## What futures are not
+
+`get()` blocks the PHP process. The driver resolves futures on its own IO threads, but PHP has one
+execution thread, so:
+
+- **A future does not free the PHP process.** Between `executeAsync()` and `get()`, PHP can run
+  other PHP code, not other requests.
+- **There is no callback and no event loop integration** in this release. You cannot register a
+  handler that fires when the future resolves.
+- **`get()` is the only way to observe completion.** Collect futures in the order you want to
+  consume them.
+
+Within those limits, concurrency across many queries is real and large. The work happens on the C
+driver IO threads while PHP waits once instead of many times.

--- a/website/guide/authentication.md
+++ b/website/guide/authentication.md
@@ -1,0 +1,109 @@
+# Authentication
+
+The driver supports the password authenticator that ScyllaDB and Cassandra ship with
+(`PasswordAuthenticator`). Supply the credentials on the builder.
+
+```php
+$cluster = Cassandra::cluster()
+    ->withContactPoints('10.0.0.1')
+    ->withCredentials('app_user', getenv('SCYLLA_PASSWORD'))
+    ->build();
+```
+
+The password parameter carries the `#[\SensitiveParameter]` attribute. PHP redacts it in stack
+traces, so a leaked exception log does not expose the password.
+
+## Where credentials go
+
+Never write the password into source code. Read it from the environment or from a secret store:
+
+```php
+$password = getenv('SCYLLA_PASSWORD');
+
+if ($password === false || $password === '') {
+    throw new RuntimeException('SCYLLA_PASSWORD is not set');
+}
+
+$builder->withCredentials(getenv('SCYLLA_USER') ?: 'app_user', $password);
+```
+
+## Credentials travel in clear text
+
+The CQL password authenticator sends the user name and the password in a plain protocol frame.
+Anyone on the network path can read them.
+
+::: danger Always pair credentials with TLS
+Turn on TLS whenever the connection leaves a trusted network segment. See
+[TLS and SSL](/guide/tls).
+:::
+
+```php
+$cluster = Cassandra::cluster()
+    ->withContactPoints('db.internal.example.com')
+    ->withCredentials('app_user', getenv('SCYLLA_PASSWORD'))
+    ->withSSL(
+        Cassandra::ssl()
+            ->withTrustedCerts('/etc/ssl/certs/scylla-ca.pem')
+            ->withVerifyFlags(Cassandra::VERIFY_PEER_CERT | Cassandra::VERIFY_PEER_IDENTITY)
+            ->build()
+    )
+    ->build();
+```
+
+## Failures
+
+A wrong user name or password produces `Cassandra\Exception\AuthenticationException` from
+`connect()`. The exception message comes from the server.
+
+```php
+use Cassandra\Exception\AuthenticationException;
+
+try {
+    $session = $cluster->connect('shop');
+} catch (AuthenticationException $e) {
+    // Do not log the password. Log the user name and the server message only.
+    error_log(sprintf('auth failed for %s: %s', $user, $e->getMessage()));
+    throw $e;
+}
+```
+
+The exception arrives at `connect()` time, not at `build()` time. `build()` performs no network
+work.
+
+## A node with no authenticator
+
+When the cluster runs `AllowAllAuthenticator`, credentials are ignored. Sending them is harmless.
+The default ScyllaDB Docker image works this way, so local development needs no credentials:
+
+```php
+$session = Cassandra::cluster()
+    ->withContactPoints('127.0.0.1')
+    ->build()
+    ->connect();
+```
+
+## Per-user sessions
+
+The driver has no per-request user switch. Authentication belongs to the cluster configuration, so a
+second identity needs a second cluster and a second session.
+
+```php
+$readOnly  = makeCluster('reporting_user', $reportingPassword)->connect('shop');
+$readWrite = makeCluster('app_user', $appPassword)->connect('shop');
+```
+
+Each session opens its own connection pool. Two identities cost twice the sockets. Prefer one
+application identity plus CQL permissions on the server side.
+
+## Role permissions
+
+Authorization stays on the server. Grant the smallest useful set:
+
+```sql
+CREATE ROLE app_user WITH PASSWORD = '...' AND LOGIN = true;
+
+GRANT SELECT ON KEYSPACE shop TO app_user;
+GRANT MODIFY ON KEYSPACE shop TO app_user;
+```
+
+A denied operation raises `Cassandra\Exception\UnauthorizedException` at query time.

--- a/website/guide/batches.md
+++ b/website/guide/batches.md
@@ -1,0 +1,171 @@
+# Batches
+
+A batch sends several statements in one request. Its purpose is atomicity inside one partition, not
+throughput.
+
+```php
+$batch = new Cassandra\BatchStatement(Cassandra::BATCH_LOGGED);
+
+$batch->add($insertUser, [$id, 'ada@example.com']);
+$batch->add($insertIndex, ['ada@example.com', $id]);
+
+$session->execute($batch);
+```
+
+`add()` returns the batch, so calls chain:
+
+```php
+$batch
+    ->add($insertUser, [$id, $email])
+    ->add($insertIndex, [$email, $id]);
+```
+
+::: danger A batch is not a performance tool
+In a relational database a batch reduces round trips. In ScyllaDB it does the opposite when the
+statements touch different partitions: one coordinator receives everything and forwards each write,
+so it becomes a bottleneck and latency rises.
+
+Use [`executeAsync()`](/guide/async) for throughput. Use a batch for atomicity.
+:::
+
+## Batch types
+
+### `BATCH_LOGGED`
+
+```php
+new Cassandra\BatchStatement(Cassandra::BATCH_LOGGED);   // the default
+```
+
+The coordinator writes a batch log before it applies anything. If it dies partway, another node
+replays the log, so every statement eventually applies.
+
+The guarantee is atomicity, not isolation. Another reader can observe some statements applied and
+others not, while the batch is in flight.
+
+The batch log costs an extra write and an extra delete per batch. Use logged batches only where a
+partial apply would corrupt the data model, such as keeping a table and its inverted index in step.
+
+### `BATCH_UNLOGGED`
+
+```php
+new Cassandra\BatchStatement(Cassandra::BATCH_UNLOGGED);
+```
+
+No batch log, so no atomicity across partitions. When every statement targets the same partition,
+the write is atomic anyway and this is the right type.
+
+```php
+// Same partition key: one atomic write, no batch log.
+$batch = new Cassandra\BatchStatement(Cassandra::BATCH_UNLOGGED);
+$batch->add($insertEvent, [$userId, $event1Id, $payload1]);
+$batch->add($insertEvent, [$userId, $event2Id, $payload2]);
+```
+
+### `BATCH_COUNTER`
+
+```php
+new Cassandra\BatchStatement(Cassandra::BATCH_COUNTER);
+```
+
+Required for counter updates. A counter batch cannot contain a normal write, and a normal batch
+cannot contain a counter update.
+
+```php
+$batch = new Cassandra\BatchStatement(Cassandra::BATCH_COUNTER);
+$batch->add($incrementViews, [$postId]);
+$batch->add($incrementDaily, [$day, $postId]);
+```
+
+Counter updates are not idempotent. A retry double-counts. See
+[retry policies](/guide/retry-policies#retries-and-idempotency).
+
+## What you can add
+
+`add()` accepts a CQL string, a `Cassandra\SimpleStatement`, or a `Cassandra\PreparedStatement`. The
+second argument is the array of bound values.
+
+```php
+$batch->add('UPDATE users SET email = ? WHERE id = ?', [$email, $id]);
+
+$batch->add(new Cassandra\SimpleStatement('DELETE FROM sessions WHERE id = ?'), [$sid]);
+
+$prepared = $session->prepare('INSERT INTO audit (id, action) VALUES (?, ?)');
+$batch->add($prepared, [new Cassandra\Timeuuid(), 'login']);
+```
+
+Bind by name with a string-keyed array:
+
+```php
+$batch->add($prepared, ['id' => new Cassandra\Timeuuid(), 'action' => 'login']);
+```
+
+Prepared statements are as valuable in a batch as anywhere else.
+
+## Execution options
+
+A batch takes the same options as any statement:
+
+```php
+$session->execute($batch, [
+    'consistency' => Cassandra::CONSISTENCY_LOCAL_QUORUM,
+    'timeout'     => 5.0,
+]);
+```
+
+The `arguments` key does not apply. Values belong to each `add()` call.
+
+## Size limits
+
+The server rejects an oversized batch and warns about a large one. Both thresholds are server
+settings (`batch_size_fail_threshold_in_kb` and `batch_size_warn_threshold_in_kb`).
+
+Keep a batch small, in the tens of statements. Split a large workload:
+
+```php
+foreach (array_chunk($writes, 25) as $chunk) {
+    $batch = new Cassandra\BatchStatement(Cassandra::BATCH_UNLOGGED);
+
+    foreach ($chunk as [$id, $email]) {
+        $batch->add($insert, [$id, $email]);
+    }
+
+    $session->execute($batch);
+}
+```
+
+## When to use what
+
+| Goal | Tool |
+| --- | --- |
+| Several rows in one partition, applied together | `BATCH_UNLOGGED` |
+| A table and its index kept in step across partitions | `BATCH_LOGGED` |
+| Counter updates | `BATCH_COUNTER` |
+| Many independent writes, as fast as possible | [`executeAsync()`](/guide/async) |
+| A conditional write | [A lightweight transaction](/guide/queries#lightweight-transactions) |
+
+## A bulk load, done right
+
+```php
+$insert  = $session->prepare('INSERT INTO users (id, email) VALUES (?, ?)');
+$inFlight = [];
+
+foreach ($records as $record) {
+    $inFlight[] = $session->executeAsync($insert, [
+        'arguments' => [$record['id'], $record['email']],
+    ]);
+
+    if (count($inFlight) >= 100) {
+        foreach ($inFlight as $future) {
+            $future->get();
+        }
+        $inFlight = [];
+    }
+}
+
+foreach ($inFlight as $future) {
+    $future->get();
+}
+```
+
+Each write goes straight to a replica, because the statement is prepared and routing is token aware.
+No single coordinator carries the whole load.

--- a/website/guide/collections.md
+++ b/website/guide/collections.md
@@ -1,0 +1,293 @@
+# Collections and user defined types
+
+CQL has four composite types. Each maps to a PHP class that carries its element type, because the
+driver must know the CQL type to encode the values.
+
+| CQL | PHP class | Ordered | Duplicates | Keyed |
+| --- | --- | --- | --- | --- |
+| `list<T>` | `Cassandra\Collection` | yes | yes | no |
+| `set<T>` | `Cassandra\Set` | no | no | no |
+| `map<K,V>` | `Cassandra\Map` | no | no | yes |
+| `tuple<A,B,…>` | `Cassandra\Tuple` | yes, fixed | — | by position |
+| user defined type | `Cassandra\UserTypeValue` | — | — | by field name |
+
+All of them implement `Countable` and `Iterator`. `Map` also implements `ArrayAccess`.
+
+## Lists
+
+```sql
+CREATE TABLE posts (id uuid PRIMARY KEY, tags list<text>);
+```
+
+```php
+$tags = new Cassandra\Collection(Cassandra::TYPE_TEXT);
+
+$tags->add('php');                 // returns the new count
+$tags->add('scylladb', 'cql');     // variadic
+
+$tags->get(0);           // 'php'
+$tags->find('cql');      // 2, or null when absent
+$tags->remove(0);        // true
+count($tags);            // 2
+$tags->values();         // a plain PHP array
+
+$session->execute($insert, ['arguments' => [$id, $tags]]);
+```
+
+The constructor takes a type name string or a `Cassandra\Type`:
+
+```php
+new Cassandra\Collection(Cassandra::TYPE_TEXT);
+new Cassandra\Collection(Cassandra\Type::text());
+```
+
+## Sets
+
+```sql
+CREATE TABLE users (id uuid PRIMARY KEY, roles set<text>);
+```
+
+```php
+$roles = new Cassandra\Set(Cassandra::TYPE_TEXT);
+
+$roles->add('admin');      // true when added, false when already present
+$roles->add('admin');      // false
+$roles->has('admin');      // true
+$roles->remove('admin');   // true
+$roles->values();          // a plain PHP array
+```
+
+A set holds each value once and does not keep insertion order. Use it for membership. Use a list
+when order matters.
+
+## Maps
+
+```sql
+CREATE TABLE users (id uuid PRIMARY KEY, attributes map<text, int>);
+```
+
+```php
+$attrs = new Cassandra\Map(Cassandra::TYPE_TEXT, Cassandra::TYPE_INT);
+
+$attrs->set('logins', 12);
+$attrs->get('logins');       // 12
+$attrs->has('logins');       // true
+$attrs->remove('logins');    // true
+
+// ArrayAccess works as well:
+$attrs['logins'] = 12;
+echo $attrs['logins'];
+unset($attrs['logins']);
+
+$attrs->keys();     // a plain PHP array
+$attrs->values();   // a plain PHP array
+```
+
+A map key can be any CQL type, including a value class:
+
+```php
+$byId = new Cassandra\Map(Cassandra::TYPE_UUID, Cassandra::TYPE_TEXT);
+$byId->set(new Cassandra\Uuid(), 'ada');
+```
+
+That is why `Map` does not simply take a PHP array. A PHP array key can only be an int or a string.
+
+## Tuples
+
+A tuple is a fixed-length, positional group with a type per position.
+
+```sql
+CREATE TABLE places (id uuid PRIMARY KEY, coords tuple<double, double, text>);
+```
+
+```php
+$coords = new Cassandra\Tuple([
+    Cassandra::TYPE_DOUBLE,
+    Cassandra::TYPE_DOUBLE,
+    Cassandra::TYPE_TEXT,
+]);
+
+$coords->set(0, 48.8584);
+$coords->set(1, 2.2945);
+$coords->set(2, 'Paris');
+
+$coords->get(0);     // 48.8584
+$coords->values();   // [48.8584, 2.2945, 'Paris']
+count($coords);      // 3
+```
+
+Build one from a type object instead, which is shorter:
+
+```php
+$type = Cassandra\Type::tuple(
+    Cassandra\Type::double(),
+    Cassandra\Type::double(),
+    Cassandra\Type::text(),
+);
+
+$coords = $type->create(48.8584, 2.2945, 'Paris');
+```
+
+## User defined types
+
+```sql
+CREATE TYPE shop.address (
+    street text,
+    city text,
+    zip text,
+    country text
+);
+
+CREATE TABLE shop.users (
+    id uuid PRIMARY KEY,
+    home frozen<address>
+);
+```
+
+### Building a value
+
+```php
+$address = new Cassandra\UserTypeValue([
+    'street'  => Cassandra::TYPE_TEXT,
+    'city'    => Cassandra::TYPE_TEXT,
+    'zip'     => Cassandra::TYPE_TEXT,
+    'country' => Cassandra::TYPE_TEXT,
+]);
+
+$address->set('street', '1 Rue de Rivoli');
+$address->set('city', 'Paris');
+$address->set('zip', '75001');
+$address->set('country', 'FR');
+
+$session->execute($insert, ['arguments' => [$id, $address]]);
+```
+
+### Building from the schema
+
+Declaring the field types by hand duplicates the schema. Read the real type from the cluster
+instead:
+
+```php
+$type = $session->schema()
+    ->keyspace('shop')
+    ->userType('address');
+
+$address = $type->create(
+    'street',  '1 Rue de Rivoli',
+    'city',    'Paris',
+    'zip',     '75001',
+    'country', 'FR',
+);
+```
+
+`create()` takes alternating field names and values. The type stays in sync with the schema, so a
+new field does not break the code. See [schema metadata](/guide/schema-metadata).
+
+### Reading a value
+
+```php
+$row  = $session->execute($findById, ['arguments' => [$id]])->first();
+$home = $row['home'];   // Cassandra\UserTypeValue
+
+$home->get('city');     // 'Paris'
+$home->values();        // ['street' => ..., 'city' => ..., ...]
+
+foreach ($home as $field => $value) {
+    printf("%s = %s\n", $field, $value);
+}
+```
+
+## Nesting
+
+Composite types nest. Build the inner type first.
+
+```php
+// map<text, list<int>>
+$type = Cassandra\Type::map(
+    Cassandra\Type::text(),
+    Cassandra\Type::collection(Cassandra\Type::int()),
+);
+
+$scores = $type->create();
+
+$inner = Cassandra\Type::collection(Cassandra\Type::int())->create(10, 20, 30);
+$scores->set('round1', $inner);
+```
+
+```php
+// set<frozen<address>>
+$addressType = $session->schema()->keyspace('shop')->userType('address');
+$addresses   = Cassandra\Type::set($addressType)->create();
+
+$addresses->add($addressType->create('city', 'Paris', 'country', 'FR'));
+```
+
+CQL requires `frozen<...>` for a user defined type inside a collection. The driver follows whatever
+the schema declares.
+
+## Reading collections
+
+Collection columns come back as the matching class, never as a plain PHP array:
+
+```php
+$row = $session->execute('SELECT tags, attributes FROM posts')->first();
+
+$row['tags'];        // Cassandra\Collection
+$row['attributes'];  // Cassandra\Map
+
+// Convert when a plain array is easier to work with:
+$tags = $row['tags']->values();          // ['php', 'cql']
+$attrs = [];
+foreach ($row['attributes'] as $k => $v) {
+    $attrs[(string) $k] = $v;
+}
+```
+
+An empty collection in CQL is stored as `null`, so an empty list reads back as `null`, not as an
+empty `Collection`.
+
+```php
+$tags = $row['tags']?->values() ?? [];
+```
+
+## Updating without a read
+
+CQL updates collections in place. Do not read, change, and write back.
+
+```php
+// Append to a list.
+$session->execute(
+    'UPDATE posts SET tags = tags + ? WHERE id = ?',
+    ['arguments' => [$newTags, $id]],
+);
+
+// Add to a set.
+$session->execute(
+    'UPDATE users SET roles = roles + ? WHERE id = ?',
+    ['arguments' => [$newRoles, $id]],
+);
+
+// Set one map entry.
+$session->execute(
+    "UPDATE users SET attributes['logins'] = ? WHERE id = ?",
+    ['arguments' => [new Cassandra\Bigint(13), $id]],
+);
+```
+
+These updates are not idempotent. A retry can apply them twice. See
+[retry policies](/guide/retry-policies#retries-and-idempotency).
+
+## Size limits
+
+A collection is read and written as a whole cell. Keep them small, in the low hundreds of elements.
+For a growing list, model a clustering key instead:
+
+```sql
+-- Instead of events list<text> on the user row:
+CREATE TABLE user_events (
+    user_id uuid,
+    event_id timeuuid,
+    payload text,
+    PRIMARY KEY (user_id, event_id)
+) WITH CLUSTERING ORDER BY (event_id DESC);
+```

--- a/website/guide/connecting.md
+++ b/website/guide/connecting.md
@@ -1,0 +1,205 @@
+# Clusters and sessions
+
+Connecting has three steps. Each one produces a different object with a different lifetime.
+
+```
+Cassandra::cluster()
+        ▼
+Cassandra\Cluster\Builder    mutable, cheap, one per configuration
+        │ build()
+        ▼
+Cassandra\Cluster            immutable, holds no sockets
+        │ connect($keyspace)
+        ▼
+Cassandra\Session            owns the connection pool
+```
+
+## The builder
+
+`Cassandra::cluster()` returns a fresh `Cassandra\Cluster\Builder`. Every `with*()` method mutates
+the builder and returns it, so calls chain in any order.
+
+```php
+$builder = Cassandra::cluster()
+    ->withContactPoints('10.0.0.1', '10.0.0.2', '10.0.0.3')
+    ->withPort(9042)
+    ->withCredentials('app_user', getenv('SCYLLA_PASSWORD'))
+    ->withDefaultConsistency(Cassandra::CONSISTENCY_LOCAL_QUORUM)
+    ->withTokenAwareRouting(true);
+
+$cluster = $builder->build();
+```
+
+`build()` copies the configuration into an immutable `Cassandra\Cluster`. Later changes to the
+builder do not affect a cluster that is already built, so one builder can produce several clusters.
+
+## Contact points
+
+Contact points are the addresses the driver dials first. After the first connection succeeds, the
+driver reads the full node list from the cluster and connects to the rest.
+
+```php
+->withContactPoints('10.0.0.1', '10.0.0.2', '10.0.0.3')
+```
+
+The method is variadic. Spread an array when the list comes from configuration:
+
+```php
+$hosts = explode(',', getenv('SCYLLA_HOSTS') ?: '127.0.0.1');
+
+$builder->withContactPoints(...$hosts);
+```
+
+Guidance:
+
+- **Give two or three contact points, not one.** If the single contact point is down, the driver
+  cannot bootstrap, even when the rest of the cluster is healthy.
+- **Do not list every node.** The driver discovers them. A long list only slows down startup.
+- **Host names work.** Turn on `withHostnameResolution(true)` when you want the driver to resolve
+  peer IP addresses back to host names, which matters for TLS host name verification.
+- **Randomize the order** with `withRandomizedContactPoints(true)` so that many application
+  processes do not all hit the same node first. This is on by default.
+
+## Port
+
+```php
+->withPort(9042)
+```
+
+9042 is the CQL native port. Change it only when the cluster listens elsewhere. The port applies to
+every node, so a cluster with mixed ports is not supported.
+
+## Building and connecting
+
+```php
+$cluster = $builder->build();
+
+$session  = $cluster->connect();          // no keyspace
+$session  = $cluster->connect('shop');    // sets the keyspace
+$session  = $cluster->connect('shop', 10); // 10 second connect timeout
+```
+
+`connect()` blocks until the pool is ready. It throws on failure. The most common failures are
+`Cassandra\Exception\RuntimeException` for an unreachable host, and
+`Cassandra\Exception\AuthenticationException` for bad credentials.
+
+::: warning Empty keyspace strings
+Pass `null`, or omit the argument, when you have no keyspace. An empty string produces an invalid
+`USE` statement on newer drivers.
+
+```php
+$keyspace = getenv('SCYLLA_KEYSPACE') ?: null;
+$session  = $cluster->connect($keyspace);
+```
+:::
+
+### Connecting asynchronously
+
+```php
+$future  = $cluster->connectAsync('shop');
+// ... other startup work ...
+$session = $future->get(5.0);   // blocks up to 5 seconds
+```
+
+`connectAsync()` returns a `Cassandra\FutureSession`. Use it to overlap the connection handshake
+with other startup work. See [asynchronous queries](/guide/async).
+
+## The session
+
+A `Cassandra\Session` is the object you keep. It owns:
+
+- the connection pool to every node it knows about,
+- the prepared statement cache,
+- the schema metadata,
+- the load balancing and retry policy state.
+
+```php
+$session->execute($statement, $options);      // returns Rows
+$session->executeAsync($statement, $options); // returns FutureRows
+$session->prepare($cql);                      // returns PreparedStatement
+$session->prepareAsync($cql);                 // returns FuturePreparedStatement
+$session->schema();                           // returns Schema
+$session->metrics();                          // returns array
+$session->close();                            // blocks until closed
+$session->closeAsync();                       // returns FutureClose
+```
+
+### Session lifetime
+
+Opening a session is expensive. It performs a TCP handshake per connection, an optional TLS
+handshake, authentication, and a schema fetch. Do not do that per HTTP request.
+
+| Runtime | Recommendation |
+| --- | --- |
+| CLI script, worker, daemon | One session for the whole process. Reuse it. |
+| FrankenPHP, RoadRunner, Swoole | One session per worker, created at boot. |
+| PHP-FPM | Turn on persistent sessions. See below. |
+
+### Persistent sessions
+
+```php
+->withPersistentSessions(true)
+```
+
+With persistent sessions on, the driver caches the session in process memory and keys it by the
+connection configuration. A later `connect()` in the same PHP worker process returns the cached
+session instead of opening a new pool. This is what makes the driver usable under PHP-FPM, where
+each request starts a fresh PHP request but reuses the worker process.
+
+Two consequences:
+
+- Sessions live until the worker process exits. A configuration change needs a worker restart.
+- `close()` on a persistent session is a no-op for the pool. It stays available to the next request.
+
+Turn it off for tests and short lived scripts so each run starts clean.
+
+## Full connection example
+
+```php
+<?php
+
+declare(strict_types=1);
+
+function makeSession(): Cassandra\Session
+{
+    static $session = null;
+
+    if ($session !== null) {
+        return $session;
+    }
+
+    $ssl = Cassandra::ssl()
+        ->withTrustedCerts('/etc/ssl/certs/scylla-ca.pem')
+        ->withVerifyFlags(Cassandra::VERIFY_PEER_CERT | Cassandra::VERIFY_PEER_IDENTITY)
+        ->build();
+
+    $cluster = Cassandra::cluster()
+        ->withContactPoints(...explode(',', getenv('SCYLLA_HOSTS')))
+        ->withPort((int) (getenv('SCYLLA_PORT') ?: 9042))
+        ->withCredentials(getenv('SCYLLA_USER'), getenv('SCYLLA_PASSWORD'))
+        ->withSSL($ssl)
+        ->withDefaultConsistency(Cassandra::CONSISTENCY_LOCAL_QUORUM)
+        ->withDatacenterAwareRoundRobinLoadBalancingPolicy('eu-west-1', 0, false)
+        ->withTokenAwareRouting(true)
+        ->withConnectTimeout(5.0)
+        ->withRequestTimeout(12.0)
+        ->withConnectionsPerHost(2, 8)
+        ->withConnectionHeartbeatInterval(30.0)
+        ->withTCPNodelay(true)
+        ->withPersistentSessions(true)
+        ->build();
+
+    return $session = $cluster->connect(getenv('SCYLLA_KEYSPACE') ?: null);
+}
+```
+
+## Where to go next
+
+| Topic | Page |
+| --- | --- |
+| Username, password, and secrets | [Authentication](/guide/authentication) |
+| Certificates and verification | [TLS and SSL](/guide/tls) |
+| Which node gets the request | [Load balancing and routing](/guide/load-balancing) |
+| Pool size, timeouts, heartbeats | [Connection pool and timeouts](/guide/connection-tuning) |
+| What happens after a failure | [Retry policies](/guide/retry-policies) |
+| Every method, in one table | [`Cluster\Builder` reference](/reference/cluster-builder) |

--- a/website/guide/connection-tuning.md
+++ b/website/guide/connection-tuning.md
@@ -1,0 +1,177 @@
+# Connection pool and timeouts
+
+These settings control how many sockets the driver opens, how long it waits, and how it detects a
+dead connection. The defaults work for a small cluster and moderate traffic. Change them when you
+measure a reason to.
+
+## Timeouts
+
+All timeout values are given in **seconds**, as a float. `0.25` is 250 milliseconds.
+
+| Setting | Default | What it bounds |
+| --- | --- | --- |
+| `withConnectTimeout(float $seconds)` | 5.0 | The TCP and TLS handshake for one connection. |
+| `withRequestTimeout(float $seconds)` | 12.0 | One request, measured inside the C driver. |
+| `withDefaultTimeout(float $seconds)` | none | The default timeout applied by `execute()` when the call passes none. |
+
+```php
+->withConnectTimeout(5.0)
+->withRequestTimeout(12.0)
+->withDefaultTimeout(10.0)
+```
+
+Three timeouts exist because they answer different questions:
+
+- `withConnectTimeout()` bounds pool setup. Raise it on a high-latency link, lower it when you want
+  a dead node marked down quickly.
+- `withRequestTimeout()` is the hard ceiling the C driver enforces. Nothing can exceed it.
+- `withDefaultTimeout()` and the per-query `timeout` option bound the wait on the PHP side.
+
+A per-query timeout overrides the default:
+
+```php
+$rows = $session->execute($statement, ['timeout' => 2.5]);
+```
+
+::: tip Set the request timeout below the client timeout
+Give the application a shorter deadline than the server-side write timeout of your cluster.
+Otherwise the client gives up while the coordinator is still working, and a retry can duplicate a
+non-idempotent write.
+:::
+
+## Connections per host
+
+```php
+->withConnectionsPerHost(core: 1, max: 2)
+```
+
+| Parameter | Default | Range |
+| --- | --- | --- |
+| `core` | 1 | 1 to 128 |
+| `max` | 2 | 1 to 128 |
+
+`core` connections stay open to every node. The pool grows toward `max` under load and shrinks back.
+
+Each connection multiplexes many in-flight requests, so a single connection carries a lot of
+traffic. Raise the core count when:
+
+- Latency rises while node CPU stays low, which points at request queueing on the client.
+- Connection setup cost shows in the latency tail, which TLS makes worse.
+
+Remember the multiplier. `core: 4` against a 12-node cluster with 20 PHP-FPM workers is 960 open
+sockets from one host.
+
+## IO threads
+
+```php
+->withIOThreads(1)   // default 1, range 1 to 128
+```
+
+Each IO thread runs an event loop and owns a share of the connections. One thread is right for
+PHP-FPM and CLI scripts, because a PHP process handles one request at a time.
+
+Raise it only when one PHP process drives many concurrent queries, for example a worker that fans
+out with [`executeAsync()`](/guide/async), or a Swoole or RoadRunner runtime. Two to four threads
+covers almost every such case.
+
+## Heartbeats and reconnection
+
+```php
+->withConnectionHeartbeatInterval(30.0)   // seconds, default 30
+->withReconnectInterval(2.0)              // seconds, default 2
+```
+
+The heartbeat sends a lightweight request on an idle connection. It has two jobs: it detects a
+connection that a firewall or a load balancer silently dropped, and it stops idle timeouts from
+closing the connection.
+
+Lower the interval when a stateful firewall sits between the application and the cluster and cuts
+idle flows. A value below the firewall idle timeout keeps the connection alive.
+
+The reconnect interval is the constant delay between attempts to restore a connection to a node that
+is marked down.
+
+## TCP options
+
+```php
+->withTCPNodelay(true)      // default true
+->withTCPKeepalive(60.0)    // seconds; pass null to disable (default)
+```
+
+`TCP_NODELAY` disables Nagle's algorithm. Leave it on. CQL frames are small and latency-sensitive,
+and Nagle adds delay for no gain.
+
+TCP keepalive is the kernel-level probe. It is off by default because the driver heartbeat covers
+the same failure at the protocol level. Turn it on when a network device drops idle flows below the
+protocol layer.
+
+## Protocol version
+
+```php
+->withProtocolVersion(4)   // default 4
+```
+
+Version 4 works with every supported server. Lower it only for an old cluster that rejects the
+handshake. The driver does not negotiate downward on its own.
+
+## Page size
+
+```php
+->withDefaultPageSize(5000)   // default 5000
+```
+
+This is the number of rows the server returns per page. Change it per query with the `page_size`
+option. See [results and paging](/guide/results).
+
+## Schema metadata
+
+```php
+->withSchemaMetadata(true)   // default true
+```
+
+The driver fetches the schema at connect time and tracks changes. Metadata drives two things you
+probably want: [token-aware routing](/guide/load-balancing#token-aware-routing) and
+[`Session::schema()`](/guide/schema-metadata).
+
+Turning it off saves a small amount of memory and one fetch at startup. It costs you token
+awareness. That trade is rarely worth it.
+
+## A tuned configuration
+
+```php
+$cluster = Cassandra::cluster()
+    ->withContactPoints('10.1.0.11', '10.1.0.12', '10.1.0.13')
+
+    // Fail fast on a dead node, allow a slow query to finish.
+    ->withConnectTimeout(3.0)
+    ->withRequestTimeout(10.0)
+    ->withDefaultTimeout(8.0)
+
+    // A pool that absorbs a burst without opening sockets mid-peak.
+    ->withConnectionsPerHost(2, 8)
+    ->withIOThreads(1)
+
+    // Survive an idle-flow-killing firewall.
+    ->withConnectionHeartbeatInterval(20.0)
+    ->withReconnectInterval(2.0)
+    ->withTCPNodelay(true)
+
+    ->build();
+```
+
+## Checking the result
+
+`Session::metrics()` reports the live pool state. Watch `total_connections` and
+`available_connections` after a change, and watch the error counters for timeouts. See
+[metrics and logging](/guide/observability).
+
+```php
+$m = $session->metrics();
+
+printf(
+    "connections %d/%d, request timeouts %d\n",
+    $m['stats']['available_connections'],
+    $m['stats']['total_connections'],
+    $m['errors']['request_timeouts'],
+);
+```

--- a/website/guide/data-types.md
+++ b/website/guide/data-types.md
@@ -1,0 +1,264 @@
+# Data types
+
+CQL has more numeric types than PHP. PHP has one integer type and one float type, so the driver uses
+dedicated value classes wherever a plain PHP value would lose information or bind at the wrong
+width.
+
+All value classes live directly under `Cassandra\`. The sub-namespaces you see in the source tree
+organize files, not classes.
+
+```php
+new Cassandra\Bigint('9223372036854775807');   // correct
+new Cassandra\Numbers\Bigint(...);             // wrong, this class does not exist
+```
+
+## The mapping
+
+| CQL type | Read as | Bind with |
+| --- | --- | --- |
+| `ascii`, `text`, `varchar` | `string` | `string` |
+| `int` | `int` | `int` |
+| `bigint`, `counter` | `Cassandra\Bigint` | `Cassandra\Bigint` |
+| `smallint` | `Cassandra\Smallint` | `Cassandra\Smallint` |
+| `tinyint` | `Cassandra\Tinyint` | `Cassandra\Tinyint` |
+| `varint` | `Cassandra\Varint` | `Cassandra\Varint` |
+| `decimal` | `Cassandra\Decimal` | `Cassandra\Decimal` |
+| `float` | `Cassandra\Float` | `Cassandra\Float` |
+| `double` | `float` | `float` |
+| `boolean` | `bool` | `bool` |
+| `blob` | `Cassandra\Blob` | `Cassandra\Blob` |
+| `uuid` | `Cassandra\Uuid` | `Cassandra\Uuid` |
+| `timeuuid` | `Cassandra\Timeuuid` | `Cassandra\Timeuuid` |
+| `inet` | `Cassandra\Inet` | `Cassandra\Inet` |
+| `timestamp` | `Cassandra\Timestamp` | `Cassandra\Timestamp` |
+| `date` | `Cassandra\Date` | `Cassandra\Date` |
+| `time` | `Cassandra\Time` | `Cassandra\Time` |
+| `duration` | `Cassandra\Duration` | `Cassandra\Duration` |
+| `list<T>` | `Cassandra\Collection` | `Cassandra\Collection` |
+| `set<T>` | `Cassandra\Set` | `Cassandra\Set` |
+| `map<K,V>` | `Cassandra\Map` | `Cassandra\Map` |
+| `tuple<...>` | `Cassandra\Tuple` | `Cassandra\Tuple` |
+| user defined type | `Cassandra\UserTypeValue` | `Cassandra\UserTypeValue` |
+| any type, `NULL` value | `null` | `null` |
+
+Five CQL types map to PHP natives in both directions: `text` family, `int`, `double`, `boolean`, and
+`null`. Everything else uses a value class.
+
+## The four traps
+
+### 1. A plain int binds as a 4-byte int
+
+```php
+// Wrong. The server rejects it.
+$session->execute($insert, ['arguments' => [$id, 42]]);
+// Validation failed for type ... LongType: got 4 bytes
+
+// Right.
+$session->execute($insert, ['arguments' => [$id, new Cassandra\Bigint(42)]]);
+```
+
+A PHP `int` always binds as CQL `int`, which is 32 bits. A `bigint`, `counter`, `smallint`,
+`tinyint`, or `varint` column needs its own class.
+
+### 2. A plain float binds as a double
+
+```php
+// Wrong for a `float` column.
+$session->execute($insert, ['arguments' => [$id, 1.5]]);
+
+// Right.
+$session->execute($insert, ['arguments' => [$id, new Cassandra\Float(1.5)]]);
+```
+
+A PHP `float` is a double. CQL `float` is 32-bit, so it needs `Cassandra\Float`.
+
+### 3. Large integers arrive as strings
+
+```php
+$bigint = $row['login_count'];      // Cassandra\Bigint
+
+$bigint->value();                   // string, exact
+(string) $bigint;                   // the same string
+$bigint->toInt();                   // int, may overflow on a 32-bit value range
+```
+
+`value()` returns a string because a `varint` or a `decimal` can exceed the range of a PHP `int`.
+Convert only when you know the value fits.
+
+### 4. A blob is not a string
+
+```php
+$blob = new Cassandra\Blob(random_bytes(16));
+
+$blob->bytes();            // the raw bytes as a PHP string
+$blob->toBinaryString();   // the raw bytes as a PHP string
+(string) $blob;            // the hexadecimal form, for display
+```
+
+Binding a plain PHP string to a `blob` column binds it as text. Wrap it.
+
+## Numbers
+
+`Bigint`, `Smallint`, `Tinyint`, `Varint`, `Decimal`, and `Float` all implement
+`Cassandra\Numeric`, so they share an arithmetic interface that preserves precision.
+
+```php
+$a = new Cassandra\Bigint('9007199254740993');
+$b = new Cassandra\Bigint(2);
+
+$a->add($b);      // Cassandra\Bigint
+$a->sub($b);
+$a->mul($b);
+$a->div($b);
+$a->mod($b);
+$a->abs();
+$a->neg();
+$a->sqrt();
+
+$a->toInt();      // int
+$a->toDouble();   // float
+(string) $a;      // exact decimal string
+```
+
+The constructors accept an `int`, a `float`, a numeric `string`, or another instance of the same
+class. Pass a string for any value that a PHP `int` cannot hold exactly.
+
+`Bigint`, `Smallint`, `Tinyint`, and `Float` also expose the range:
+
+```php
+Cassandra\Bigint::min();   // -9223372036854775808
+Cassandra\Bigint::max();   //  9223372036854775807
+```
+
+`Decimal` keeps an unscaled value and a scale:
+
+```php
+$price = new Cassandra\Decimal('19.99');
+
+$price->value();   // '1999' — the unscaled integer
+$price->scale();   // 2
+(string) $price;   // '19.99'
+```
+
+Division by zero raises `Cassandra\Exception\DivideByZeroException`.
+
+`Float` reports the special values:
+
+```php
+$f = new Cassandra\Float(INF);
+
+$f->isInfinite();   // true
+$f->isFinite();     // false
+$f->isNaN();        // false
+```
+
+## Dates and times
+
+CQL splits date and time. The driver mirrors that split.
+
+| Class | CQL type | Holds |
+| --- | --- | --- |
+| `Cassandra\Timestamp` | `timestamp` | A point in time, millisecond resolution |
+| `Cassandra\Date` | `date` | A calendar day, no time and no zone |
+| `Cassandra\Time` | `time` | A time of day, nanosecond resolution |
+| `Cassandra\Duration` | `duration` | Months, days, and nanoseconds |
+
+```php
+$ts = new Cassandra\Timestamp(time());                 // from a Unix timestamp
+$ts = Cassandra\Timestamp::fromDateTime(new DateTime());
+
+$ts->time();                 // seconds
+$ts->microtime(true);        // float
+$ts->toDateTime();           // DateTime
+```
+
+```php
+$date = new Cassandra\Date(time());
+$date = Cassandra\Date::fromDateTime(new DateTimeImmutable('2026-08-05'));
+
+$date->seconds();                       // Unix seconds at midnight
+$date->toDateTime();                    // DateTime, midnight
+$date->toDateTime(new Cassandra\Time(0)); // combine a date and a time
+```
+
+```php
+$time = new Cassandra\Time(3_600_000_000_000);   // nanoseconds since midnight
+$time = Cassandra\Time::fromDateTime(new DateTime('13:45:00'));
+
+$time->seconds();
+```
+
+`Duration` is a calendar-aware interval, so it is not a fixed number of seconds. One month has a
+different length depending on the month.
+
+```php
+$d = new Cassandra\Duration(months: 1, days: 15, nanos: 0);
+
+$d->months();   // string
+$d->days();     // string
+$d->nanos();    // string
+(string) $d;    // '1mo15d0ns'
+```
+
+The string form is `Mmo Dd Nns` without spaces. A negative duration leads with a minus sign, so
+`(-3, -2, -1)` prints as `-3mo2d1ns`.
+
+## UUIDs
+
+```php
+$id = new Cassandra\Uuid();                                      // random version 4
+$id = new Cassandra\Uuid('7b5a4c1e-8f2a-4c9e-9a1b-3c2d1e0f5a6b'); // from a string
+
+$id->uuid();      // canonical string
+$id->version();   // 4
+(string) $id;     // canonical string
+```
+
+A `timeuuid` embeds a timestamp and sorts by time. Use it as a clustering key for an event log.
+
+```php
+$tid = new Cassandra\Timeuuid();          // now
+$tid = new Cassandra\Timeuuid(time());    // from a Unix timestamp
+
+$tid->time();      // Unix seconds
+$tid->version();   // 1
+```
+
+Both implement `Cassandra\UuidInterface`.
+
+## IP addresses
+
+```php
+$ip = new Cassandra\Inet('192.168.1.1');
+$ip = new Cassandra\Inet('2001:db8::1');
+
+$ip->address();   // the string form
+```
+
+IPv4 and IPv6 both work. An invalid address raises
+`Cassandra\Exception\InvalidArgumentException`.
+
+## Type names in code
+
+Every value has a `type()` method that returns a `Cassandra\Type`:
+
+```php
+$row['login_count']->type()->name();   // 'bigint'
+(string) $row['tags']->type();         // 'set<text>'
+```
+
+The `Cassandra\Type` factory builds type objects, which collection constructors need. See
+[collections and user defined types](/guide/collections) and the
+[type factory reference](/reference/types).
+
+## Comparison and equality
+
+Value objects define their own comparison, so `==` compares the value, not the object identity:
+
+```php
+new Cassandra\Bigint(42) == new Cassandra\Bigint(42);   // true
+new Cassandra\Bigint(42) === new Cassandra\Bigint(42);  // false, different objects
+```
+
+Use `==` for a value comparison. For a sort, compare the string form or use `toInt()` when the range
+allows it.

--- a/website/guide/error-handling.md
+++ b/website/guide/error-handling.md
@@ -1,0 +1,209 @@
+# Error handling
+
+Every exception the driver throws implements `Cassandra\Exception`. Each one also extends a matching
+SPL exception, so existing `catch (RuntimeException $e)` blocks keep working.
+
+```php
+try {
+    $rows = $session->execute($statement, ['arguments' => [$id]]);
+} catch (Cassandra\Exception $e) {
+    // Any driver error.
+}
+```
+
+## The hierarchy
+
+```
+Cassandra\Exception  (interface)
+│
+├── Cassandra\Exception\LogicException            extends \LogicException
+├── Cassandra\Exception\DomainException           extends \DomainException
+├── Cassandra\Exception\InvalidArgumentException  extends \InvalidArgumentException
+├── Cassandra\Exception\RangeException            extends \RangeException
+│   └── Cassandra\Exception\DivideByZeroException
+│
+└── Cassandra\Exception\RuntimeException          extends \RuntimeException
+    ├── Cassandra\Exception\TimeoutException
+    ├── Cassandra\Exception\AuthenticationException
+    ├── Cassandra\Exception\ProtocolException
+    │
+    ├── Cassandra\Exception\ExecutionException
+    │   ├── Cassandra\Exception\ReadTimeoutException
+    │   ├── Cassandra\Exception\WriteTimeoutException
+    │   ├── Cassandra\Exception\UnavailableException
+    │   └── Cassandra\Exception\TruncateException
+    │
+    ├── Cassandra\Exception\ValidationException
+    │   ├── Cassandra\Exception\InvalidQueryException
+    │   ├── Cassandra\Exception\InvalidSyntaxException
+    │   ├── Cassandra\Exception\UnauthorizedException
+    │   ├── Cassandra\Exception\UnpreparedException
+    │   └── Cassandra\Exception\ConfigurationException
+    │       └── Cassandra\Exception\AlreadyExistsException
+    │
+    └── Cassandra\Exception\ServerException
+        ├── Cassandra\Exception\IsBootstrappingException
+        └── Cassandra\Exception\OverloadedException
+```
+
+The three branches under `RuntimeException` split by cause, which is what decides your response:
+
+| Branch | Cause | Retry? |
+| --- | --- | --- |
+| `ExecutionException` | The cluster could not complete the request | Often yes |
+| `ValidationException` | The request is wrong | No |
+| `ServerException` | A node is not in a state to serve | Yes, after a delay |
+
+## The exceptions that matter
+
+### `ReadTimeoutException`
+
+Not enough replicas answered a read in time. The data may be fine. A retry commonly succeeds, and
+the [default retry policy](/guide/retry-policies) already tried once.
+
+```php
+catch (Cassandra\Exception\ReadTimeoutException $e) {
+    // Safe to retry. Consider a lower consistency for this specific read.
+}
+```
+
+### `WriteTimeoutException`
+
+The coordinator did not get enough acknowledgements in time. **The write may have applied.** A
+timeout is not a rejection.
+
+```php
+catch (Cassandra\Exception\WriteTimeoutException $e) {
+    // Retry only when the write is idempotent.
+    // A counter increment or a collection append must not be retried blindly.
+}
+```
+
+### `UnavailableException`
+
+The coordinator knows there are not enough live replicas to meet the consistency level. It did not
+even try. Retrying at once fails again.
+
+```php
+catch (Cassandra\Exception\UnavailableException $e) {
+    // A node is down. Back off, or degrade the consistency deliberately.
+}
+```
+
+### `InvalidQueryException` and `InvalidSyntaxException`
+
+A bug in the query, the table name, or the column list. Never retry. Let it reach your error
+reporting.
+
+### `AlreadyExistsException`
+
+A `CREATE` for something that exists. Use `IF NOT EXISTS` in migrations to avoid it.
+
+### `UnpreparedException`
+
+The coordinator does not know the prepared statement identifier, usually because the node restarted.
+The driver re-prepares and retries on its own. Seeing this in PHP means the recovery also failed.
+
+### `OverloadedException` and `IsBootstrappingException`
+
+The node is saturated or is still joining the cluster. Back off. Do not retry in a tight loop.
+
+### `AuthenticationException`
+
+Bad credentials. Thrown from `connect()`. See [authentication](/guide/authentication).
+
+### `TimeoutException`
+
+The client gave up waiting. The request may still be running on the server. This is the PHP-side
+timeout from `execute()` or `Future::get()`, not a server timeout.
+
+### `InvalidArgumentException`
+
+A bad value passed to the driver: an unknown execution option, a negative page size, an unreadable
+certificate path, a malformed IP address. Thrown before any network work.
+
+### `DivideByZeroException`
+
+From arithmetic on the [numeric value classes](/guide/data-types#numbers).
+
+## Catch order
+
+Catch from specific to general. PHP takes the first matching block.
+
+```php
+use Cassandra\Exception\InvalidQueryException;
+use Cassandra\Exception\UnavailableException;
+use Cassandra\Exception\WriteTimeoutException;
+
+try {
+    $session->execute($insert, ['arguments' => $values]);
+} catch (WriteTimeoutException $e) {
+    $this->queueForVerification($values);          // may or may not have applied
+} catch (UnavailableException $e) {
+    $this->scheduleRetry($values, delaySeconds: 5); // cluster is degraded
+} catch (InvalidQueryException $e) {
+    throw $e;                                       // a bug, do not swallow it
+} catch (Cassandra\Exception $e) {
+    $this->logger->error('cassandra write failed', ['error' => $e->getMessage()]);
+    throw $e;
+}
+```
+
+## What to retry
+
+| Exception | Retry | Note |
+| --- | --- | --- |
+| `ReadTimeoutException` | Yes | Reads are idempotent |
+| `WriteTimeoutException` | Only if idempotent | The write may have applied |
+| `UnavailableException` | After a delay | Retrying at once fails again |
+| `OverloadedException` | After a delay | Backoff is required |
+| `IsBootstrappingException` | After a delay | The node is joining |
+| `TruncateException` | Yes | |
+| `InvalidQueryException` | No | Fix the query |
+| `InvalidSyntaxException` | No | Fix the query |
+| `UnauthorizedException` | No | Fix the grant |
+| `AlreadyExistsException` | No | Use `IF NOT EXISTS` |
+| `AuthenticationException` | No | Fix the credentials |
+| `InvalidArgumentException` | No | Fix the call |
+
+## Exception codes
+
+Server-side exceptions carry the C driver error code in `getCode()`. The message comes from the
+driver.
+
+```php
+catch (Cassandra\Exception $e) {
+    $this->logger->error('cassandra error', [
+        'class'   => $e::class,
+        'code'    => $e->getCode(),
+        'message' => $e->getMessage(),
+    ]);
+}
+```
+
+## A wrapper for your application
+
+Driver exceptions crossing a domain boundary couple your code to the driver. Translate at the edge:
+
+```php
+final class UserRepository
+{
+    public function find(Cassandra\Uuid $id): ?User
+    {
+        try {
+            $row = $this->session
+                ->execute($this->findById, ['arguments' => [$id]])
+                ->first();
+        } catch (Cassandra\Exception\ValidationException $e) {
+            throw new StorageBugException($e->getMessage(), previous: $e);
+        } catch (Cassandra\Exception $e) {
+            throw new StorageUnavailableException($e->getMessage(), previous: $e);
+        }
+
+        return $row === null ? null : User::fromRow($row);
+    }
+}
+```
+
+The split matters. `ValidationException` is your bug and belongs in the error tracker.
+Everything else is an infrastructure condition and belongs in a retry or a circuit breaker.

--- a/website/guide/installation.md
+++ b/website/guide/installation.md
@@ -1,0 +1,167 @@
+# Installation
+
+The extension is compiled from source. It links against two native libraries:
+
+- **libuv** — the event loop used by the C/C++ driver.
+- **The ScyllaDB C/C++ driver**, or the DataStax `libcassandra` driver as an alternative.
+
+Install both before you build the extension.
+
+::: warning 64-bit only
+The extension supports x86-64 only. A 32-bit PHP build cannot load it.
+:::
+
+## 1. Install the native dependencies
+
+The repository ships build scripts for both libraries. Pick a prefix that your user can write to.
+
+```bash
+git clone https://github.com/he4rt/scylladb-php-driver.git
+cd scylladb-php-driver
+
+./scripts/compile-libuv.sh --prefix ~/.local
+./scripts/compile-cpp-driver.sh --driver scylladb --prefix ~/.local
+```
+
+To build against Apache Cassandra through the DataStax driver, change the `--driver` value:
+
+```bash
+./scripts/compile-cpp-driver.sh --driver cassandra --prefix ~/.local
+```
+
+Export the `pkg-config` path so the build can find both libraries:
+
+```bash
+export PKG_CONFIG_PATH="$HOME/.local/lib/pkgconfig:$PKG_CONFIG_PATH"
+```
+
+Add that line to your shell profile. The build fails with a "cpp driver not found" error when the
+path is missing.
+
+### System packages
+
+::: code-group
+
+```bash [Debian / Ubuntu]
+sudo apt install -y build-essential ninja-build cmake \
+    libssl-dev libgmp-dev zlib1g-dev libpcre3-dev
+```
+
+```bash [Fedora / RHEL]
+sudo dnf install -y gcc gcc-c++ ninja-build cmake \
+    openssl-devel gmp-devel zlib-devel pcre2-devel
+```
+
+```bash [macOS]
+brew install cmake ninja openssl@3 gmp zlib pcre2
+```
+
+:::
+
+GMP is required. The driver uses it for `varint` and `decimal` arithmetic.
+
+## 2. Install the extension
+
+### With PIE (recommended)
+
+[PIE](https://github.com/php/pie) is the official PHP extension installer. It downloads, builds, and
+enables the extension in one command.
+
+```bash
+pie install codelieutenant/scylla-driver
+```
+
+To link against DataStax `libcassandra` instead of the ScyllaDB driver:
+
+```bash
+pie install codelieutenant/scylla-driver --enable-libcassandra
+```
+
+PIE puts the compiled `cassandra.so` in the PHP extension directory and enables it.
+
+Other configure options that PIE accepts:
+
+| Option | Effect |
+| --- | --- |
+| `--enable-debug` | Build with debug symbols and assertions |
+| `--enable-lto` | Enable link time optimization |
+| `--enable-avx` / `--enable-avx2` | Enable the matching instruction set |
+| `--with-cpu-type=<type>` | Target a micro-architecture, for example `x86-64-v3` |
+| `--enable-driver-static` | Link the C/C++ driver statically |
+| `--enable-sanitizers` | Link AddressSanitizer and UndefinedBehaviorSanitizer |
+
+### With CMake, from source
+
+The repository uses CMake presets. A preset name follows the pattern
+`<BuildType>PHP<Version><ThreadModel>`, for example `ReleasePHP8.4NTS`.
+
+```bash
+cmake --list-presets
+cmake --preset ReleasePHP8.4NTS
+cmake --build out/ReleasePHP8.4NTS
+```
+
+The build produces `out/<preset>/cassandra.so` on Linux and `cassandra.dylib` on macOS. Copy it to
+your PHP extension directory, or load it by absolute path:
+
+```bash
+php -d extension="$PWD/out/ReleasePHP8.4NTS/cassandra.so" -m | grep cassandra
+```
+
+To find the extension directory:
+
+```bash
+php -i | grep '^extension_dir'
+```
+
+After you add a new PHP version, regenerate the presets:
+
+```bash
+php generate-presets.php
+```
+
+### With phpize
+
+```bash
+phpize
+./configure --with-cpu-type=x86-64-v3
+make -j"$(nproc)"
+sudo make install
+```
+
+## 3. Enable and verify
+
+Add the extension to your `php.ini`, or to a file in the `conf.d` directory:
+
+```ini
+extension=cassandra.so
+
+[cassandra]
+; Log level: CRITICAL | ERROR | WARN | INFO | DEBUG | TRACE
+cassandra.log_level = ERROR
+
+; Log file path. An empty value sends the log to stderr.
+cassandra.log = /var/log/php-cassandra.log
+```
+
+Check the result:
+
+```bash
+php -m | grep cassandra
+php -r 'echo Cassandra::VERSION, " on cpp-driver ", Cassandra::CPP_DRIVER_VERSION, PHP_EOL;'
+```
+
+The second command prints the extension version and the version of the C/C++ driver it links
+against.
+
+## A local ScyllaDB node
+
+To develop against a real node, start one with the helper script. It runs the Compose file in
+`docker/`.
+
+```bash
+./scripts/run-scylladb.sh
+```
+
+The node listens on `127.0.0.1:9042`. The default ScyllaDB image accepts any credentials, so
+`withCredentials()` is optional against a local node.

--- a/website/guide/introduction.md
+++ b/website/guide/introduction.md
@@ -1,0 +1,86 @@
+# Introduction
+
+The ScyllaDB PHP driver is a PHP extension written in C. It connects PHP applications to
+[ScyllaDB](https://www.scylladb.com) and [Apache Cassandra](https://cassandra.apache.org) over the
+native CQL binary protocol.
+
+The extension name is `cassandra`. All classes live in the `Cassandra\` namespace, plus one global
+`Cassandra` class that acts as the entry point and constant holder.
+
+## How it works
+
+The extension does not implement the CQL protocol itself. It wraps the
+[ScyllaDB C/C++ driver](https://github.com/scylladb/cpp-driver), which owns the sockets, the
+connection pools, and the IO threads.
+
+```
+┌───────────────────────┐
+│  Your PHP application │
+└──────────┬────────────┘
+           │  Cassandra\Session::execute()
+┌──────────▼────────────┐
+│  cassandra.so  (C23)  │  zvals ⇄ CQL values, object handlers, exceptions
+└──────────┬────────────┘
+           │  cass_session_execute()
+┌──────────▼────────────┐
+│  ScyllaDB C/C++ driver│  IO threads, connection pools, routing, retries
+└──────────┬────────────┘
+           │  CQL binary protocol (TCP, optional TLS)
+┌──────────▼────────────┐
+│  ScyllaDB / Cassandra │
+└───────────────────────┘
+```
+
+Two consequences matter for application code:
+
+1. **Row decoding happens in C.** A `SELECT` returns a `Cassandra\Rows` object that decodes each
+   column into the correct PHP value. You never parse a wire format.
+2. **The connection pool lives below PHP.** One `Cassandra\Session` holds many TCP connections to
+   many nodes. Reuse the session. Do not build one per request when you can avoid it. See
+   [performance](/guide/performance).
+
+## What the driver gives you
+
+| Capability | Entry point |
+| --- | --- |
+| Cluster configuration | [`Cassandra::cluster()`](/reference/cluster-builder) |
+| Query execution | [`Session::execute()`](/reference/session) |
+| Prepared statements | [`Session::prepare()`](/guide/queries#prepared-statements) |
+| Batches | [`Cassandra\BatchStatement`](/guide/batches) |
+| Paging | [`Rows::nextPage()`](/guide/results) |
+| Concurrency | [`Session::executeAsync()`](/guide/async) |
+| Schema introspection | [`Session::schema()`](/guide/schema-metadata) |
+| TLS | [`Cassandra::ssl()`](/guide/tls) |
+| Metrics | [`Session::metrics()`](/guide/observability) |
+
+## Compatibility
+
+| Component | Supported versions |
+| --- | --- |
+| PHP | 8.2, 8.3, 8.4, 8.5 |
+| ScyllaDB | 4.4.x, 5.x, 6.x |
+| Apache Cassandra | 3.0 and later, through DataStax libcassandra |
+| Architecture | x86-64, 64-bit only |
+| Thread safety | NTS and ZTS |
+| Compilers | GCC 13 or later, Clang 16 or later |
+| Operating system | Linux, macOS |
+
+## Relation to the old DataStax driver
+
+The API follows the DataStax PHP driver that this project forked from. Most code that ran on the old
+extension runs here. Three differences catch people out:
+
+- Value classes are flat. Use `Cassandra\Bigint`, not `Cassandra\Numbers\Bigint`. The sub-namespaces
+  in the source tree organize files, not classes.
+- Signatures are strictly typed. The stubs declare union types such as `string|Statement`. A wrong
+  argument type raises a `TypeError` instead of a silent cast.
+- `Cassandra\ExecutionOptions` as a constructor is deprecated. Pass a plain array instead. See
+  [queries and statements](/guide/queries#execution-options).
+
+## Project status
+
+The extension is being ported from C++ to C23. The port is incremental and does not change the PHP
+API. `src/Cluster/` is the reference module for the new style.
+
+Read [CONTRIBUTING.md](https://github.com/he4rt/scylladb-php-driver/blob/trunk/CONTRIBUTING.md)
+before you send a patch.

--- a/website/guide/load-balancing.md
+++ b/website/guide/load-balancing.md
@@ -1,0 +1,160 @@
+# Load balancing and routing
+
+Every request must go to a node. Three independent mechanisms decide which one:
+
+1. **The load balancing policy** builds an ordered list of candidate nodes.
+2. **Token-aware routing** reorders that list to put data owners first.
+3. **Host and datacenter filters** remove nodes from the list before anything else runs.
+
+The settings combine. A common production setup uses a datacenter-aware policy plus token-aware
+routing.
+
+## Load balancing policies
+
+### Round robin (default)
+
+```php
+->withRoundRobinLoadBalancingPolicy()
+```
+
+The driver cycles through every node in the cluster, in every datacenter. This is the default and it
+is correct only when the application and the whole cluster sit in one datacenter.
+
+### Datacenter-aware round robin
+
+```php
+->withDatacenterAwareRoundRobinLoadBalancingPolicy(
+    localDatacenter: 'eu-west-1',
+    hostPerRemoteDatacenter: 0,
+    useRemoteDatacenterForLocalConsistencies: false,
+)
+```
+
+Nodes in the local datacenter are used first. Use this policy whenever the cluster spans more than
+one datacenter or region.
+
+| Parameter | Meaning |
+| --- | --- |
+| `localDatacenter` | The datacenter name as the cluster reports it, for example `eu-west-1`. It must match exactly. |
+| `hostPerRemoteDatacenter` | How many nodes per remote datacenter the driver may fall back to when the local datacenter has no node available. `0` disables remote fallback. |
+| `useRemoteDatacenterForLocalConsistencies` | Whether a remote node may serve a request that asks for `LOCAL_ONE` or `LOCAL_QUORUM`. Keep this `false`. |
+
+All three parameters are required. There is no default.
+
+::: warning Two ways to lose datacenter isolation
+`hostPerRemoteDatacenter` above `0` sends cross-region traffic during a local outage, which raises
+latency but keeps the application alive. `useRemoteDatacenterForLocalConsistencies: true` breaks the
+guarantee that `LOCAL_QUORUM` means "local". Set it to `true` only after a deliberate decision.
+:::
+
+Find the datacenter name from a node:
+
+```bash
+nodetool status | head -3
+```
+
+Or from CQL:
+
+```sql
+SELECT data_center, rack FROM system.local;
+```
+
+## Token-aware routing
+
+```php
+->withTokenAwareRouting(true)   // on by default
+```
+
+The driver hashes the partition key of the statement, computes the token, and sends the request
+straight to a replica that owns it. Without it, the coordinator has to forward the request, which
+adds a network hop and load on a node that holds none of the data.
+
+Two conditions must hold for it to work:
+
+- **The statement must be prepared.** A prepared statement carries partition key metadata. A
+  `SimpleStatement` does not, so the driver cannot compute a token for it.
+- **Schema metadata must be on.** It is on by default. `withSchemaMetadata(false)` turns off token
+  awareness as a side effect.
+
+This is the strongest single reason to prepare statements. See
+[performance](/guide/performance).
+
+## Latency-aware routing
+
+```php
+->withLatencyAwareRouting(true)   // on by default
+```
+
+The driver measures response latency per node and moves consistently slow nodes to the back of the
+candidate list. It helps against a node that is degraded rather than down, which normal failure
+detection does not catch.
+
+Turn it off when node latency is naturally uneven and the penalty causes traffic to bunch up on a
+few nodes.
+
+## Host and datacenter filters
+
+Four filters remove nodes from consideration. Each takes a variadic list.
+
+```php
+->withWhiteListHosts('10.0.0.1', '10.0.0.2')   // use only these nodes
+->withBlackListHosts('10.0.0.9')               // never use these nodes
+->withWhiteListDCs('eu-west-1')                // use only these datacenters
+->withBlackListDCs('us-east-1')                // never use these datacenters
+```
+
+Use them for:
+
+- Pinning a batch job to a small set of nodes so it does not disturb the serving path.
+- Taking a node out of rotation from the client side during maintenance.
+- Keeping an application inside one datacenter without changing the load balancing policy.
+
+::: tip Prefer the datacenter-aware policy
+A datacenter whitelist and the datacenter-aware policy solve overlapping problems. The policy is the
+better tool, because it keeps a controlled fallback path. Reach for the filters when you need a hard
+boundary.
+:::
+
+A whitelist that excludes every reachable node makes `connect()` fail. There is no fallback.
+
+## Consistency and routing together
+
+Routing decides which node receives the request. Consistency decides how many replicas must
+acknowledge it. They interact:
+
+| Consistency | Behavior with a datacenter-aware policy |
+| --- | --- |
+| `CONSISTENCY_LOCAL_ONE` | One replica in the local datacenter answers. |
+| `CONSISTENCY_LOCAL_QUORUM` | A quorum inside the local datacenter answers. The usual production choice. |
+| `CONSISTENCY_QUORUM` | A quorum across all datacenters answers, so a remote round trip is likely. |
+| `CONSISTENCY_EACH_QUORUM` | A quorum in every datacenter answers. Writes only. |
+| `CONSISTENCY_ALL` | Every replica answers. One node down means the request fails. |
+
+Set the cluster default once and override it per statement where needed:
+
+```php
+$cluster = Cassandra::cluster()
+    ->withDefaultConsistency(Cassandra::CONSISTENCY_LOCAL_QUORUM)
+    ->build();
+
+// Override for one query that tolerates staleness.
+$rows = $session->execute($stmt, ['consistency' => Cassandra::CONSISTENCY_LOCAL_ONE]);
+```
+
+The cluster default is `Cassandra::CONSISTENCY_LOCAL_ONE`. Most applications want
+`LOCAL_QUORUM` instead. The full list is in the [constants reference](/reference/constants).
+
+## A production configuration
+
+```php
+$cluster = Cassandra::cluster()
+    ->withContactPoints('10.1.0.11', '10.1.0.12', '10.1.0.13')
+    ->withDatacenterAwareRoundRobinLoadBalancingPolicy('eu-west-1', 0, false)
+    ->withTokenAwareRouting(true)
+    ->withLatencyAwareRouting(true)
+    ->withDefaultConsistency(Cassandra::CONSISTENCY_LOCAL_QUORUM)
+    ->build();
+```
+
+Contact points name local nodes. The policy keeps traffic local. Token awareness removes the extra
+hop. Consistency stays inside the datacenter.

--- a/website/guide/observability.md
+++ b/website/guide/observability.md
@@ -1,0 +1,193 @@
+# Metrics and logging
+
+## Metrics
+
+`Session::metrics()` returns the C driver's live counters as a nested array. It reads process
+memory, so it costs nothing and is safe to call on a hot path.
+
+```php
+$metrics = $session->metrics();
+```
+
+The array has three keys.
+
+### `requests`
+
+Latency in **microseconds**, plus throughput rates.
+
+| Key | Meaning |
+| --- | --- |
+| `min`, `max`, `mean`, `median`, `stddev` | Latency summary |
+| `p75`, `p95`, `p98`, `p99`, `p999` | Latency percentiles |
+| `mean_rate` | Requests per second since start |
+| `m1_rate`, `m5_rate`, `m15_rate` | One, five, and fifteen minute rates |
+
+```php
+$r = $metrics['requests'];
+
+printf("p50=%.1fms p99=%.1fms %.0f req/s\n",
+    $r['median'] / 1000,
+    $r['p99'] / 1000,
+    $r['m1_rate'],
+);
+```
+
+### `stats`
+
+Connection pool state.
+
+| Key | Meaning |
+| --- | --- |
+| `total_connections` | Connections the pool holds |
+| `available_connections` | Connections ready to take a request |
+| `exceeded_pending_requests_water_mark` | Times the pending queue crossed its limit |
+| `exceeded_write_bytes_water_mark` | Times the write buffer crossed its limit |
+
+A gap between `total_connections` and `available_connections` means connections are busy or
+reconnecting. A rising `exceeded_pending_requests_water_mark` means the client is queueing, which
+calls for more connections per host or less concurrency.
+
+### `errors`
+
+| Key | Meaning |
+| --- | --- |
+| `connection_timeouts` | Connections that failed to establish in time |
+| `pending_request_timeouts` | Requests that timed out while queued on the client |
+| `request_timeouts` | Requests that timed out after they were sent |
+
+The split matters. `pending_request_timeouts` points at a client-side bottleneck.
+`request_timeouts` points at the cluster.
+
+### Exporting
+
+Counters are cumulative per session. Export them at the end of a request, or on a timer in a long
+running process.
+
+```php
+function exportMetrics(Cassandra\Session $session, StatsdClient $statsd): void
+{
+    $m = $session->metrics();
+
+    $statsd->gauge('cassandra.latency.p50', $m['requests']['median'] / 1000);
+    $statsd->gauge('cassandra.latency.p99', $m['requests']['p99'] / 1000);
+    $statsd->gauge('cassandra.rate.1m', $m['requests']['m1_rate']);
+
+    $statsd->gauge('cassandra.connections.total', $m['stats']['total_connections']);
+    $statsd->gauge('cassandra.connections.available', $m['stats']['available_connections']);
+
+    $statsd->gauge('cassandra.errors.request_timeouts', $m['errors']['request_timeouts']);
+    $statsd->gauge('cassandra.errors.connection_timeouts', $m['errors']['connection_timeouts']);
+}
+```
+
+### What to alert on
+
+| Signal | Meaning |
+| --- | --- |
+| p99 rises while the median stays flat | One slow node, or client-side queueing |
+| `available_connections` below `total_connections` for a long time | Nodes flapping |
+| `pending_request_timeouts` above zero | The client cannot keep up. Raise the pool or lower concurrency |
+| `request_timeouts` rising | The cluster is slow or overloaded |
+| `m1_rate` drops to zero | The application stopped querying. Check the application, not the cluster |
+
+## Logging
+
+The C driver writes its own log. Two `php.ini` settings control it.
+
+```ini
+[cassandra]
+cassandra.log_level = ERROR
+cassandra.log = /var/log/php-cassandra.log
+```
+
+| Setting | Default | Values |
+| --- | --- | --- |
+| `cassandra.log_level` | `ERROR` | `CRITICAL`, `ERROR`, `WARN`, `INFO`, `DEBUG`, `TRACE` |
+| `cassandra.log` | `cassandra.log` | An absolute path, or an empty value for stderr |
+
+::: warning Both settings are PHP_INI_SYSTEM
+They can be changed in `php.ini` only. `ini_set()` at runtime has no effect, because the log callback
+runs on driver IO threads that have no PHP context.
+:::
+
+::: tip Set an absolute path
+The default is the relative name `cassandra.log`, which resolves against the current working
+directory of the process. Under PHP-FPM that is rarely where you expect. Always set an absolute path
+that the PHP user can write, or leave the value empty so the log goes to stderr and your process
+supervisor collects it.
+:::
+
+### Log format
+
+To a file:
+
+```
+05-08-2026 14:23:11 CEST [ERROR] Connection error 'Connection timeout' (src/connector.cpp:120)
+```
+
+To stderr:
+
+```
+cassandra | [ERROR] Connection error 'Connection timeout' (src/connector.cpp:120)
+```
+
+### Choosing a level
+
+| Level | Use |
+| --- | --- |
+| `CRITICAL` | Almost nothing is logged |
+| `ERROR` | The production default |
+| `WARN` | Adds node up and down events, and retry notices |
+| `INFO` | Adds connection and schema events. Useful during a rollout |
+| `DEBUG` | Per-request detail. Development only |
+| `TRACE` | Very high volume. Short debugging sessions only |
+
+`DEBUG` and `TRACE` produce a lot of output on a busy process. Do not leave them on.
+
+### Logging retry decisions
+
+The driver log does not record retries by default. Wrap the retry policy to get them:
+
+```php
+$cluster = Cassandra::cluster()
+    ->withRetryPolicy(
+        new Cassandra\RetryPolicy\Logging(new Cassandra\RetryPolicy\DefaultPolicy())
+    )
+    ->build();
+```
+
+The decisions go to the same driver log. See [retry policies](/guide/retry-policies).
+
+## Correlating with application logs
+
+The driver log has no request identifier, so it cannot be joined to your application log
+automatically. Log the driver exception on the application side, where the request context exists:
+
+```php
+try {
+    $rows = $session->execute($statement, $options);
+} catch (Cassandra\Exception $e) {
+    $this->logger->error('cassandra query failed', [
+        'request_id' => $this->requestId,
+        'exception'  => $e::class,
+        'code'       => $e->getCode(),
+        'message'    => $e->getMessage(),
+    ]);
+    throw $e;
+}
+```
+
+Use the driver log for cluster-level events, and the application log for per-request failures.
+
+## Server-side view
+
+The client view is one half. Compare it with the cluster:
+
+```bash
+nodetool tpstats          # dropped messages and queued tasks
+nodetool proxyhistograms  # coordinator latency
+nodetool tablehistograms shop users
+```
+
+Client p99 far above the coordinator p99 points at the network or at the client. The two matching
+points at the cluster.

--- a/website/guide/performance.md
+++ b/website/guide/performance.md
@@ -1,0 +1,203 @@
+# Performance
+
+Five things account for almost every performance problem with this driver. They are listed in the
+order of how much they usually matter.
+
+## 1. Reuse the session
+
+A `connect()` opens sockets to every node, performs the TLS handshake, authenticates, and reads the
+schema. That is expensive. Doing it per request dominates everything else.
+
+```php
+// Wrong: a new pool on every request.
+function handle(Request $r): Response
+{
+    $session = Cassandra::cluster()->withContactPoints('10.0.0.1')->build()->connect('shop');
+    // ...
+}
+```
+
+```php
+// Right: one session, created once.
+final class SessionFactory
+{
+    private static ?Cassandra\Session $session = null;
+
+    public static function get(): Cassandra\Session
+    {
+        return self::$session ??= Cassandra::cluster()
+            ->withContactPoints(...HOSTS)
+            ->withPersistentSessions(true)
+            ->build()
+            ->connect('shop');
+    }
+}
+```
+
+Under PHP-FPM, `withPersistentSessions(true)` keeps the session in the worker process across
+requests. It is on by default. Do not turn it off in production.
+
+Under a long-running runtime such as RoadRunner, FrankenPHP, or Swoole, hold the session in a
+container or a static and build it at boot.
+
+## 2. Prepare every statement on the request path
+
+```php
+// Wrong: a network round trip to prepare, on every call.
+function find(Cassandra\Session $s, $id) {
+    $stmt = $s->prepare('SELECT * FROM users WHERE id = ?');
+    return $s->execute($stmt, ['arguments' => [$id]]);
+}
+```
+
+Preparing costs a round trip and, worse, an unprepared statement cannot be routed to a replica.
+Every simple statement takes an extra network hop through a coordinator.
+
+Prepare in the constructor and keep the object:
+
+```php
+final class UserRepository
+{
+    private Cassandra\PreparedStatement $findById;
+
+    public function __construct(private Cassandra\Session $session)
+    {
+        $this->findById = $session->prepare('SELECT id, email FROM users WHERE id = ?');
+    }
+}
+```
+
+Combined with token-aware routing, which is on by default, this removes one hop from every query.
+
+## 3. Use concurrency instead of loops
+
+A sequential loop pays the full round trip for every row.
+
+```php
+// 1000 sequential round trips.
+foreach ($ids as $id) {
+    $users[] = $session->execute($findById, ['arguments' => [$id]])->first();
+}
+```
+
+```php
+// About one round trip, in windows of 128.
+$window = 128;
+$futures = [];
+
+foreach ($ids as $id) {
+    $futures[] = $session->executeAsync($findById, ['arguments' => [$id]]);
+
+    if (count($futures) >= $window) {
+        foreach ($futures as $f) { $users[] = $f->get()->first(); }
+        $futures = [];
+    }
+}
+foreach ($futures as $f) { $users[] = $f->get()->first(); }
+```
+
+See [asynchronous queries](/guide/async). Do not reach for a
+[batch](/guide/batches) here. A multi-partition batch is slower than concurrent single writes.
+
+## 4. Select the columns you need
+
+```php
+// Transfers and decodes every column.
+$session->execute('SELECT * FROM users WHERE id = ?', ['arguments' => [$id]]);
+
+// Transfers and decodes two.
+$session->execute('SELECT id, email FROM users WHERE id = ?', ['arguments' => [$id]]);
+```
+
+Decoding happens in C, but a wide row with collections still costs allocation per value. Naming the
+columns also keeps the code working when someone adds a column.
+
+## 5. Match the page size to the work
+
+```php
+$session->execute($listQuery,   ['page_size' => 50]);     // a user-facing list
+$session->execute($exportQuery, ['page_size' => 5000]);   // a background export
+```
+
+A page too small adds round trips. A page too large risks the request timeout and raises peak memory.
+The default is 5000. See [results and paging](/guide/results#choosing-a-page-size).
+
+## Consistency costs latency
+
+| Level | Replicas that must answer | Relative cost |
+| --- | --- | --- |
+| `CONSISTENCY_LOCAL_ONE` | One, in the local datacenter | Lowest |
+| `CONSISTENCY_LOCAL_QUORUM` | A local quorum | The usual choice |
+| `CONSISTENCY_QUORUM` | A quorum across datacenters | A cross-region round trip |
+| `CONSISTENCY_ALL` | Every replica | Highest, and fragile |
+
+Set the cluster default to `LOCAL_QUORUM` and lower it per query where staleness is acceptable:
+
+```php
+$rows = $session->execute($popularItems, [
+    'consistency' => Cassandra::CONSISTENCY_LOCAL_ONE,
+]);
+```
+
+## Pool and thread settings
+
+Defaults suit PHP-FPM. Change them only against a measurement. See
+[connection pool and timeouts](/guide/connection-tuning).
+
+| Setting | Default | Raise it when |
+| --- | --- | --- |
+| `withConnectionsPerHost(core, max)` | 1, 2 | Latency rises while node CPU stays low |
+| `withIOThreads(n)` | 1 | One process drives many concurrent futures |
+| `withConnectionHeartbeatInterval(s)` | 30 | Never raise. Lower it behind an idle-flow-killing firewall |
+
+Remember the multiplier: connections per host times nodes times PHP worker processes is the total
+socket count from one machine.
+
+## Value objects and memory
+
+Every non-native column allocates a PHP object per row per column. A page of 5000 rows with ten
+`bigint` columns allocates 50000 objects.
+
+Two ways to reduce that:
+
+- Select fewer columns.
+- Use a smaller page size when memory matters more than round trips.
+
+Convert to plain PHP values as soon as you can, so the driver objects become collectable:
+
+```php
+$emails = [];
+foreach ($rows as $row) {
+    $emails[(string) $row['id']] = $row['email'];
+}
+unset($rows);
+```
+
+## Measuring
+
+`Session::metrics()` gives the driver's own view. Read it before you change a setting, and again
+after.
+
+```php
+$m = $session->metrics();
+
+$m['requests']['median'];       // microseconds
+$m['requests']['p99'];
+$m['requests']['mean_rate'];    // requests per second
+$m['stats']['total_connections'];
+$m['errors']['request_timeouts'];
+```
+
+A rising p99 with a flat median points at queueing or at one slow node. See
+[metrics and logging](/guide/observability).
+
+## A checklist
+
+1. One session per process, or persistent sessions under PHP-FPM.
+2. Every request-path statement prepared once and kept.
+3. Token-aware routing on. It is the default.
+4. Batches only for atomicity. Concurrency for throughput.
+5. Explicit column lists.
+6. `LOCAL_QUORUM` by default, lower where staleness is fine.
+7. A page size chosen per query.
+8. Metrics recorded before and after every tuning change.

--- a/website/guide/queries.md
+++ b/website/guide/queries.md
@@ -1,0 +1,252 @@
+# Queries and statements
+
+`Session::execute()` runs one statement and returns [`Cassandra\Rows`](/guide/results).
+
+```php
+public function execute(
+    string|Statement $statement,
+    array|ExecutionOptions|null $options = null,
+): Rows;
+```
+
+The first argument is a CQL string or a `Cassandra\Statement`. The second holds the bound values and
+the per-query settings.
+
+## Simple statements
+
+A plain string is the shortest form. The driver wraps it in a `Cassandra\SimpleStatement`.
+
+```php
+$rows = $session->execute('SELECT id, email FROM users LIMIT 10');
+```
+
+Build the object yourself when you want to keep and reuse it:
+
+```php
+$statement = new Cassandra\SimpleStatement('SELECT id, email FROM users LIMIT 10');
+$rows = $session->execute($statement);
+```
+
+A simple statement can take bound values too:
+
+```php
+$rows = $session->execute(
+    'SELECT * FROM users WHERE id = ?',
+    ['arguments' => [$id]],
+);
+```
+
+::: warning Simple statements defeat token-aware routing
+A simple statement carries no partition key metadata, so the driver cannot route it to a replica.
+The request goes to an arbitrary coordinator, which then forwards it. Prepare any statement you run
+more than once.
+:::
+
+Use simple statements for schema changes and one-off administrative queries. Use prepared statements
+for everything on the request path.
+
+## Prepared statements
+
+`prepare()` sends the CQL to the cluster once. The server answers with an identifier and the type of
+every marker.
+
+```php
+$insert = $session->prepare(
+    'INSERT INTO users (id, email, created_at) VALUES (?, ?, ?)'
+);
+
+$session->execute($insert, [
+    'arguments' => [$id, 'ada@example.com', new Cassandra\Timestamp(time())],
+]);
+```
+
+Preparing buys three things:
+
+1. **Token-aware routing.** The driver knows the partition key, so it reaches a replica directly.
+2. **Type checking on the client.** Marker types are known, so a wrong value fails before the
+   network call.
+3. **A smaller request.** Later executions send the identifier and the values, not the CQL text.
+
+Prepare each statement once and keep the object:
+
+```php
+final class UserRepository
+{
+    private Cassandra\PreparedStatement $findById;
+    private Cassandra\PreparedStatement $insert;
+
+    public function __construct(private Cassandra\Session $session)
+    {
+        $this->findById = $session->prepare('SELECT * FROM users WHERE id = ?');
+        $this->insert   = $session->prepare('INSERT INTO users (id, email) VALUES (?, ?)');
+    }
+
+    public function find(Cassandra\Uuid $id): ?array
+    {
+        return $this->session->execute($this->findById, ['arguments' => [$id]])->first();
+    }
+}
+```
+
+`Cassandra\PreparedStatement` has a private constructor. `prepare()` is the only way to get one.
+
+::: tip Do not prepare in a loop
+`prepare()` is a network round trip. Preparing the same CQL on every request adds a round trip to
+every request.
+:::
+
+Prepare without blocking with `prepareAsync()`, which returns a
+`Cassandra\FuturePreparedStatement`. See [asynchronous queries](/guide/async).
+
+## Binding values
+
+Values go in the `arguments` key of the options array.
+
+### By position
+
+An array with integer keys binds by position. Markers are `?`.
+
+```php
+$statement = $session->prepare(
+    'INSERT INTO users (id, email, created_at) VALUES (?, ?, ?)'
+);
+
+$session->execute($statement, [
+    'arguments' => [$id, 'ada@example.com', new Cassandra\Timestamp(time())],
+]);
+```
+
+### By name
+
+An array with string keys binds by name. Markers are `:name`.
+
+```php
+$statement = $session->prepare(
+    'INSERT INTO users (id, email, created_at) VALUES (:id, :email, :created_at)'
+);
+
+$session->execute($statement, [
+    'arguments' => [
+        'id'         => $id,
+        'email'      => 'ada@example.com',
+        'created_at' => new Cassandra\Timestamp(time()),
+    ],
+]);
+```
+
+Named binding does not depend on the order of the markers, which makes a long insert easier to read
+and safer to change.
+
+### Never concatenate CQL
+
+```php
+// Wrong. This is a CQL injection.
+$session->execute("SELECT * FROM users WHERE email = '$email'");
+
+// Right.
+$session->execute($findByEmail, ['arguments' => [$email]]);
+```
+
+Bound values travel as typed protocol values. They are never parsed as CQL.
+
+### Null values
+
+```php
+$session->execute($statement, ['arguments' => [$id, null]]);
+```
+
+A PHP `null` binds as a CQL `null`, which deletes the cell. That is not the same as leaving the
+column out of the insert, which writes nothing at all.
+
+## Execution options
+
+The second argument to `execute()` accepts a plain array. Each key is optional.
+
+| Key | Type | Purpose |
+| --- | --- | --- |
+| `arguments` | `array` | Values for the markers, by position or by name. |
+| `consistency` | `int` | A `Cassandra::CONSISTENCY_*` constant. Overrides the cluster default. |
+| `serial_consistency` | `int` | `CONSISTENCY_SERIAL` or `CONSISTENCY_LOCAL_SERIAL`, for lightweight transactions. |
+| `page_size` | `int` | Rows per page. Must be greater than zero. |
+| `paging_state_token` | `string` | Resume from a token returned by a previous page. |
+| `timeout` | `int` or `float` | Seconds to wait. Must be greater than zero, or `null`. |
+| `retry_policy` | `Cassandra\RetryPolicy` | Overrides the cluster policy for this statement. |
+| `timestamp` | `int` or numeric string | An explicit write timestamp, in microseconds. |
+
+```php
+$rows = $session->execute($statement, [
+    'arguments'   => [$id],
+    'consistency' => Cassandra::CONSISTENCY_LOCAL_QUORUM,
+    'page_size'   => 500,
+    'timeout'     => 2.5,
+]);
+```
+
+An invalid value raises `Cassandra\Exception\InvalidArgumentException` and names the key.
+
+::: warning The ExecutionOptions constructor is deprecated
+`new Cassandra\ExecutionOptions([...])` still works and still reads its values through magic
+properties in camel case (`$options->pageSize`). Pass a plain array in new code.
+:::
+
+## Lightweight transactions
+
+A conditional write returns a result set with an `[applied]` column instead of an empty result.
+
+```php
+$statement = $session->prepare(
+    'INSERT INTO users (id, email) VALUES (?, ?) IF NOT EXISTS'
+);
+
+$rows = $session->execute($statement, [
+    'arguments'          => [$id, 'ada@example.com'],
+    'serial_consistency' => Cassandra::CONSISTENCY_LOCAL_SERIAL,
+]);
+
+$row = $rows->first();
+
+if ($row['[applied]'] === false) {
+    // A row with this key already exists. The other columns hold the current values.
+}
+```
+
+Lightweight transactions use Paxos and cost several round trips. Use them where correctness needs
+them, not as a general concurrency tool.
+
+## Explicit write timestamps
+
+```php
+$session->execute($statement, [
+    'arguments' => [$id, $email],
+    'timestamp' => (int) (microtime(true) * 1_000_000),
+]);
+```
+
+The value is in microseconds. It sets the cell timestamp that decides which write wins. Supply it
+when you replay events and need the original order preserved.
+
+For automatic timestamps generated on the client, set a generator on the cluster:
+
+```php
+->withTimestampGenerator(new Cassandra\TimestampGenerator\Monotonic())
+```
+
+`Monotonic` guarantees a strictly increasing value inside one process, which prevents two writes in
+the same microsecond from getting the same timestamp. `ServerSide` leaves the timestamp to the
+coordinator, which is the default behavior.
+
+## Asynchronous execution
+
+```php
+$future = $session->executeAsync($statement, ['arguments' => [$id]]);
+$rows   = $future->get();
+```
+
+`executeAsync()` returns immediately with a `Cassandra\FutureRows`. See
+[asynchronous queries](/guide/async).
+
+## Next
+
+- [Batches](/guide/batches) — group several statements into one request.
+- [Results and paging](/guide/results) — read the result set.
+- [Data types](/guide/data-types) — what to bind for each CQL type.

--- a/website/guide/quickstart.md
+++ b/website/guide/quickstart.md
@@ -1,0 +1,192 @@
+# Quick start
+
+This page builds a small application end to end: connect, create a schema, write, read, and handle
+errors. It assumes the extension is installed and a node is reachable. See
+[installation](/guide/installation) if it is not.
+
+## 1. Connect
+
+```php
+<?php
+
+declare(strict_types=1);
+
+$cluster = Cassandra::cluster()
+    ->withContactPoints('127.0.0.1')
+    ->withPort(9042)
+    ->build();
+
+$session = $cluster->connect();
+```
+
+`Cassandra::cluster()` returns a [`Cassandra\Cluster\Builder`](/reference/cluster-builder). Every
+`with*()` method returns the same builder, so calls chain. `build()` produces an immutable
+`Cassandra\Cluster`. `connect()` opens the connection pool and returns a `Cassandra\Session`.
+
+::: tip One session per process
+Building a cluster is cheap. Connecting is not: it opens sockets to every node and reads the schema.
+Create the session once and share it. See [performance](/guide/performance).
+:::
+
+## 2. Create a keyspace and a table
+
+```php
+$session->execute(
+    "CREATE KEYSPACE IF NOT EXISTS shop
+     WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}"
+);
+
+$session->execute(
+    'CREATE TABLE IF NOT EXISTS shop.users (
+        id uuid PRIMARY KEY,
+        email text,
+        created_at timestamp,
+        login_count bigint
+    )'
+);
+```
+
+`execute()` accepts a plain CQL string. The driver wraps it in a
+[`Cassandra\SimpleStatement`](/guide/queries#simple-statements) for you.
+
+## 3. Select the keyspace
+
+Connect with a keyspace to avoid writing it in every query:
+
+```php
+$session = $cluster->connect('shop');
+```
+
+An existing session can switch with `USE`, but a per-keyspace session is clearer.
+
+## 4. Write with a prepared statement
+
+```php
+$insert = $session->prepare(
+    'INSERT INTO users (id, email, created_at, login_count) VALUES (?, ?, ?, ?)'
+);
+
+$id = new Cassandra\Uuid();   // random version 4 UUID
+
+$session->execute($insert, [
+    'arguments' => [
+        $id,
+        'ada@example.com',
+        new Cassandra\Timestamp(time()),
+        new Cassandra\Bigint(0),
+    ],
+]);
+```
+
+Two rules to remember:
+
+- Bind values with the `arguments` key. Never build CQL by string concatenation.
+- A `bigint` column needs a `Cassandra\Bigint`, not a PHP `int`. A plain `int` marshals as a 4-byte
+  value and the server rejects it. The full table is in [data types](/guide/data-types).
+
+## 5. Read
+
+```php
+$rows = $session->execute('SELECT id, email, login_count FROM users');
+
+echo count($rows), " rows\n";
+
+foreach ($rows as $row) {
+    printf(
+        "%s  %-24s logins=%s\n",
+        $row['id'],          // Cassandra\Uuid
+        $row['email'],       // string
+        $row['login_count'], // Cassandra\Bigint
+    );
+}
+```
+
+Each row is an associative array keyed by column name. Values arrive as PHP scalars or as driver
+value objects. See [results and paging](/guide/results).
+
+## 6. Bind by name
+
+Named markers work as well, and they do not depend on argument order:
+
+```php
+$byId = $session->prepare('SELECT email, login_count FROM users WHERE id = :id');
+
+$rows = $session->execute($byId, [
+    'arguments' => ['id' => $id],
+]);
+
+$first = $rows->first();   // null when the result is empty
+```
+
+## 7. Handle errors
+
+Every driver error implements `Cassandra\Exception`. Catch the specific class you can act on, and
+the interface for everything else.
+
+```php
+use Cassandra\Exception\InvalidQueryException;
+use Cassandra\Exception\ReadTimeoutException;
+
+try {
+    $rows = $session->execute($select, ['timeout' => 2.5]);
+} catch (ReadTimeoutException $e) {
+    // Not enough replicas answered in time. Safe to retry a read.
+    error_log('read timeout: ' . $e->getMessage());
+} catch (InvalidQueryException $e) {
+    // The table or column does not exist. Retrying will not help.
+    throw $e;
+} catch (Cassandra\Exception $e) {
+    error_log('driver error: ' . $e->getMessage());
+}
+```
+
+The full hierarchy is in [error handling](/guide/error-handling).
+
+## 8. Close
+
+```php
+$session->close();
+```
+
+The session closes on script shutdown as well. Call `close()` when you want the sockets released at
+a known point, for example in a long running worker between jobs.
+
+## The complete example
+
+```php
+<?php
+
+declare(strict_types=1);
+
+$session = Cassandra::cluster()
+    ->withContactPoints('127.0.0.1')
+    ->withPort(9042)
+    ->withDefaultConsistency(Cassandra::CONSISTENCY_LOCAL_QUORUM)
+    ->withTokenAwareRouting(true)
+    ->build()
+    ->connect('shop');
+
+$insert = $session->prepare(
+    'INSERT INTO users (id, email, created_at, login_count) VALUES (?, ?, ?, ?)'
+);
+
+$id = new Cassandra\Uuid();
+
+$session->execute($insert, [
+    'arguments' => [$id, 'ada@example.com', new Cassandra\Timestamp(time()), new Cassandra\Bigint(0)],
+]);
+
+$select = $session->prepare('SELECT email, login_count FROM users WHERE id = ?');
+$row = $session->execute($select, ['arguments' => [$id]])->first();
+
+printf("%s has %s logins\n", $row['email'], $row['login_count']);
+
+$session->close();
+```
+
+## Next steps
+
+- [Clusters and sessions](/guide/connecting) — the full connection model and every builder option.
+- [Queries and statements](/guide/queries) — simple, prepared, and batch statements.
+- [Data types](/guide/data-types) — the CQL to PHP mapping.
+- [Asynchronous queries](/guide/async) — run many queries at once.

--- a/website/guide/results.md
+++ b/website/guide/results.md
@@ -1,0 +1,192 @@
+# Results and paging
+
+`execute()` returns a `Cassandra\Rows` object. It holds one page of the result set and knows how to
+fetch the next one.
+
+`Rows` implements `Iterator`, `Countable`, and `ArrayAccess`.
+
+```php
+$rows = $session->execute('SELECT id, email, login_count FROM users');
+
+echo count($rows), " rows on this page\n";
+
+foreach ($rows as $index => $row) {
+    echo $index, ': ', $row['email'], "\n";
+}
+
+$firstRow = $rows[0];        // by offset
+$firstRow = $rows->first();  // null when the page is empty
+```
+
+## Rows are associative arrays
+
+Each row is a PHP array keyed by column name. Values arrive already decoded.
+
+```php
+$row = $session->execute('SELECT id, email, created_at, login_count FROM users')->first();
+
+$row['id'];          // Cassandra\Uuid
+$row['email'];       // string
+$row['created_at'];  // Cassandra\Timestamp
+$row['login_count']; // Cassandra\Bigint
+```
+
+A `null` column arrives as PHP `null`. The full mapping is in [data types](/guide/data-types).
+
+::: tip Select the columns you need
+`SELECT *` transfers and decodes every column. Naming the columns cuts network traffic and decode
+cost, and it keeps the code working when someone adds a column.
+:::
+
+## Counting
+
+```php
+count($rows);   // rows on the current page, not in the whole result
+```
+
+`count()` never triggers a fetch. To count rows in the database, ask the database:
+
+```php
+$total = $session->execute('SELECT COUNT(*) FROM users')->first()['count'];
+```
+
+`COUNT(*)` without a partition key scans the whole table. Avoid it on large tables.
+
+## Paging
+
+The server returns at most `page_size` rows per response. The default is 5000. `Rows` holds one page.
+
+### Automatic paging
+
+```php
+$rows = $session->execute($statement, ['page_size' => 1000]);
+
+while (true) {
+    foreach ($rows as $row) {
+        process($row);
+    }
+
+    if ($rows->isLastPage()) {
+        break;
+    }
+
+    $rows = $rows->nextPage();
+}
+```
+
+`nextPage()` blocks while it fetches. It takes an optional timeout in seconds:
+
+```php
+$rows = $rows->nextPage(5.0);
+```
+
+::: warning Always check isLastPage() first
+Call `isLastPage()` before `nextPage()`. Calling `nextPage()` past the end does not return a usable
+result set.
+:::
+
+### Asynchronous paging
+
+`nextPageAsync()` starts the fetch and returns a future at once, so the current page can be processed
+while the next one travels.
+
+```php
+$rows = $session->execute($statement, ['page_size' => 1000]);
+
+while (true) {
+    $future = $rows->isLastPage() ? null : $rows->nextPageAsync();
+
+    foreach ($rows as $row) {
+        process($row);   // overlaps with the fetch
+    }
+
+    if ($future === null) {
+        break;
+    }
+
+    $rows = $future->get();
+}
+```
+
+This is the fastest way to walk a large result set. See [asynchronous queries](/guide/async).
+
+### Stateless paging
+
+Web applications cannot hold a `Rows` object between requests. Use the paging state token instead.
+It is an opaque string that tells the server where to resume.
+
+```php
+// Request 1: the first page.
+$rows  = $session->execute($statement, ['page_size' => 50]);
+$token = $rows->pagingStateToken();   // null when there is no next page
+
+// Send $token to the client, for example base64 encoded in a link.
+$next = base64_encode($token);
+```
+
+```php
+// Request 2: continue from the token.
+$rows = $session->execute($statement, [
+    'page_size'          => 50,
+    'paging_state_token' => base64_decode($_GET['next']),
+]);
+```
+
+::: danger Treat the token as opaque and untrusted
+The token encodes a position in the result set. Do not build one, do not edit one, and do not accept
+one from a client without care. Sign it, or store it server side and hand out a key.
+:::
+
+Paging tokens are tied to the exact query. Changing the CQL, the page size, or the bound values
+invalidates the token.
+
+## Choosing a page size
+
+| Page size | Effect |
+| --- | --- |
+| Small, 100 to 500 | Low memory per page, more round trips. Good for user-facing lists. |
+| Default, 5000 | A balanced choice for background work. |
+| Large, above 10000 | Fewer round trips, but a large page can exceed the request timeout and raises memory use. |
+
+Set it per query rather than globally when different queries need different values:
+
+```php
+$session->execute($listQuery,   ['page_size' => 50]);      // a page in a web view
+$session->execute($exportQuery, ['page_size' => 5000]);    // a background export
+```
+
+## Iterating twice
+
+`Rows` is a forward iterator with a rewind, so a second `foreach` over the same page works:
+
+```php
+foreach ($rows as $row) { /* first pass */ }
+foreach ($rows as $row) { /* the same page again */ }
+```
+
+`nextPage()` returns a new `Rows` object rather than advancing the current one, so the page you hold
+stays valid.
+
+## Empty results
+
+An empty result set is a valid `Rows` object, not `null` and not an exception.
+
+```php
+$rows = $session->execute($findById, ['arguments' => [$id]]);
+
+if (count($rows) === 0) {
+    throw new NotFoundException();
+}
+
+// Or:
+$row = $rows->first();
+if ($row === null) {
+    throw new NotFoundException();
+}
+```
+
+## Writes and schema changes
+
+An `INSERT`, `UPDATE`, `DELETE`, or `CREATE TABLE` also returns a `Rows` object. It is empty, except
+for a lightweight transaction, which returns the `[applied]` column. See
+[lightweight transactions](/guide/queries#lightweight-transactions).

--- a/website/guide/retry-policies.md
+++ b/website/guide/retry-policies.md
@@ -1,0 +1,141 @@
+# Retry policies
+
+A retry policy decides what the driver does when a request fails with a timeout, an unavailable
+error, or a read error. It runs inside the C driver, before the exception reaches PHP.
+
+```php
+$cluster = Cassandra::cluster()
+    ->withRetryPolicy(new Cassandra\RetryPolicy\DefaultPolicy())
+    ->build();
+```
+
+Set it per statement as well:
+
+```php
+$rows = $session->execute($statement, [
+    'retry_policy' => new Cassandra\RetryPolicy\Fallthrough(),
+]);
+```
+
+The statement value wins over the cluster value.
+
+## The policies
+
+### `DefaultPolicy`
+
+```php
+new Cassandra\RetryPolicy\DefaultPolicy()
+```
+
+The sensible baseline, and the behavior you get when you set no policy.
+
+- **Read timeout** — retry once when enough replicas answered but the data did not arrive.
+- **Write timeout** — retry once, and only for a batch log write, where a retry is safe.
+- **Unavailable** — retry once on the next host.
+
+It never lowers the consistency level. A request that cannot meet the requested consistency fails.
+
+### `Fallthrough`
+
+```php
+new Cassandra\RetryPolicy\Fallthrough()
+```
+
+Never retries. Every error goes straight to PHP as an exception.
+
+Use it when the application owns the retry decision, for example when a job queue already retries
+with backoff, or when the write is not idempotent and a duplicate would be wrong.
+
+### `Logging`
+
+```php
+new Cassandra\RetryPolicy\Logging(new Cassandra\RetryPolicy\DefaultPolicy())
+```
+
+A decorator. It wraps another policy and writes a log line on every retry decision, then delegates.
+The output goes to the driver log configured by `cassandra.log`. See
+[metrics and logging](/guide/observability).
+
+Use it to find out how often retries happen in production. It changes no behavior.
+
+### `DowngradingConsistency` (deprecated)
+
+```php
+new Cassandra\RetryPolicy\DowngradingConsistency()   // deprecated
+```
+
+Retries with a lower consistency level when the requested level cannot be met.
+
+::: danger Do not use this in new code
+The class is deprecated. A silent downgrade means a query you believe ran at `LOCAL_QUORUM`
+actually ran at `ONE`, and you cannot tell from the result. In a degraded cluster it turns a visible
+failure into silent stale data.
+
+Set the consistency each query really needs instead, and let the failure surface.
+:::
+
+## Choosing
+
+| Situation | Policy |
+| --- | --- |
+| Normal application traffic | `DefaultPolicy` |
+| Non-idempotent writes | `Fallthrough`, retry in the application |
+| Investigating retry rates | `Logging` around `DefaultPolicy` |
+| An external system already retries | `Fallthrough` |
+
+## Retries and idempotency
+
+A retry re-sends the same statement. That is safe for a read, and for a write that produces the same
+result when applied twice.
+
+Not idempotent, and therefore not safe to retry blindly:
+
+```sql
+UPDATE counters SET hits = hits + 1 WHERE id = ?;         -- counter increment
+UPDATE users SET tags = tags + {'new'} WHERE id = ?;       -- collection append
+INSERT INTO users (id, email) VALUES (?, ?) IF NOT EXISTS; -- lightweight transaction
+```
+
+The driver cannot tell which is which. For those statements, use `Fallthrough` and handle the failure
+where you know whether a duplicate matters.
+
+## What a retry does not fix
+
+A retry policy handles a failed request. It does not handle:
+
+- **A wrong query.** `InvalidQueryException` and `InvalidSyntaxException` are never retried.
+- **Authorization.** `UnauthorizedException` is final.
+- **An overloaded cluster.** Retries add load. Use backpressure in the application.
+
+See [error handling](/guide/error-handling) for what reaches PHP after the policy runs.
+
+## Application-level retry
+
+When you need control over backoff, turn driver retries off and write the loop yourself:
+
+```php
+use Cassandra\Exception\ReadTimeoutException;
+use Cassandra\Exception\UnavailableException;
+
+function executeWithBackoff(
+    Cassandra\Session $session,
+    Cassandra\Statement $statement,
+    array $options = [],
+    int $attempts = 3,
+): Cassandra\Rows {
+    $options['retry_policy'] = new Cassandra\RetryPolicy\Fallthrough();
+
+    for ($i = 1; ; $i++) {
+        try {
+            return $session->execute($statement, $options);
+        } catch (ReadTimeoutException | UnavailableException $e) {
+            if ($i >= $attempts) {
+                throw $e;
+            }
+            usleep((int) (50_000 * 2 ** ($i - 1)));   // 50ms, 100ms, 200ms
+        }
+    }
+}
+```
+
+Retry only the exceptions that a second attempt can fix. Let the rest propagate.

--- a/website/guide/schema-metadata.md
+++ b/website/guide/schema-metadata.md
@@ -1,0 +1,222 @@
+# Schema metadata
+
+The driver keeps a live copy of the cluster schema. `Session::schema()` returns it.
+
+```php
+$schema = $session->schema();
+```
+
+Metadata is fetched at connect time and updated when the schema changes. Reading it costs no network
+call.
+
+::: tip Metadata requires withSchemaMetadata(true)
+It is on by default. Turning it off also turns off
+[token-aware routing](/guide/load-balancing#token-aware-routing).
+:::
+
+## Keyspaces
+
+```php
+$schema->keyspaces();          // array<string, Cassandra\Keyspace>
+$schema->keyspace('shop');     // Cassandra\Keyspace, or false when absent
+
+$keyspace = $schema->keyspace('shop');
+
+$keyspace->name();                    // 'shop'
+$keyspace->replicationClassName();    // 'org.apache.cassandra.locator.NetworkTopologyStrategy'
+$keyspace->replicationOptions();      // ['eu-west-1' => '3', ...]
+$keyspace->hasDurableWrites();        // true
+```
+
+`keyspace()` returns `false` for a name that does not exist. Check before you use it:
+
+```php
+$keyspace = $schema->keyspace($name);
+
+if ($keyspace === false) {
+    throw new RuntimeException("Keyspace $name does not exist");
+}
+```
+
+## Tables
+
+```php
+$keyspace->tables();            // array<string, Cassandra\Table>
+$keyspace->table('users');      // Cassandra\Table, or false
+
+$table = $keyspace->table('users');
+
+$table->name();
+$table->comment();
+$table->options();              // every option, as an array
+$table->option('bloom_filter_fp_chance');
+```
+
+Named accessors exist for the common options. Each returns `false` when the option is not set:
+
+```php
+$table->defaultTTL();
+$table->gcGraceSeconds();
+$table->caching();
+$table->bloomFilterFPChance();
+$table->compactionStrategyClassName();
+$table->compactionStrategyOptions();
+$table->compressionParameters();
+$table->speculativeRetry();
+$table->memtableFlushPeriodMs();
+$table->minIndexInterval();
+$table->maxIndexInterval();
+```
+
+### Keys
+
+```php
+$table->partitionKey();      // array<int, Column>
+$table->clusteringKey();     // array<int, Column>
+$table->primaryKey();        // partition key plus clustering key
+$table->clusteringOrder();   // array<int, string>, for example ['DESC']
+```
+
+```php
+$partition = array_map(fn ($c) => $c->name(), $table->partitionKey());
+
+echo 'PRIMARY KEY ((', implode(', ', $partition), '))', PHP_EOL;
+```
+
+## Columns
+
+```php
+$table->columns();            // array<string, Cassandra\Column>
+$table->column('email');      // Cassandra\Column, or false
+
+$column = $table->column('email');
+
+$column->name();          // 'email'
+$column->type();          // Cassandra\Type, or null
+$column->isStatic();      // bool
+$column->isFrozen();      // bool
+$column->isReversed();    // bool, true for a DESC clustering column
+$column->indexName();     // string, or null
+$column->indexOptions();  // string, or null
+```
+
+Print a table definition:
+
+```php
+foreach ($table->columns() as $name => $column) {
+    printf("%-24s %s%s\n", $name, $column->type(), $column->isStatic() ? ' static' : '');
+}
+```
+
+## User defined types
+
+This is the most useful part of the metadata for application code. It removes the need to declare
+field types by hand.
+
+```php
+$type = $keyspace->userType('address');    // Cassandra\Type\UserType, or null
+
+$type->name();        // 'address'
+$type->keyspace();    // 'shop'
+$type->types();       // array<string, Cassandra\Type>
+
+$address = $type->create(
+    'street',  '1 Rue de Rivoli',
+    'city',    'Paris',
+    'country', 'FR',
+);
+```
+
+```php
+$keyspace->userTypes();   // array<string, Cassandra\Type\UserType>
+```
+
+See [collections and user defined types](/guide/collections#user-defined-types).
+
+## Materialized views
+
+```php
+$keyspace->materializedViews();                 // array<string, MaterializedView>
+$keyspace->materializedView('users_by_email');  // MaterializedView, or false
+
+$view = $keyspace->materializedView('users_by_email');
+
+$view->baseTable();   // Cassandra\Table, or null
+$view->columns();     // a view is a Table, so every Table method works
+```
+
+`Cassandra\MaterializedView` extends `Cassandra\Table`.
+
+## Functions and aggregates
+
+```php
+$keyspace->functions();                             // array<string, Cassandra\Function_>
+$keyspace->function('to_upper', Cassandra::TYPE_TEXT);
+
+$keyspace->aggregates();
+$keyspace->aggregate('sum_all', Cassandra::TYPE_INT);
+```
+
+Both take the name plus the argument types, because CQL allows overloading. The PHP class is named
+`Cassandra\Function_` because `function` is a reserved word.
+
+## Practical uses
+
+### Check that a table exists before you use it
+
+```php
+function requireTable(Cassandra\Session $session, string $ks, string $table): Cassandra\Table
+{
+    $keyspace = $session->schema()->keyspace($ks);
+
+    if ($keyspace === false) {
+        throw new RuntimeException("Missing keyspace $ks");
+    }
+
+    $found = $keyspace->table($table);
+
+    if ($found === false) {
+        throw new RuntimeException("Missing table $ks.$table");
+    }
+
+    return $found;
+}
+```
+
+Run this at process start. A missing table then fails at boot, not on the first customer request.
+
+### Verify a migration
+
+```php
+$columns = array_keys($session->schema()->keyspace('shop')->table('users')->columns());
+
+$expected = ['id', 'email', 'created_at', 'login_count'];
+$missing  = array_diff($expected, $columns);
+
+if ($missing !== []) {
+    throw new RuntimeException('Missing columns: ' . implode(', ', $missing));
+}
+```
+
+### Generate a schema report
+
+```php
+foreach ($session->schema()->keyspaces() as $name => $keyspace) {
+    if (str_starts_with($name, 'system')) {
+        continue;
+    }
+
+    printf("%s (%s)\n", $name, $keyspace->replicationClassName());
+
+    foreach ($keyspace->tables() as $tableName => $table) {
+        printf("  %-30s %d columns\n", $tableName, count($table->columns()));
+    }
+}
+```
+
+## Freshness
+
+Metadata updates when the cluster pushes a schema change event. A change made through a different
+session, or by an operator, reaches the driver shortly after it applies. Code that creates a table
+and immediately reads its metadata may see the old view. Re-read `schema()` after a short wait when
+that matters.

--- a/website/guide/tls.md
+++ b/website/guide/tls.md
@@ -1,0 +1,170 @@
+# TLS and SSL
+
+TLS is configured with a second builder. `Cassandra::ssl()` returns a
+`Cassandra\SSLOptions\Builder`. Its `build()` produces a `Cassandra\SSLOptions` object that you hand
+to the cluster builder.
+
+```php
+$ssl = Cassandra::ssl()
+    ->withTrustedCerts('/etc/ssl/certs/scylla-ca.pem')
+    ->withVerifyFlags(Cassandra::VERIFY_PEER_CERT | Cassandra::VERIFY_PEER_IDENTITY)
+    ->build();
+
+$cluster = Cassandra::cluster()
+    ->withContactPoints('db-1.example.com', 'db-2.example.com')
+    ->withSSL($ssl)
+    ->build();
+```
+
+::: danger Set the verify flags
+The builder starts with no verify flags, which equals `Cassandra::VERIFY_NONE`. A connection built
+without `withVerifyFlags()` encrypts the traffic but accepts any certificate, so it does not stop a
+machine-in-the-middle attack. Always set the flags.
+:::
+
+## Verification levels
+
+| Constant | Meaning |
+| --- | --- |
+| `Cassandra::VERIFY_NONE` | Encrypt only. The server certificate is not checked. |
+| `Cassandra::VERIFY_PEER_CERT` | Check the server certificate against the trusted certificates. |
+| `Cassandra::VERIFY_PEER_IDENTITY` | Also check that the certificate identity matches the peer. |
+
+Combine the flags with the bitwise `or` operator:
+
+```php
+->withVerifyFlags(Cassandra::VERIFY_PEER_CERT | Cassandra::VERIFY_PEER_IDENTITY)
+```
+
+`VERIFY_PEER_IDENTITY` compares the certificate against the address the driver dialed. When the
+certificate carries host names and the driver connects by IP address, the check fails. Turn on
+host name resolution so the driver learns the peer host names:
+
+```php
+$cluster = Cassandra::cluster()
+    ->withContactPoints('db-1.example.com')
+    ->withHostnameResolution(true)
+    ->withSSL($ssl)
+    ->build();
+```
+
+::: warning Host name resolution needs driver support
+Some backends do not implement host name resolution. The driver emits a warning and continues with
+the feature off. Issue certificates that carry the node IP addresses in the subject alternative name
+when that happens.
+:::
+
+## Trusted certificates
+
+`withTrustedCerts()` takes one or more paths to PEM files. Each file is read at `build()` time and
+loaded into the TLS context.
+
+```php
+->withTrustedCerts('/etc/ssl/certs/scylla-ca.pem')
+
+// Several certificates, for example during a CA rotation:
+->withTrustedCerts('/etc/ssl/certs/scylla-ca.pem', '/etc/ssl/certs/scylla-ca-next.pem')
+```
+
+The paths must be readable by the PHP process. An unreadable path raises
+`Cassandra\Exception\InvalidArgumentException`.
+
+::: tip System trust store
+The driver does not read the operating system trust store. Pass the CA certificate that signed the
+node certificates, even when it is a public CA.
+:::
+
+## Client certificates (mutual TLS)
+
+When the cluster requires client certificates, supply the certificate and the private key:
+
+```php
+$ssl = Cassandra::ssl()
+    ->withTrustedCerts('/etc/ssl/certs/scylla-ca.pem')
+    ->withVerifyFlags(Cassandra::VERIFY_PEER_CERT | Cassandra::VERIFY_PEER_IDENTITY)
+    ->withClientCert('/etc/ssl/certs/app-client.pem')
+    ->withPrivateKey('/etc/ssl/private/app-client-key.pem', getenv('KEY_PASSPHRASE'))
+    ->build();
+```
+
+`withPrivateKey()` takes an optional passphrase. Omit it for an unencrypted key:
+
+```php
+->withPrivateKey('/etc/ssl/private/app-client-key.pem')
+```
+
+Both methods check that the path exists and is readable when you call them, not at `build()` time.
+
+## Full example
+
+```php
+<?php
+
+declare(strict_types=1);
+
+function makeSslOptions(): Cassandra\SSLOptions
+{
+    $builder = Cassandra::ssl()
+        ->withTrustedCerts(getenv('SCYLLA_CA') ?: '/etc/ssl/certs/scylla-ca.pem')
+        ->withVerifyFlags(
+            Cassandra::VERIFY_PEER_CERT | Cassandra::VERIFY_PEER_IDENTITY
+        );
+
+    $clientCert = getenv('SCYLLA_CLIENT_CERT');
+    $clientKey  = getenv('SCYLLA_CLIENT_KEY');
+
+    if ($clientCert && $clientKey) {
+        $builder = $builder
+            ->withClientCert($clientCert)
+            ->withPrivateKey($clientKey, getenv('SCYLLA_KEY_PASSPHRASE') ?: null);
+    }
+
+    return $builder->build();
+}
+
+$session = Cassandra::cluster()
+    ->withContactPoints(...explode(',', getenv('SCYLLA_HOSTS')))
+    ->withPort(9142)
+    ->withCredentials(getenv('SCYLLA_USER'), getenv('SCYLLA_PASSWORD'))
+    ->withSSL(makeSslOptions())
+    ->withHostnameResolution(true)
+    ->build()
+    ->connect('shop');
+```
+
+Note the port. A cluster that terminates TLS on a separate port commonly uses 9142. Check the
+`native_transport_port_ssl` setting of your cluster.
+
+## Cost
+
+TLS adds a handshake to every new connection and encrypts every frame. Two settings reduce the
+impact:
+
+- Keep the session alive so the handshake happens once. See [performance](/guide/performance).
+- Raise the core connection count so the pool does not open connections during traffic peaks. See
+  [connection pool and timeouts](/guide/connection-tuning).
+
+## Debugging a failed handshake
+
+A TLS failure surfaces as a connection error from `connect()`. Raise the driver log level to see the
+reason from the C driver:
+
+```ini
+cassandra.log_level = DEBUG
+cassandra.log = /var/log/php-cassandra.log
+```
+
+Then check the certificate chain from the command line:
+
+```bash
+openssl s_client -connect db-1.example.com:9142 -CAfile /etc/ssl/certs/scylla-ca.pem
+```
+
+Common causes:
+
+| Symptom | Cause |
+| --- | --- |
+| Handshake fails at once, no server log | Wrong port. The plain CQL port does not speak TLS. |
+| "certificate verify failed" | The CA file does not match the chain the node presents. |
+| Verification passes by IP, fails by name | The certificate lacks the subject alternative name. |
+| Works with `VERIFY_NONE` only | The trusted certificate is missing or is the wrong one. |

--- a/website/guide/troubleshooting.md
+++ b/website/guide/troubleshooting.md
@@ -1,0 +1,220 @@
+# Troubleshooting
+
+## Installation
+
+### `Class "Cassandra" not found`
+
+The extension is not loaded.
+
+```bash
+php -m | grep cassandra              # is it listed?
+php -i | grep '^extension_dir'       # where does PHP look?
+php --ini                            # which ini files are read?
+```
+
+The CLI and the web server often read different ini files. Check both.
+
+### `cannot open shared object file: libscylla-cpp-driver.so`
+
+The extension loaded, but the dynamic linker cannot find the C/C++ driver.
+
+```bash
+ldd "$(php -i | grep '^extension_dir' | cut -d' ' -f3)/cassandra.so"
+```
+
+Fix it by adding the library path:
+
+```bash
+echo "$HOME/.local/lib" | sudo tee /etc/ld.so.conf.d/scylla.conf
+sudo ldconfig
+```
+
+On macOS, set `DYLD_LIBRARY_PATH`, or install the driver to a standard prefix.
+
+### `symbol not found in flat namespace '__emalloc_512'`
+
+The extension was built against a different PHP than the one loading it. The Zend memory manager ABI
+differs between a debug build and a release build, and between NTS and ZTS.
+
+Rebuild against the exact PHP binary you run:
+
+```bash
+php-config --version
+php-config --php-binary
+```
+
+### The build cannot find the C/C++ driver
+
+```bash
+export PKG_CONFIG_PATH="$HOME/.local/lib/pkgconfig:$PKG_CONFIG_PATH"
+pkg-config --modversion scylla-cpp-driver
+```
+
+Set `PKG_CONFIG_PATH` in your shell profile so every build sees it.
+
+## Connecting
+
+### `connect()` hangs, then throws
+
+The contact point resolves but nothing listens, or a firewall drops the packets silently.
+
+```bash
+nc -vz 10.0.0.1 9042
+```
+
+Lower `withConnectTimeout()` to fail faster while you debug.
+
+### `No hosts available`
+
+Every contact point failed. Common causes:
+
+| Cause | Check |
+| --- | --- |
+| Wrong port | 9042 for plain CQL, often 9142 for TLS |
+| The node advertises an unreachable address | `SELECT rpc_address FROM system.local` |
+| A host or datacenter filter excludes everything | Review `withWhiteList*` and `withBlackList*` |
+| TLS mismatch | See below |
+
+The advertised address matters. A node behind NAT or inside Docker may advertise an internal
+address that the client cannot reach. The driver connects to the contact point, learns the peer
+list, and then fails on the peers. Set `broadcast_rpc_address` on the node.
+
+### Authentication fails
+
+```
+Cassandra\Exception\AuthenticationException
+```
+
+Verify the credentials with `cqlsh`:
+
+```bash
+cqlsh 10.0.0.1 9042 -u app_user -p "$SCYLLA_PASSWORD"
+```
+
+A cluster running `AllowAllAuthenticator` ignores credentials entirely, so a failure means the
+authenticator is on and the credentials are wrong.
+
+### TLS handshake fails
+
+See [TLS and SSL](/guide/tls#debugging-a-failed-handshake). The quick checks are: right port, right
+CA file, and whether `VERIFY_PEER_IDENTITY` can match the certificate against the address you dial.
+
+## Queries
+
+### `Validation failed for type ... LongType: got 4 bytes`
+
+A plain PHP `int` was bound to a `bigint` or `counter` column.
+
+```php
+// Wrong
+['arguments' => [$id, 42]]
+
+// Right
+['arguments' => [$id, new Cassandra\Bigint(42)]]
+```
+
+The same class of error affects `smallint`, `tinyint`, `varint`, `float`, and `blob`. See
+[data types](/guide/data-types#the-four-traps).
+
+### `Class Cassandra\Numbers\Bigint not found`
+
+Value classes are flat. Use `Cassandra\Bigint`.
+
+```php
+var_dump(array_filter(get_declared_classes(), fn ($c) => str_starts_with($c, 'Cassandra')));
+```
+
+### `InvalidQueryException: unconfigured table`
+
+The keyspace is wrong, or the table does not exist. Connect with the keyspace, or qualify the table
+name:
+
+```php
+$session = $cluster->connect('shop');
+// or
+$session->execute('SELECT * FROM shop.users');
+```
+
+### Queries are slow but the cluster is idle
+
+Almost always an unprepared statement plus a coordinator hop. Prepare it. See
+[performance](/guide/performance).
+
+Confirm with metrics: a high `median` with a low server-side coordinator latency points at the extra
+hop or at the client.
+
+### A timeout on a query that used to work
+
+Check the page size first. A `SELECT` over a growing partition transfers more each day until it
+crosses the request timeout.
+
+```php
+$session->execute($statement, ['page_size' => 500, 'timeout' => 10.0]);
+```
+
+## Memory
+
+### Memory grows while paging a large result
+
+Hold one page at a time. Do not accumulate `Rows` objects.
+
+```php
+// Wrong: keeps every page alive.
+$pages = [];
+while (! $rows->isLastPage()) {
+    $pages[] = $rows;
+    $rows = $rows->nextPage();
+}
+```
+
+Process each page, extract plain PHP values, then move on. See
+[performance](/guide/performance#value-objects-and-memory).
+
+### Memory grows across requests under PHP-FPM
+
+Persistent sessions live for the worker lifetime. That is by design. What should not grow is the
+number of sessions. Creating a session with a different configuration on each request creates a new
+cached entry each time, because the cache key covers the configuration.
+
+Build the configuration from constants, not from per-request data.
+
+## Environment
+
+### Different behavior between CLI and the web server
+
+They read different ini files and often different PHP builds.
+
+```bash
+php --ini
+php -i | grep -E '^(Thread Safety|Debug Build)'
+```
+
+Compare with `phpinfo()` from the web server.
+
+### The extension works locally and fails in Docker
+
+The image needs the runtime libraries, not just the build ones. A multi-stage build must copy the
+C/C++ driver and libuv shared objects into the final image, and run `ldconfig`.
+
+## Getting help
+
+Include this in a bug report:
+
+```php
+<?php
+printf("driver:      %s\n", Cassandra::VERSION);
+printf("cpp-driver:  %s\n", Cassandra::CPP_DRIVER_VERSION);
+printf("php:         %s (%s, %s)\n",
+    PHP_VERSION,
+    PHP_ZTS ? 'ZTS' : 'NTS',
+    PHP_DEBUG ? 'debug' : 'release',
+);
+printf("os:          %s %s\n", PHP_OS, php_uname('r'));
+```
+
+Add the ScyllaDB or Cassandra version, the full exception with its stack trace, and a minimal script
+that reproduces the problem.
+
+Open an issue at
+[github.com/he4rt/scylladb-php-driver](https://github.com/he4rt/scylladb-php-driver/issues), or ask
+in the [ScyllaDB Developers Discord](https://discord.gg/B6rutCXvgp).

--- a/website/index.md
+++ b/website/index.md
@@ -1,0 +1,90 @@
+---
+layout: home
+
+hero:
+  name: ScyllaDB PHP Driver
+  text: Native CQL for PHP 8
+  tagline: A C extension that speaks the CQL binary protocol directly. Built on the ScyllaDB C/C++ driver, with token-aware routing, prepared statements, async futures, and full CQL type support.
+  image:
+    src: /logo.svg
+    alt: ScyllaDB PHP driver
+  actions:
+    - theme: brand
+      text: Get started
+      link: /guide/quickstart
+    - theme: alt
+      text: Installation
+      link: /guide/installation
+    - theme: alt
+      text: View on GitHub
+      link: https://github.com/he4rt/scylladb-php-driver
+
+features:
+  - icon: ⚡
+    title: Native protocol, no PHP overhead
+    details: Queries run through the ScyllaDB C/C++ driver. Result rows decode in C and arrive as PHP values. No CQL parsing or text protocol in userland.
+    link: /guide/introduction
+    linkText: How it works
+
+  - icon: 🎯
+    title: Token-aware and shard-aware
+    details: The driver sends each request to a replica that owns the data. Add datacenter-aware and latency-aware routing to control which nodes get traffic.
+    link: /guide/load-balancing
+    linkText: Routing options
+
+  - icon: 🔐
+    title: TLS with peer verification
+    details: Load trusted certificates, present a client certificate, and choose the verification level. Credentials use the SensitiveParameter attribute.
+    link: /guide/tls
+    linkText: Set up TLS
+
+  - icon: 🧩
+    title: Every CQL type
+    details: Collections, tuples, user defined types, durations, decimals, varints, inet addresses, and time UUIDs all map to dedicated PHP classes.
+    link: /guide/data-types
+    linkText: Type mapping
+
+  - icon: 🔀
+    title: Futures for concurrency
+    details: Each blocking call has an async twin. Start many queries, then collect the results. Result pages fetch asynchronously too.
+    link: /guide/async
+    linkText: Run queries in parallel
+
+  - icon: 🐘
+    title: PHP 8.2 through 8.5
+    details: Typed signatures generated from PHP stubs, NTS and ZTS builds, and installation through PIE. Tested against ScyllaDB 4.4 to 6.x and Cassandra 3.0+.
+    link: /guide/installation
+    linkText: Compatibility
+---
+
+<div style="max-width: 1152px; margin: 64px auto 0; padding: 0 24px;">
+
+## From zero to a query
+
+```php
+<?php
+
+$session = Cassandra::cluster()
+    ->withContactPoints('10.0.0.1', '10.0.0.2', '10.0.0.3')
+    ->withPort(9042)
+    ->withCredentials('scylla', getenv('SCYLLA_PASSWORD'))
+    ->withDefaultConsistency(Cassandra::CONSISTENCY_LOCAL_QUORUM)
+    ->withTokenAwareRouting(true)
+    ->build()
+    ->connect('shop');
+
+$statement = $session->prepare('SELECT id, email FROM users WHERE id = ?');
+
+$rows = $session->execute($statement, [
+    'arguments' => [new Cassandra\Uuid('7b5a4c1e-8f2a-4c9e-9a1b-3c2d1e0f5a6b')],
+]);
+
+foreach ($rows as $row) {
+    printf("%s <%s>\n", $row['id'], $row['email']);
+}
+```
+
+Read the [quick start](/guide/quickstart) for a complete first application, or go to
+[clusters and sessions](/guide/connecting) for the full connection model.
+
+</div>

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1,0 +1,2579 @@
+{
+  "name": "scylladb-php-driver-docs",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "scylladb-php-driver-docs",
+      "version": "0.0.0",
+      "devDependencies": {
+        "vitepress": "^1.6.4"
+      }
+    },
+    "node_modules/@algolia/abtesting": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.22.0.tgz",
+      "integrity": "sha512-BFR6zNowNKcY7Ou7TaJc9QWexES4YKPbmf/OTFofpdsdhz4x6q0lbxp3duO0EHnyrN7rE4ba/TSXuY+BDGu4+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/autocomplete-core": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.17.7.tgz",
+      "integrity": "sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-plugin-algolia-insights": "1.17.7",
+        "@algolia/autocomplete-shared": "1.17.7"
+      }
+    },
+    "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.17.7.tgz",
+      "integrity": "sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.17.7"
+      },
+      "peerDependencies": {
+        "search-insights": ">= 1 < 3"
+      }
+    },
+    "node_modules/@algolia/autocomplete-preset-algolia": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.17.7.tgz",
+      "integrity": "sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.17.7"
+      },
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/autocomplete-shared": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.17.7.tgz",
+      "integrity": "sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/client-abtesting": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.56.0.tgz",
+      "integrity": "sha512-7r4Z3NC7yU1oAQVWJNA2HX7tX481F3pJvCGyLIXiTdBcthz4Q/o21jwcMYDFkuI92UWTNBQQmHYgwHo1zS5dzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-analytics": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.56.0.tgz",
+      "integrity": "sha512-avmjXQSq+jadFO8Xl2em05/uQdQnEmHsJyOAdVbZkmVgpMfxL12aJwVVfGNwYr9nulcpuJN1X0lTaQ5wxuNGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-common": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.56.0.tgz",
+      "integrity": "sha512-v2TPStUhY//ripPjIVclZ8AWc7DEGooXULZGFlFu37zNatgHjw34oZZ+OSbbc/YHO+xZwPl62I1k8xH1m4S2eg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-insights": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.56.0.tgz",
+      "integrity": "sha512-P0ehROpM4Sem3Sqo5x2cKPgj67D3G3jy0rh1Amwkcvsfr6tkvIcdCmerieanqTF7NxUMPNFLkpIFeMO8Rpa50w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-personalization": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.56.0.tgz",
+      "integrity": "sha512-SXK3Vn3WVxyzbm31oePZBJkp1wpOyuWdd4B/Pv7n0aXDxmeSWhC1R1FC1517mMrFAIaPH4Rt0x6RUe7ZNjz8FA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-query-suggestions": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.56.0.tgz",
+      "integrity": "sha512-5+ZdX8garFnmycnZgKhtXHePEaLj5zqDxI/0lkhhluzCcvTn0/PvvTirTg8hHYetQHvn7GDyeAiqTAieMvMW4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-search": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.56.0.tgz",
+      "integrity": "sha512-+mKUdYvqOi0BcvpAEyCEw49vSBptufIcfibtHz2bdr1pI789M46Yt0uQEk/sxtK3teh71OQvVFHaTDzShUWewQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/ingestion": {
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.56.0.tgz",
+      "integrity": "sha512-9g/zj+AZx5moFcdFIrYQoVrueXivjUcc3MQHtCYT8WhIuk1lUh1AyEhvJCS0XBZld09cLvd1AZ3BvDBpVpX2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/monitoring": {
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.56.0.tgz",
+      "integrity": "sha512-Qf3Sr6f9A9uxCZUf3MXS0d2b877uYzEB5yxqpVGXAhcJnBCQjrRRon0KvefpGkxy+BshrIJs96OUoMtGqXTFDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/recommend": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.56.0.tgz",
+      "integrity": "sha512-GXWG1rWc5wu8hY4N33Y3b6ernY6sAdAvmKWN/zHAiACOx40WnpG0TVX5YazCAr/9gOYGInSiM2A0y2jy2xbiDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-browser-xhr": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.56.0.tgz",
+      "integrity": "sha512-7t24cBxaInS3mZb7ddEaZT/tp6q+/aR4YttsQVyP1/i+LmwPR34atO35KjaLFCcRVrlP7sYOAqkCfg6lIRB+ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-fetch": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.56.0.tgz",
+      "integrity": "sha512-R7ePHgVYmDFjZpvrsVAfbDz/d4RxKAYZ5/vgLfIsCVRZRryjWl/3INOxpOICzitehQ5FjNtNjcLQTrmHPTcHBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-node-http": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.56.0.tgz",
+      "integrity": "sha512-PIOUXlSnrqM0S+WOgDRb4RzotydJH7ZoT6tOyL7tAO7qJOfvX5wsEW8Pe+PMKMwvuI4/gIyK9cg2H7lJXqnc4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@docsearch/css": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.8.2.tgz",
+      "integrity": "sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@docsearch/js": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.8.2.tgz",
+      "integrity": "sha512-Q5wY66qHn0SwA7Taa0aDbHiJvaFJLOJyHmooQ7y8hlwwQLQ/5WwCcoX0g7ii04Qi2DJlHsd0XXzJ8Ypw9+9YmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@docsearch/react": "3.8.2",
+        "preact": "^10.0.0"
+      }
+    },
+    "node_modules/@docsearch/react": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.8.2.tgz",
+      "integrity": "sha512-xCRrJQlTt8N9GU0DG4ptwHRkfnSnD/YpdeaXe02iKfqs97TkZJv60yE+1eq/tjPcVnTW8dP5qLP7itifFVV5eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-core": "1.17.7",
+        "@algolia/autocomplete-preset-algolia": "1.17.7",
+        "@docsearch/css": "3.8.2",
+        "algoliasearch": "^5.14.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">= 16.8.0 < 19.0.0",
+        "react": ">= 16.8.0 < 19.0.0",
+        "react-dom": ">= 16.8.0 < 19.0.0",
+        "search-insights": ">= 1 < 3"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "search-insights": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@iconify-json/simple-icons": {
+      "version": "1.2.93",
+      "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.93.tgz",
+      "integrity": "sha512-/XhANjfGYOuqvSR3TmUnkQkINvQ4GVjVuukvymRbxtVFBvIq/yiXJqCDycKcQPT401OYT9H2vIY6ihAlz1QIAw==",
+      "dev": true,
+      "license": "CC0-1.0",
+      "dependencies": {
+        "@iconify/types": "*"
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
+      "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
+      "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
+      "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
+      "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
+      "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
+      "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
+      "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
+      "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
+      "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
+      "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
+      "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
+      "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
+      "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
+      "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
+      "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
+      "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
+      "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
+      "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
+      "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
+      "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
+      "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
+      "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
+      "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@shikijs/core": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-2.5.0.tgz",
+      "integrity": "sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/engine-javascript": "2.5.0",
+        "@shikijs/engine-oniguruma": "2.5.0",
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.4"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-2.5.0.tgz",
+      "integrity": "sha512-VjnOpnQf8WuCEZtNUdjjwGUbtAVKuZkVQ/5cHy/tojVVRIRtlWMYVjyWhxOmIq05AlSOv72z7hRNRGVBgQOl0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^3.1.0"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-2.5.0.tgz",
+      "integrity": "sha512-pGd1wRATzbo/uatrCIILlAdFVKdxImWJGQ5rFiB5VZi2ve5xj3Ax9jny8QvkaV93btQEwR/rSz5ERFpC5mKNIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-2.5.0.tgz",
+      "integrity": "sha512-Qfrrt5OsNH5R+5tJ/3uYBBZv3SuGmnRPejV9IlIbFH3HTGLDlkqgHymAlzklVmKBjAaVmkPkyikAV/sQ1wSL+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-2.5.0.tgz",
+      "integrity": "sha512-wGrk+R8tJnO0VMzmUExHR+QdSaPUl/NKs+a4cQQRWyoc3YFbUzuLEi/KWK1hj+8BfHRKm2jNhhJck1dfstJpiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/transformers": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-2.5.0.tgz",
+      "integrity": "sha512-SI494W5X60CaUwgi8u4q4m4s3YAFSxln3tzNjOSYqq54wlVgz0/NbbXEb3mdLbqMBztcmS7bVTaEd2w0qMmfeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "2.5.0",
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-2.5.0.tgz",
+      "integrity": "sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/web-bluetooth": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
+      "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
+      "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.41.tgz",
+      "integrity": "sha512-q0Xtv/F9w2YO/7htQhtiL+Ev2WCJbe5N2hc+XfgyKkEKqWpSxknmT8QOuGdEKNdjPq0c3F7rNpFkTo3Kfrm7pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@vue/shared": "3.5.41",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.41.tgz",
+      "integrity": "sha512-oKacVfNglLvGjnS6BXOlGL7EyG2h8X03pqXCjzotRZUaXGjbrTJUnVAQjrCqUnS+lyu31nwQjZY/d817GmCnfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.41",
+        "@vue/shared": "3.5.41"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.41.tgz",
+      "integrity": "sha512-XJhip7R2wy6vX3knCxdZN4KracFaZUef58s1KYewqluedHIJaPIVfXoYT7MF1F8nCvv6k8bWWxDC8opMkg1VTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@vue/compiler-core": "3.5.41",
+        "@vue/compiler-dom": "3.5.41",
+        "@vue/compiler-ssr": "3.5.41",
+        "@vue/shared": "3.5.41",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.19",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.41.tgz",
+      "integrity": "sha512-U3v5OejKEGqOI0Wy0+Sz7hGuIFZHA4LSXzrNM3IMIeDyJEBBfTpX26n3SDgToRpP2bLc9FfI2j/kSgcJ8Emq5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.41",
+        "@vue/shared": "3.5.41"
+      }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "7.7.10",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.10.tgz",
+      "integrity": "sha512-KxtEpUOOpFz/qOGRrAwA36QF7DqIA+FXgCYit9mk9wjbaZt0sXOFz81ElOZtKA4HbWHUdwNjZHBFsFFyp5BZiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-kit": "^7.7.10"
+      }
+    },
+    "node_modules/@vue/devtools-kit": {
+      "version": "7.7.10",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.10.tgz",
+      "integrity": "sha512-3WNi2Kq4tbpVbmhml7RiphmAt0279oh3fKNeWMQIrltfX8Q91b4i5PL8DtyNKdwmcsGrV4fg+erwWOmD05CLIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-shared": "^7.7.10",
+        "birpc": "^2.3.0",
+        "hookable": "^5.5.3",
+        "mitt": "^3.0.1",
+        "perfect-debounce": "^1.0.0",
+        "speakingurl": "^14.0.1",
+        "superjson": "^2.2.2"
+      }
+    },
+    "node_modules/@vue/devtools-shared": {
+      "version": "7.7.10",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.10.tgz",
+      "integrity": "sha512-wOPslzB8vTvpxwdaOcR2qAbwmuSP0L+rhpoC6Cf56V3Jip+HWb7PQQXOUPgBNQARpXsbQX/+mvi8kKucmBGRwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rfdc": "^1.4.1"
+      }
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.41.tgz",
+      "integrity": "sha512-rznsqKM0np0x18EjzF8x88MpEhdNsffbvFbckLL5+oUKz1BxAImEmO7J1ArRYSyo6aQaVoBDp7jEkT91OOxydA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.41"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.41.tgz",
+      "integrity": "sha512-Vcry58hiAKwGen9Z1jUZE0feFsNArPCMOImYI8el48A9Idf6DuQYD0U05zZIF2Iad1hGhPSvcbBbAOhNr55fhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.41",
+        "@vue/shared": "3.5.41"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.41.tgz",
+      "integrity": "sha512-3vVBahVBS9+U6cmXBLyb8nE6/yYo4J/CGI9eVFs3KiMc0YHuudwKyShTD65jtJy/L9PUUxNAFu4cj4LiJ0UFbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.41",
+        "@vue/runtime-core": "3.5.41",
+        "@vue/shared": "3.5.41",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.41.tgz",
+      "integrity": "sha512-n6hx/pNFfbD6SuyeuMVkvqox8bwf/ET9JlA/kAz/imw8sw++wkqKe2mHX5KutjPpbKE4Z56yTHszoOjGMI9igQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.41",
+        "@vue/runtime-dom": "3.5.41",
+        "@vue/shared": "3.5.41"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.41.tgz",
+      "integrity": "sha512-IOnwSCma8j+9xJT6b8H0dEYidC80NsYmNMlZxRsukYcSoGaDBohog5hDxzeUXdFeGWFA++vWvxqOmrr96VlqMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vueuse/core": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-12.8.2.tgz",
+      "integrity": "sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.21",
+        "@vueuse/metadata": "12.8.2",
+        "@vueuse/shared": "12.8.2",
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/integrations": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-12.8.2.tgz",
+      "integrity": "sha512-fbGYivgK5uBTRt7p5F3zy6VrETlV9RtZjBqd1/HxGdjdckBgBM4ugP8LHpjolqTj14TXTxSK1ZfgPbHYyGuH7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vueuse/core": "12.8.2",
+        "@vueuse/shared": "12.8.2",
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "async-validator": "^4",
+        "axios": "^1",
+        "change-case": "^5",
+        "drauu": "^0.4",
+        "focus-trap": "^7",
+        "fuse.js": "^7",
+        "idb-keyval": "^6",
+        "jwt-decode": "^4",
+        "nprogress": "^0.2",
+        "qrcode": "^1.5",
+        "sortablejs": "^1",
+        "universal-cookie": "^7"
+      },
+      "peerDependenciesMeta": {
+        "async-validator": {
+          "optional": true
+        },
+        "axios": {
+          "optional": true
+        },
+        "change-case": {
+          "optional": true
+        },
+        "drauu": {
+          "optional": true
+        },
+        "focus-trap": {
+          "optional": true
+        },
+        "fuse.js": {
+          "optional": true
+        },
+        "idb-keyval": {
+          "optional": true
+        },
+        "jwt-decode": {
+          "optional": true
+        },
+        "nprogress": {
+          "optional": true
+        },
+        "qrcode": {
+          "optional": true
+        },
+        "sortablejs": {
+          "optional": true
+        },
+        "universal-cookie": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vueuse/metadata": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-12.8.2.tgz",
+      "integrity": "sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-12.8.2.tgz",
+      "integrity": "sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/algoliasearch": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.56.0.tgz",
+      "integrity": "sha512-PrqppUmhT4ENdas2pH9caE7efUcxy6EcSFhWzosiVuQBzu2tQ5yLTI6jwomT/1cuBnivzGfxiJCqDNN9FRRh+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/abtesting": "1.22.0",
+        "@algolia/client-abtesting": "5.56.0",
+        "@algolia/client-analytics": "5.56.0",
+        "@algolia/client-common": "5.56.0",
+        "@algolia/client-insights": "5.56.0",
+        "@algolia/client-personalization": "5.56.0",
+        "@algolia/client-query-suggestions": "5.56.0",
+        "@algolia/client-search": "5.56.0",
+        "@algolia/ingestion": "1.56.0",
+        "@algolia/monitoring": "1.56.0",
+        "@algolia/recommend": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/birpc": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
+      "integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/copy-anything": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
+      "integrity": "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-what": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/emoji-regex-xs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
+      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/focus-trap": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.8.0.tgz",
+      "integrity": "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tabbable": "^6.4.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hookable": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-what": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
+      "integrity": "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mark.js": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
+      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/minisearch": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.2.0.tgz",
+      "integrity": "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-3.1.1.tgz",
+      "integrity": "sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex-xs": "^1.0.0",
+        "regex": "^6.0.1",
+        "regex-recursion": "^6.0.2"
+      }
+    },
+    "node_modules/perfect-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.8",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.8.tgz",
+      "integrity": "sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact-render-to-string": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "preact-render-to-string": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
+      "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.4",
+        "@rollup/rollup-android-arm64": "4.62.4",
+        "@rollup/rollup-darwin-arm64": "4.62.4",
+        "@rollup/rollup-darwin-x64": "4.62.4",
+        "@rollup/rollup-freebsd-arm64": "4.62.4",
+        "@rollup/rollup-freebsd-x64": "4.62.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.4",
+        "@rollup/rollup-linux-arm64-musl": "4.62.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.4",
+        "@rollup/rollup-linux-loong64-musl": "4.62.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-musl": "4.62.4",
+        "@rollup/rollup-openbsd-x64": "4.62.4",
+        "@rollup/rollup-openharmony-arm64": "4.62.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.4",
+        "@rollup/rollup-win32-x64-gnu": "4.62.4",
+        "@rollup/rollup-win32-x64-msvc": "4.62.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/search-insights": {
+      "version": "2.17.3",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
+      "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/shiki": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-2.5.0.tgz",
+      "integrity": "sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "2.5.0",
+        "@shikijs/engine-javascript": "2.5.0",
+        "@shikijs/engine-oniguruma": "2.5.0",
+        "@shikijs/langs": "2.5.0",
+        "@shikijs/themes": "2.5.0",
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/speakingurl": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
+      "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/superjson": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
+      "integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "copy-anything": "^4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tabbable": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
+      "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitepress": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.6.4.tgz",
+      "integrity": "sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@docsearch/css": "3.8.2",
+        "@docsearch/js": "3.8.2",
+        "@iconify-json/simple-icons": "^1.2.21",
+        "@shikijs/core": "^2.1.0",
+        "@shikijs/transformers": "^2.1.0",
+        "@shikijs/types": "^2.1.0",
+        "@types/markdown-it": "^14.1.2",
+        "@vitejs/plugin-vue": "^5.2.1",
+        "@vue/devtools-api": "^7.7.0",
+        "@vue/shared": "^3.5.13",
+        "@vueuse/core": "^12.4.0",
+        "@vueuse/integrations": "^12.4.0",
+        "focus-trap": "^7.6.4",
+        "mark.js": "8.11.1",
+        "minisearch": "^7.1.1",
+        "shiki": "^2.1.0",
+        "vite": "^5.4.14",
+        "vue": "^3.5.13"
+      },
+      "bin": {
+        "vitepress": "bin/vitepress.js"
+      },
+      "peerDependencies": {
+        "markdown-it-mathjax3": "^4",
+        "postcss": "^8"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it-mathjax3": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.41.tgz",
+      "integrity": "sha512-2laE0p+aK+/AOPG/XL/WepOs/GlK755LJ1XECi9kDUrz1FKNw8rb2Xzlw9JS1rqEV55nb0ttsKxVlTCcd+R5cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.41",
+        "@vue/compiler-sfc": "3.5.41",
+        "@vue/runtime-dom": "3.5.41",
+        "@vue/server-renderer": "3.5.41",
+        "@vue/shared": "3.5.41"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    }
+  }
+}

--- a/website/package.json
+++ b/website/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "scylladb-php-driver-docs",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Documentation site for the ScyllaDB PHP driver",
+  "scripts": {
+    "dev": "vitepress dev",
+    "build": "vitepress build",
+    "preview": "vitepress preview"
+  },
+  "devDependencies": {
+    "vitepress": "^1.6.4"
+  }
+}

--- a/website/public/logo.svg
+++ b/website/public/logo.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <defs>
+    <linearGradient id="g" x1="8" y1="6" x2="56" y2="58" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#8B5CF6"/>
+      <stop offset="0.55" stop-color="#6D4AFF"/>
+      <stop offset="1" stop-color="#22D3EE"/>
+    </linearGradient>
+  </defs>
+  <path d="M32 4 55 17v30L32 60 9 47V17z" stroke="url(#g)" stroke-width="3" stroke-linejoin="round"/>
+  <circle cx="32" cy="18" r="5.5" fill="url(#g)"/>
+  <circle cx="16" cy="42" r="5.5" fill="url(#g)"/>
+  <circle cx="48" cy="42" r="5.5" fill="url(#g)"/>
+  <path d="M32 18 16 42h32z" stroke="url(#g)" stroke-width="2.5" stroke-linejoin="round" opacity="0.5"/>
+</svg>

--- a/website/reference/cluster-builder.md
+++ b/website/reference/cluster-builder.md
@@ -1,0 +1,161 @@
+# `Cassandra\Cluster\Builder`
+
+Obtained from `Cassandra::cluster()`. Every method returns the builder, so calls chain. `build()`
+produces an immutable `Cassandra\Cluster`.
+
+```php
+$cluster = Cassandra::cluster()
+    ->withContactPoints('10.0.0.1')
+    ->build();
+```
+
+## Every method
+
+| Method | Parameters | Default | Description |
+| --- | --- | --- | --- |
+| `withContactPoints` | `string ...$host` | `127.0.0.1` | Addresses the driver dials first |
+| `withPort` | `int $port` | `9042` | The CQL native port on every node |
+| `withCredentials` | `string $username, string $password` | none | Password authentication. The password is a `SensitiveParameter` |
+| `withSSL` | `Cassandra\SSLOptions $options` | none | TLS settings from `Cassandra::ssl()` |
+| `withDefaultConsistency` | `int $consistency` | `CONSISTENCY_LOCAL_ONE` | Consistency for statements that set none |
+| `withDefaultPageSize` | `int $pageSize` | `5000` | Rows per page for statements that set none |
+| `withDefaultTimeout` | `float $timeout` | none | Seconds. Timeout for statements that set none |
+| `withConnectTimeout` | `float $timeout` | `5.0` | Seconds. Bounds one connection handshake |
+| `withRequestTimeout` | `float $timeout` | `12.0` | Seconds. The hard ceiling on one request |
+| `withRoundRobinLoadBalancingPolicy` | — | active | Cycle through every node in the cluster |
+| `withDatacenterAwareRoundRobinLoadBalancingPolicy` | `string $localDatacenter, int $hostPerRemoteDatacenter, bool $useRemoteDatacenterForLocalConsistencies` | — | Prefer the local datacenter. All three arguments are required |
+| `withTokenAwareRouting` | `bool $enabled = true` | `true` | Send a request straight to a replica that owns the data |
+| `withLatencyAwareRouting` | `bool $enabled = true` | `true` | Push consistently slow nodes down the candidate list |
+| `withWhiteListHosts` | `string ...$hosts` | none | Use only these nodes |
+| `withBlackListHosts` | `string ...$hosts` | none | Never use these nodes |
+| `withWhiteListDCs` | `string ...$dcs` | none | Use only these datacenters |
+| `withBlackListDCs` | `string ...$dcs` | none | Never use these datacenters |
+| `withConnectionsPerHost` | `int $core, int $max = 2` | `1`, `2` | Pool size per node. Each value must be 1 to 128 |
+| `withIOThreads` | `int $count` | `1` | Event loop threads in the C driver. 1 to 128 |
+| `withReconnectInterval` | `float $interval` | `2.0` | Seconds between attempts to reach a node that is down |
+| `withConnectionHeartbeatInterval` | `float $interval` | `30.0` | Seconds between keepalive requests on an idle connection |
+| `withTCPNodelay` | `bool $enabled = true` | `true` | Disable Nagle's algorithm |
+| `withTCPKeepalive` | `?float $delay` | disabled | Seconds. Pass `null` to disable |
+| `withProtocolVersion` | `int $version` | `4` | CQL protocol version |
+| `withPersistentSessions` | `bool $enabled = true` | `true` | Cache the session in the PHP worker process |
+| `withSchemaMetadata` | `bool $enabled = true` | `true` | Fetch and track the schema. Required for token awareness |
+| `withHostnameResolution` | `bool $enabled = true` | `false` | Resolve peer addresses to host names |
+| `withRandomizedContactPoints` | `bool $enabled = true` | `true` | Shuffle the contact point order |
+| `withRetryPolicy` | `Cassandra\RetryPolicy $policy` | `DefaultPolicy` | See [retry policies](/guide/retry-policies) |
+| `withTimestampGenerator` | `Cassandra\TimestampGenerator $generator` | server side | Client-side write timestamps |
+| `build` | — | — | Produce the `Cassandra\Cluster` |
+
+All time values are seconds, given as a float. `0.25` is 250 milliseconds.
+
+## Grouped by purpose
+
+### Where to connect
+
+```php
+->withContactPoints('10.0.0.1', '10.0.0.2', '10.0.0.3')
+->withPort(9042)
+->withRandomizedContactPoints(true)
+->withHostnameResolution(false)
+```
+
+See [clusters and sessions](/guide/connecting).
+
+### Security
+
+```php
+->withCredentials('app_user', getenv('SCYLLA_PASSWORD'))
+->withSSL($sslOptions)
+```
+
+See [authentication](/guide/authentication) and [TLS and SSL](/guide/tls).
+
+### Which node gets the request
+
+```php
+->withDatacenterAwareRoundRobinLoadBalancingPolicy('eu-west-1', 0, false)
+->withTokenAwareRouting(true)
+->withLatencyAwareRouting(true)
+->withWhiteListDCs('eu-west-1')
+```
+
+See [load balancing and routing](/guide/load-balancing).
+
+### Pool and timeouts
+
+```php
+->withConnectionsPerHost(2, 8)
+->withIOThreads(1)
+->withConnectTimeout(5.0)
+->withRequestTimeout(12.0)
+->withReconnectInterval(2.0)
+->withConnectionHeartbeatInterval(30.0)
+->withTCPNodelay(true)
+->withTCPKeepalive(null)
+```
+
+See [connection pool and timeouts](/guide/connection-tuning).
+
+### Query defaults
+
+```php
+->withDefaultConsistency(Cassandra::CONSISTENCY_LOCAL_QUORUM)
+->withDefaultPageSize(5000)
+->withDefaultTimeout(10.0)
+->withRetryPolicy(new Cassandra\RetryPolicy\DefaultPolicy())
+->withTimestampGenerator(new Cassandra\TimestampGenerator\Monotonic())
+```
+
+Every one of these is overridable per statement. See
+[queries and statements](/guide/queries#execution-options).
+
+## Validation
+
+Invalid values raise `Cassandra\Exception\InvalidArgumentException` at the call, not at `build()`.
+
+| Method | Rule |
+| --- | --- |
+| `withDefaultPageSize` | 0 or greater |
+| `withIOThreads` | 1 to 128 |
+| `withConnectionsPerHost` | Each value 1 to 128 |
+| `withProtocolVersion` | 1 or greater |
+| `withDatacenterAwareRoundRobinLoadBalancingPolicy` | `hostPerRemoteDatacenter` 0 or greater |
+| Every timeout | 0 or greater |
+
+## Reading the configuration back
+
+The builder exposes its state as read-only properties, which is convenient in tests.
+
+```php
+$builder = Cassandra::cluster()
+    ->withContactPoints('10.0.0.1')
+    ->withTokenAwareRouting(true);
+
+get_object_vars($builder);
+// ['contactPoints' => '10.0.0.1', 'useTokenAwareRouting' => true, ...]
+```
+
+The exposed names are: `contactPoints`, `loadBalancingPolicy`, `localDatacenter`,
+`hostPerRemoteDatacenter`, `useRemoteDatacenterForLocalConsistencies`, `useTokenAwareRouting`,
+`username`, `password`, `connectTimeout`, `requestTimeout`, `sslOptions`, `defaultConsistency`,
+`defaultPageSize`, `defaultTimeout`, `usePersistentSessions`, `protocolVersion`, `ioThreads`,
+`coreConnectionPerHost`, `maxConnectionsPerHost`, `reconnectInterval`, `latencyAwareRouting`,
+`tcpNodelay`, `tcpKeepalive`, `retryPolicy`, `timestampGenerator`, `schemaMetadata`,
+`blacklist_hosts`, `whitelist_hosts`, `blacklist_dcs`, `whitelist_dcs`, `hostnameResolution`,
+`randomizedContactPoints`, and `connectionHeartbeatInterval`. The port is not among them.
+
+::: danger The password is readable
+`password` returns the value in clear text. `var_dump()`, `print_r()`, and any framework debug
+panel that dumps objects will print it. The `SensitiveParameter` attribute hides the password in
+stack traces, not here.
+
+Never dump a builder in a context that reaches a log, an error page, or a user.
+:::
+
+## Persistent session cache
+
+With `withPersistentSessions(true)`, `build()` hashes the whole configuration and reuses a cached
+cluster when the hash matches. Two builders with identical settings share one underlying cluster
+inside a PHP worker process.
+
+This is why the configuration must come from constants, not from per-request values. A configuration
+that varies per request fills the cache. See [performance](/guide/performance#1-reuse-the-session).

--- a/website/reference/constants.md
+++ b/website/reference/constants.md
@@ -1,0 +1,139 @@
+# Constants
+
+All constants live on the global `Cassandra` class.
+
+## Version
+
+```php
+Cassandra::VERSION;              // the extension version, for example '1.4.1'
+Cassandra::CPP_DRIVER_VERSION;   // the linked C/C++ driver version, resolved at runtime
+```
+
+```php
+printf("driver %s on cpp-driver %s\n", Cassandra::VERSION, Cassandra::CPP_DRIVER_VERSION);
+```
+
+## Consistency levels
+
+| Constant | Replicas that must answer |
+| --- | --- |
+| `Cassandra::CONSISTENCY_ANY` | Any node, including a hinted handoff. Writes only |
+| `Cassandra::CONSISTENCY_ONE` | One replica, any datacenter |
+| `Cassandra::CONSISTENCY_TWO` | Two replicas |
+| `Cassandra::CONSISTENCY_THREE` | Three replicas |
+| `Cassandra::CONSISTENCY_QUORUM` | A quorum across all datacenters |
+| `Cassandra::CONSISTENCY_ALL` | Every replica |
+| `Cassandra::CONSISTENCY_LOCAL_ONE` | One replica in the local datacenter |
+| `Cassandra::CONSISTENCY_LOCAL_QUORUM` | A quorum inside the local datacenter |
+| `Cassandra::CONSISTENCY_EACH_QUORUM` | A quorum in every datacenter. Writes only |
+| `Cassandra::CONSISTENCY_SERIAL` | For a lightweight transaction, across datacenters |
+| `Cassandra::CONSISTENCY_LOCAL_SERIAL` | For a lightweight transaction, local datacenter |
+
+The cluster default is `CONSISTENCY_LOCAL_ONE`. Most applications set `CONSISTENCY_LOCAL_QUORUM`.
+
+```php
+$cluster = Cassandra::cluster()
+    ->withDefaultConsistency(Cassandra::CONSISTENCY_LOCAL_QUORUM)
+    ->build();
+
+$rows = $session->execute($statement, [
+    'consistency' => Cassandra::CONSISTENCY_LOCAL_ONE,
+]);
+```
+
+`CONSISTENCY_SERIAL` and `CONSISTENCY_LOCAL_SERIAL` belong in the `serial_consistency` option, not
+in `consistency`. See
+[lightweight transactions](/guide/queries#lightweight-transactions).
+
+## TLS verification flags
+
+| Constant | Meaning |
+| --- | --- |
+| `Cassandra::VERIFY_NONE` | Encrypt only. Do not check the server certificate |
+| `Cassandra::VERIFY_PEER_CERT` | Check the certificate against the trusted certificates |
+| `Cassandra::VERIFY_PEER_IDENTITY` | Also check that the identity matches the peer |
+
+Combine them with the bitwise `or` operator:
+
+```php
+Cassandra::ssl()
+    ->withVerifyFlags(Cassandra::VERIFY_PEER_CERT | Cassandra::VERIFY_PEER_IDENTITY)
+    ->build();
+```
+
+See [TLS and SSL](/guide/tls).
+
+## Batch types
+
+| Constant | Meaning |
+| --- | --- |
+| `Cassandra::BATCH_LOGGED` | Atomic across partitions, at the cost of a batch log write |
+| `Cassandra::BATCH_UNLOGGED` | No batch log |
+| `Cassandra::BATCH_COUNTER` | Required for counter updates |
+
+```php
+new Cassandra\BatchStatement(Cassandra::BATCH_UNLOGGED);
+```
+
+See [batches](/guide/batches).
+
+## Log levels
+
+| Constant | Value in `php.ini` |
+| --- | --- |
+| `Cassandra::LOG_DISABLED` | — |
+| `Cassandra::LOG_CRITICAL` | `CRITICAL` |
+| `Cassandra::LOG_ERROR` | `ERROR` |
+| `Cassandra::LOG_WARN` | `WARN` |
+| `Cassandra::LOG_INFO` | `INFO` |
+| `Cassandra::LOG_DEBUG` | `DEBUG` |
+| `Cassandra::LOG_TRACE` | `TRACE` |
+
+The log level is set in `php.ini`, not in code:
+
+```ini
+cassandra.log_level = ERROR
+```
+
+See [metrics and logging](/guide/observability#logging).
+
+## CQL type names
+
+String constants used by the collection constructors.
+
+| Constant | Value |
+| --- | --- |
+| `Cassandra::TYPE_ASCII` | `ascii` |
+| `Cassandra::TYPE_TEXT` | `text` |
+| `Cassandra::TYPE_VARCHAR` | `varchar` |
+| `Cassandra::TYPE_TINYINT` | `tinyint` |
+| `Cassandra::TYPE_SMALLINT` | `smallint` |
+| `Cassandra::TYPE_INT` | `int` |
+| `Cassandra::TYPE_BIGINT` | `bigint` |
+| `Cassandra::TYPE_VARINT` | `varint` |
+| `Cassandra::TYPE_COUNTER` | `counter` |
+| `Cassandra::TYPE_FLOAT` | `float` |
+| `Cassandra::TYPE_DOUBLE` | `double` |
+| `Cassandra::TYPE_DECIMAL` | `decimal` |
+| `Cassandra::TYPE_BOOLEAN` | `boolean` |
+| `Cassandra::TYPE_BLOB` | `blob` |
+| `Cassandra::TYPE_INET` | `inet` |
+| `Cassandra::TYPE_UUID` | `uuid` |
+| `Cassandra::TYPE_TIMEUUID` | `timeuuid` |
+| `Cassandra::TYPE_TIMESTAMP` | `timestamp` |
+
+```php
+new Cassandra\Collection(Cassandra::TYPE_TEXT);
+new Cassandra\Map(Cassandra::TYPE_UUID, Cassandra::TYPE_INT);
+```
+
+For a composite element type, use the [type factory](/reference/types) instead.
+
+## Static methods
+
+```php
+Cassandra::cluster(): Cassandra\Cluster\Builder;
+Cassandra::ssl(): Cassandra\SSLOptions\Builder;
+```
+
+These are the two entry points to the driver.

--- a/website/reference/exceptions.md
+++ b/website/reference/exceptions.md
@@ -1,0 +1,109 @@
+# Exceptions
+
+Every driver exception implements the `Cassandra\Exception` marker interface and extends a matching
+SPL exception.
+
+```php
+namespace Cassandra;
+
+interface Exception {}
+```
+
+## The tree
+
+```
+Cassandra\Exception  (interface)
+│
+├── Cassandra\Exception\LogicException            extends \LogicException
+├── Cassandra\Exception\DomainException           extends \DomainException
+├── Cassandra\Exception\InvalidArgumentException  extends \InvalidArgumentException
+├── Cassandra\Exception\RangeException            extends \RangeException
+│   └── Cassandra\Exception\DivideByZeroException
+│
+└── Cassandra\Exception\RuntimeException          extends \RuntimeException
+    ├── Cassandra\Exception\TimeoutException
+    ├── Cassandra\Exception\AuthenticationException
+    ├── Cassandra\Exception\ProtocolException
+    │
+    ├── Cassandra\Exception\ExecutionException
+    │   ├── Cassandra\Exception\ReadTimeoutException
+    │   ├── Cassandra\Exception\WriteTimeoutException
+    │   ├── Cassandra\Exception\UnavailableException
+    │   └── Cassandra\Exception\TruncateException
+    │
+    ├── Cassandra\Exception\ValidationException
+    │   ├── Cassandra\Exception\InvalidQueryException
+    │   ├── Cassandra\Exception\InvalidSyntaxException
+    │   ├── Cassandra\Exception\UnauthorizedException
+    │   ├── Cassandra\Exception\UnpreparedException
+    │   └── Cassandra\Exception\ConfigurationException
+    │       └── Cassandra\Exception\AlreadyExistsException
+    │
+    └── Cassandra\Exception\ServerException
+        ├── Cassandra\Exception\IsBootstrappingException
+        └── Cassandra\Exception\OverloadedException
+```
+
+## Reference
+
+| Exception | Thrown when | Retry |
+| --- | --- | --- |
+| `InvalidArgumentException` | A bad argument reaches the driver: an unknown option, a negative page size, an unreadable certificate path, a malformed address | No |
+| `DivideByZeroException` | A numeric value class divides by zero | No |
+| `LogicException` | An operation is not valid for the object state | No |
+| `DomainException` | A value is outside the valid domain | No |
+| `RangeException` | A numeric conversion is out of range | No |
+| `RuntimeException` | A driver error with no more specific class | Depends |
+| `TimeoutException` | The client wait expired. The request may still be running on the server | Maybe |
+| `AuthenticationException` | The credentials were rejected | No |
+| `ProtocolException` | A protocol-level disagreement with the server | No |
+| `ReadTimeoutException` | Not enough replicas answered a read in time | Yes |
+| `WriteTimeoutException` | Not enough replicas acknowledged a write in time. **The write may have applied** | Only if idempotent |
+| `UnavailableException` | Not enough live replicas to meet the consistency level | After a delay |
+| `TruncateException` | A `TRUNCATE` failed | Yes |
+| `InvalidQueryException` | The table or column does not exist, or the query is not valid | No |
+| `InvalidSyntaxException` | The CQL does not parse | No |
+| `UnauthorizedException` | The role lacks permission | No |
+| `UnpreparedException` | The coordinator does not know the prepared statement identifier | The driver handles it |
+| `ConfigurationException` | A schema statement is not valid | No |
+| `AlreadyExistsException` | A `CREATE` for something that exists | No |
+| `IsBootstrappingException` | The node is still joining the cluster | After a delay |
+| `OverloadedException` | The node rejected the request under load | After a delay |
+
+## Codes
+
+Server-side exceptions carry the C driver error code in `getCode()`, and the driver message in
+`getMessage()`.
+
+```php
+catch (Cassandra\Exception $e) {
+    $logger->error('cassandra error', [
+        'class'   => $e::class,
+        'code'    => $e->getCode(),
+        'message' => $e->getMessage(),
+    ]);
+}
+```
+
+## Catching by branch
+
+The three branches under `RuntimeException` group the exceptions by what you should do about them.
+
+```php
+try {
+    $session->execute($statement, $options);
+} catch (Cassandra\Exception\ValidationException $e) {
+    // Your bug. Fix the query or the grant. Do not retry.
+    throw $e;
+} catch (Cassandra\Exception\ExecutionException $e) {
+    // The cluster could not complete it. Retry when the statement is idempotent.
+    $this->scheduleRetry();
+} catch (Cassandra\Exception\ServerException $e) {
+    // A node is not in a state to serve. Back off.
+    $this->backOff();
+} catch (Cassandra\Exception $e) {
+    throw $e;
+}
+```
+
+See [error handling](/guide/error-handling) for the full guidance.

--- a/website/reference/rows-futures.md
+++ b/website/reference/rows-futures.md
@@ -1,0 +1,178 @@
+# Rows and Futures
+
+## `Cassandra\Rows`
+
+One page of a result set.
+
+```php
+final class Rows implements \Iterator, \Countable, \ArrayAccess
+{
+    public function count(): int;
+    public function first(): mixed;
+
+    public function isLastPage(): bool;
+    public function nextPage(int|float|null $timeout = null): Rows|false;
+    public function nextPageAsync(): Future;
+    public function pagingStateToken(): ?string;
+
+    // Iterator
+    public function rewind(): void;
+    public function current(): mixed;
+    public function key(): mixed;
+    public function next(): void;
+    public function valid(): bool;
+
+    // ArrayAccess
+    public function offsetExists(mixed $offset): bool;
+    public function offsetGet(mixed $offset): mixed;
+    public function offsetSet(mixed $offset, mixed $value): void;
+    public function offsetUnset(mixed $offset): void;
+}
+```
+
+| Method | Notes |
+| --- | --- |
+| `count()` | Rows on **this page**, not in the whole result set. Triggers no fetch. |
+| `first()` | The first row of the page, or `null` when the page is empty. |
+| `isLastPage()` | `true` when no further page exists. Check it before `nextPage()`. |
+| `nextPage()` | Fetches and returns a new `Rows`. Blocks. `$timeout` is in seconds. |
+| `nextPageAsync()` | Starts the fetch and returns a future at once. |
+| `pagingStateToken()` | An opaque resume token, or `null` when there is no next page. |
+
+```php
+foreach ($rows as $index => $row) {
+    echo $index, ': ', $row['email'], "\n";
+}
+
+$rows[0];            // the first row, by offset
+count($rows);        // rows on this page
+$rows->first();      // the first row, or null
+```
+
+Each row is an associative array keyed by column name.
+
+::: warning Check isLastPage() before nextPage()
+Calling `nextPage()` past the end does not return a usable result set.
+:::
+
+See [results and paging](/guide/results).
+
+## `Cassandra\Future`
+
+```php
+interface Future
+{
+    public function get(int|float|null $timeout = null): mixed;
+}
+```
+
+`get()` blocks until the result arrives, then returns it. `$timeout` is in seconds. It throws
+whatever the blocking call would have thrown, plus `Cassandra\Exception\TimeoutException` when the
+wait expires. Calling `get()` twice returns the same result.
+
+### Implementations
+
+| Class | `get()` returns | Produced by |
+| --- | --- | --- |
+| `Cassandra\FutureRows` | `Cassandra\Rows` | `Session::executeAsync()` |
+| `Cassandra\FutureSession` | `Cassandra\Session` | `Cluster::connectAsync()` |
+| `Cassandra\FuturePreparedStatement` | `Cassandra\PreparedStatement` | `Session::prepareAsync()` |
+| `Cassandra\FutureClose` | `null` | `Session::closeAsync()` |
+| `Cassandra\FutureValue` | The wrapped value | Internal |
+
+```php
+$future = $session->executeAsync($statement, ['arguments' => [$id]]);
+
+try {
+    $rows = $future->get(2.5);
+} catch (Cassandra\Exception\TimeoutException $e) {
+    // The result did not arrive in time.
+}
+```
+
+### Limits
+
+`get()` blocks the PHP process. The C driver resolves futures on its own IO threads, so many
+requests really do run at once, but:
+
+- There is no callback and no event loop integration in this release.
+- `get()` is the only way to observe completion.
+- Between `executeAsync()` and `get()`, PHP can run other PHP code, not other requests.
+
+See [asynchronous queries](/guide/async).
+
+## `Cassandra\Schema`
+
+```php
+interface Schema
+{
+    public function keyspace(string $name): Keyspace|false;
+    public function keyspaces(): array;
+}
+```
+
+Returned by `Session::schema()`. See [schema metadata](/guide/schema-metadata).
+
+## `Cassandra\Keyspace`
+
+| Method | Returns |
+| --- | --- |
+| `name()` | `string` |
+| `replicationClassName()` | `string` |
+| `replicationOptions()` | `array<string, mixed>` |
+| `hasDurableWrites()` | `bool` |
+| `table(string $name)` | `Table` or `false` |
+| `tables()` | `array<string, Table>` |
+| `userType(string $name)` | `Cassandra\Type\UserType` or `null` |
+| `userTypes()` | `array<string, Cassandra\Type\UserType>` |
+| `materializedView(string $name)` | `MaterializedView` or `false` |
+| `materializedViews()` | `array<string, MaterializedView>` |
+| `function(string $name, mixed ...$types)` | `Cassandra\Function_` or `false` |
+| `functions()` | `array<string, Cassandra\Function_>` |
+| `aggregate(string $name, mixed ...$types)` | `Aggregate` or `false` |
+| `aggregates()` | `array<string, Aggregate>` |
+
+## `Cassandra\Table`
+
+| Method | Returns |
+| --- | --- |
+| `name()` | `string` |
+| `option(string $name)` | `mixed` |
+| `options()` | `array<string, mixed>` |
+| `comment()` | `string` or `false` |
+| `column(string $name)` | `Column` or `false` |
+| `columns()` | `array<string, Column>` |
+| `partitionKey()` | `array<int, Column>` |
+| `clusteringKey()` | `array<int, Column>` |
+| `primaryKey()` | `array<int, Column>` |
+| `clusteringOrder()` | `array<int, string>` |
+| `defaultTTL()` | `int` or `false` |
+| `gcGraceSeconds()` | `int` or `false` |
+| `caching()` | `string` or `false` |
+| `bloomFilterFPChance()` | `float` or `false` |
+| `compactionStrategyClassName()` | `string` or `false` |
+| `compactionStrategyOptions()` | `array` or `false` |
+| `compressionParameters()` | `array` or `false` |
+| `speculativeRetry()` | `string` or `false` |
+| `memtableFlushPeriodMs()` | `int` or `false` |
+| `minIndexInterval()` | `int` or `false` |
+| `maxIndexInterval()` | `int` or `false` |
+| `indexInterval()` | `int` or `false` |
+| `readRepairChance()` | `float` or `false` |
+| `localReadRepairChance()` | `float` or `false` |
+| `populateIOCacheOnFlush()` | `bool` or `false` |
+| `replicateOnWrite()` | `bool` or `false` |
+
+`Cassandra\MaterializedView` extends `Cassandra\Table` and adds `baseTable(): ?Table`.
+
+## `Cassandra\Column`
+
+| Method | Returns |
+| --- | --- |
+| `name()` | `string` |
+| `type()` | `Cassandra\Type` or `null` |
+| `isReversed()` | `bool` |
+| `isStatic()` | `bool` |
+| `isFrozen()` | `bool` |
+| `indexName()` | `string` or `null` |
+| `indexOptions()` | `string` or `null` |

--- a/website/reference/session.md
+++ b/website/reference/session.md
@@ -1,0 +1,175 @@
+# Cluster and Session
+
+## `Cassandra\Cluster`
+
+An interface. `Cassandra\Cluster\Builder::build()` returns the `Cassandra\DefaultCluster`
+implementation. A cluster holds configuration only. It opens no sockets.
+
+```php
+interface Cluster
+{
+    public function connect(?string $keyspace = null, ?int $timeout = null): Session;
+    public function connectAsync(?string $keyspace = null): Future;
+}
+```
+
+### `connect()`
+
+```php
+$session = $cluster->connect();            // no keyspace
+$session = $cluster->connect('shop');      // set the keyspace
+$session = $cluster->connect('shop', 10);  // 10 second timeout
+```
+
+Opens the connection pool and returns a `Cassandra\Session`. Blocks until the pool is ready.
+
+`$timeout` is in **seconds**, as an integer.
+
+Pass `null` rather than an empty string when there is no keyspace. An empty string produces an
+invalid `USE` statement.
+
+Throws:
+
+| Exception | Cause |
+| --- | --- |
+| `Cassandra\Exception\RuntimeException` | No contact point could be reached |
+| `Cassandra\Exception\AuthenticationException` | The credentials were rejected |
+| `Cassandra\Exception\InvalidQueryException` | The keyspace does not exist |
+
+### `connectAsync()`
+
+```php
+$future  = $cluster->connectAsync('shop');
+$session = $future->get(10.0);
+```
+
+Returns a `Cassandra\FutureSession`. See [asynchronous queries](/guide/async).
+
+## `Cassandra\Session`
+
+An interface. `connect()` returns the `Cassandra\DefaultSession` implementation.
+
+```php
+interface Session
+{
+    public function execute(string|Statement $statement, array|ExecutionOptions|null $options = null): Rows;
+    public function executeAsync(string|Statement $statement, array|ExecutionOptions|null $options = null): FutureRows;
+    public function prepare(string $cql, array|ExecutionOptions|null $options = null): PreparedStatement;
+    public function prepareAsync(string $cql, array|ExecutionOptions|null $options = null): FuturePreparedStatement;
+    public function close(int|float|null $timeout = null): void;
+    public function closeAsync(): FutureClose;
+    public function metrics(): array;
+    public function schema(): Schema;
+}
+```
+
+### `execute()`
+
+```php
+$rows = $session->execute($statement, $options);
+```
+
+Runs one statement and returns one page of results. `$statement` is a CQL string, a
+`Cassandra\SimpleStatement`, a `Cassandra\PreparedStatement`, or a `Cassandra\BatchStatement`.
+
+`$options` is an array. Every key is optional:
+
+| Key | Type | Default |
+| --- | --- | --- |
+| `arguments` | `array` | none |
+| `consistency` | `int` | The cluster default |
+| `serial_consistency` | `int` | none |
+| `page_size` | `int` | The cluster default, 5000 |
+| `paging_state_token` | `string` | none |
+| `timeout` | `int` or `float` | The cluster default |
+| `retry_policy` | `Cassandra\RetryPolicy` | The cluster policy |
+| `timestamp` | `int` or numeric string | Server side |
+
+See [queries and statements](/guide/queries).
+
+### `executeAsync()`
+
+```php
+$future = $session->executeAsync($statement, $options);
+$rows   = $future->get();
+```
+
+Returns a `Cassandra\FutureRows` at once. Same options as `execute()`.
+
+### `prepare()`
+
+```php
+$statement = $session->prepare('SELECT * FROM users WHERE id = ?');
+```
+
+Sends the CQL to the cluster and returns a `Cassandra\PreparedStatement`. One network round trip.
+Prepare once, keep the object.
+
+### `prepareAsync()`
+
+```php
+$future    = $session->prepareAsync('SELECT * FROM users WHERE id = ?');
+$statement = $future->get();
+```
+
+Returns a `Cassandra\FuturePreparedStatement`.
+
+### `close()`
+
+```php
+$session->close();
+$session->close(5.0);   // wait at most 5 seconds
+```
+
+Closes the connection pool. `$timeout` is in seconds.
+
+The session closes at script shutdown as well. Call `close()` when you want the sockets released at
+a known point.
+
+With [persistent sessions](/guide/connecting#persistent-sessions) on, the underlying cluster stays
+cached in the worker process, so a later `connect()` with the same configuration is cheap.
+
+### `closeAsync()`
+
+```php
+$future = $session->closeAsync();
+$future->get();
+```
+
+Returns a `Cassandra\FutureClose`.
+
+### `metrics()`
+
+```php
+$m = $session->metrics();
+
+$m['requests']['median'];              // microseconds
+$m['requests']['p99'];
+$m['requests']['m1_rate'];             // requests per second
+$m['stats']['total_connections'];
+$m['stats']['available_connections'];
+$m['errors']['request_timeouts'];
+```
+
+Reads process memory. No network call. The full key list is in
+[metrics and logging](/guide/observability#metrics).
+
+### `schema()`
+
+```php
+$keyspace = $session->schema()->keyspace('shop');
+$table    = $keyspace->table('users');
+```
+
+Returns the live schema metadata. See [schema metadata](/guide/schema-metadata).
+
+## Lifetime
+
+| Object | Cost to create | Lifetime |
+| --- | --- | --- |
+| `Cluster\Builder` | Free | Local to the configuration function |
+| `Cluster` | Free | Free to keep, holds no sockets |
+| `Session` | Expensive: handshake, auth, schema fetch | One per process, or per worker |
+| `PreparedStatement` | One round trip | For as long as the session lives |
+
+See [performance](/guide/performance#1-reuse-the-session).

--- a/website/reference/statements.md
+++ b/website/reference/statements.md
@@ -1,0 +1,162 @@
+# Statements
+
+`Cassandra\Statement` is a marker interface. Three classes implement it.
+
+| Class | Constructor | Use |
+| --- | --- | --- |
+| `Cassandra\SimpleStatement` | public | One-off CQL, schema changes |
+| `Cassandra\PreparedStatement` | private, from `Session::prepare()` | Everything on the request path |
+| `Cassandra\BatchStatement` | public | Atomicity across statements |
+
+## `Cassandra\SimpleStatement`
+
+```php
+final class SimpleStatement implements Statement
+{
+    public function __construct(string $cql) {}
+}
+```
+
+```php
+$statement = new Cassandra\SimpleStatement('SELECT * FROM users LIMIT 10');
+$rows = $session->execute($statement);
+```
+
+A plain string passed to `execute()` is wrapped in a `SimpleStatement` automatically, so these two
+lines are the same:
+
+```php
+$session->execute('SELECT * FROM users LIMIT 10');
+$session->execute(new Cassandra\SimpleStatement('SELECT * FROM users LIMIT 10'));
+```
+
+A simple statement carries no partition key metadata, so
+[token-aware routing](/guide/load-balancing#token-aware-routing) cannot work. Every request goes
+through a coordinator that then forwards it.
+
+## `Cassandra\PreparedStatement`
+
+```php
+final class PreparedStatement implements Statement
+{
+    private function __construct() {}
+}
+```
+
+`Session::prepare()` is the only way to obtain one.
+
+```php
+$statement = $session->prepare('INSERT INTO users (id, email) VALUES (?, ?)');
+
+$session->execute($statement, ['arguments' => [$id, $email]]);
+```
+
+The object holds no state beyond the server identifier and the marker types, so one instance is
+reusable across any number of executions and any number of value sets.
+
+Prepared statements are tied to the session that prepared them.
+
+## `Cassandra\BatchStatement`
+
+```php
+final class BatchStatement implements Statement
+{
+    public function __construct(int $type = Cassandra::BATCH_LOGGED) {}
+
+    public function add(string|Statement $statement, ?array $arguments = null): static {}
+}
+```
+
+```php
+$batch = new Cassandra\BatchStatement(Cassandra::BATCH_UNLOGGED);
+
+$batch->add($insertUser, [$id, $email])
+      ->add($insertIndex, [$email, $id]);
+
+$session->execute($batch);
+```
+
+### `add()`
+
+`$statement` is a CQL string, a `SimpleStatement`, or a `PreparedStatement`. Another
+`BatchStatement` is not allowed.
+
+`$arguments` is an array of bound values. Integer keys bind by position, string keys bind by name.
+
+Returns the batch, so calls chain.
+
+### Batch types
+
+| Constant | Meaning |
+| --- | --- |
+| `Cassandra::BATCH_LOGGED` | Atomic across partitions, at the cost of a batch log write |
+| `Cassandra::BATCH_UNLOGGED` | No batch log. Correct when every statement hits one partition |
+| `Cassandra::BATCH_COUNTER` | Required for counter updates. Cannot mix with normal writes |
+
+See [batches](/guide/batches).
+
+## `Cassandra\ExecutionOptions`
+
+```php
+final class ExecutionOptions
+{
+    /** @deprecated */
+    public function __construct(array $options) {}
+
+    public function __get(string $name): mixed {}
+}
+```
+
+::: warning Deprecated
+Pass a plain array to `execute()` instead. The class remains for compatibility with the old DataStax
+driver.
+:::
+
+The constructor takes the same snake_case keys that `execute()` takes. The magic getter reads them
+back in camel case:
+
+| Constructor key | Property |
+| --- | --- |
+| `consistency` | `$options->consistency` |
+| `serial_consistency` | `$options->serialConsistency` |
+| `page_size` | `$options->pageSize` |
+| `paging_state_token` | `$options->pagingStateToken` |
+| `timeout` | `$options->timeout` |
+| `arguments` | `$options->arguments` |
+| `retry_policy` | `$options->retryPolicy` |
+| `timestamp` | `$options->timestamp` |
+
+## `Cassandra\RetryPolicy`
+
+A marker interface with four implementations.
+
+| Class | Behavior |
+| --- | --- |
+| `Cassandra\RetryPolicy\DefaultPolicy` | Retry once on a read timeout, a batch log write timeout, or an unavailable error |
+| `Cassandra\RetryPolicy\Fallthrough` | Never retry |
+| `Cassandra\RetryPolicy\Logging` | Wrap another policy and log every decision |
+| `Cassandra\RetryPolicy\DowngradingConsistency` | Deprecated. Retry at a lower consistency |
+
+```php
+new Cassandra\RetryPolicy\Logging(new Cassandra\RetryPolicy\DefaultPolicy());
+```
+
+See [retry policies](/guide/retry-policies).
+
+## `Cassandra\TimestampGenerator`
+
+A marker interface with two implementations.
+
+| Class | Behavior |
+| --- | --- |
+| `Cassandra\TimestampGenerator\Monotonic` | Client-side, strictly increasing within one process |
+| `Cassandra\TimestampGenerator\ServerSide` | The coordinator assigns the timestamp. The default |
+
+```php
+$cluster = Cassandra::cluster()
+    ->withTimestampGenerator(new Cassandra\TimestampGenerator\Monotonic())
+    ->build();
+```
+
+Set a timestamp for one statement with the `timestamp` execution option, in microseconds. See
+[explicit write timestamps](/guide/queries#explicit-write-timestamps).

--- a/website/reference/types.md
+++ b/website/reference/types.md
@@ -1,0 +1,151 @@
+# Type factory
+
+`Cassandra\Type` is an abstract class with static factory methods. It builds the type objects that
+collection constructors need, and it is what `Value::type()` returns.
+
+```php
+abstract class Type
+{
+    abstract public function name(): string|null;
+    abstract public function __toString(): string;
+}
+```
+
+## Scalar types
+
+Each returns a `Cassandra\Type\Scalar`.
+
+```php
+Cassandra\Type::ascii();
+Cassandra\Type::text();
+Cassandra\Type::varchar();
+
+Cassandra\Type::tinyint();
+Cassandra\Type::smallint();
+Cassandra\Type::int();
+Cassandra\Type::bigint();
+Cassandra\Type::varint();
+Cassandra\Type::counter();
+
+Cassandra\Type::float();
+Cassandra\Type::double();
+Cassandra\Type::decimal();
+
+Cassandra\Type::boolean();
+Cassandra\Type::blob();
+Cassandra\Type::inet();
+
+Cassandra\Type::uuid();
+Cassandra\Type::timeuuid();
+
+Cassandra\Type::timestamp();
+Cassandra\Type::date();
+Cassandra\Type::time();
+Cassandra\Type::duration();
+```
+
+## Composite types
+
+```php
+Cassandra\Type::collection(Type $type): Cassandra\Type\Collection;   // list<T>
+Cassandra\Type::set(Type $type): Cassandra\Type\Set;
+Cassandra\Type::map(Type $keyType, Type $valueType): Cassandra\Type\Map;
+Cassandra\Type::tuple(Type ...$types): Cassandra\Type\Tuple;
+Cassandra\Type::userType(mixed ...$types): Cassandra\Type\UserType;
+```
+
+```php
+$listOfText  = Cassandra\Type::collection(Cassandra\Type::text());
+$setOfUuid   = Cassandra\Type::set(Cassandra\Type::uuid());
+$mapTextInt  = Cassandra\Type::map(Cassandra\Type::text(), Cassandra\Type::int());
+$coordinates = Cassandra\Type::tuple(
+    Cassandra\Type::double(),
+    Cassandra\Type::double(),
+);
+```
+
+`userType()` takes alternating field names and types:
+
+```php
+$address = Cassandra\Type::userType(
+    'street',  Cassandra\Type::text(),
+    'city',    Cassandra\Type::text(),
+    'country', Cassandra\Type::text(),
+)
+    ->withName('address')
+    ->withKeyspace('shop');
+```
+
+Reading the type from the schema is better, because it stays in step with the cluster:
+
+```php
+$address = $session->schema()->keyspace('shop')->userType('address');
+```
+
+## Creating values from a type
+
+Every type object has a `create()` method, which is often shorter than the value constructor.
+
+```php
+Cassandra\Type\Scalar::create(mixed $value = null): mixed;
+Cassandra\Type\Collection::create(mixed ...$value): Cassandra\Collection;
+Cassandra\Type\Set::create(mixed ...$value): Cassandra\Set;
+Cassandra\Type\Map::create(mixed ...$value): Cassandra\Map;        // key, value, key, value
+Cassandra\Type\Tuple::create(mixed ...$values): Cassandra\Tuple;
+Cassandra\Type\UserType::create(mixed ...$value): Cassandra\UserTypeValue;  // name, value, name, value
+```
+
+```php
+$tags   = Cassandra\Type::collection(Cassandra\Type::text())->create('php', 'cql');
+$roles  = Cassandra\Type::set(Cassandra\Type::text())->create('admin', 'editor');
+$attrs  = Cassandra\Type::map(Cassandra\Type::text(), Cassandra\Type::int())
+    ->create('logins', 12, 'visits', 340);
+$coords = Cassandra\Type::tuple(Cassandra\Type::double(), Cassandra\Type::double())
+    ->create(48.8584, 2.2945);
+```
+
+`Map::create()` and `UserType::create()` take pairs. An odd number of arguments raises
+`Cassandra\Exception\InvalidArgumentException`.
+
+`Cassandra\Type\Custom::create()` always throws. A custom type cannot be built on the client.
+
+## Type name strings
+
+Collection constructors also accept the type name as a string, which is shorter for a scalar
+element type.
+
+```php
+new Cassandra\Collection(Cassandra::TYPE_TEXT);
+new Cassandra\Map(Cassandra::TYPE_TEXT, Cassandra::TYPE_INT);
+```
+
+The constants are listed in the [constants reference](/reference/constants#cql-type-names). A
+composite element type needs a real type object, not a string.
+
+## Inspecting a type
+
+```php
+$type = $row['tags']->type();
+
+$type->name();       // 'set'
+(string) $type;      // 'set<text>'
+```
+
+| Class | Extra methods |
+| --- | --- |
+| `Cassandra\Type\Scalar` | — |
+| `Cassandra\Type\Collection` | `valueType()` |
+| `Cassandra\Type\Set` | `valueType()` |
+| `Cassandra\Type\Map` | `keyType()`, `valueType()` |
+| `Cassandra\Type\Tuple` | `types()` |
+| `Cassandra\Type\UserType` | `types()`, `name()`, `keyspace()`, `withName()`, `withKeyspace()` |
+| `Cassandra\Type\Custom` | `name()` |
+
+```php
+$mapType = $row['attributes']->type();
+
+$mapType->keyType();     // Cassandra\Type\Scalar, 'text'
+$mapType->valueType();   // Cassandra\Type\Scalar, 'int'
+```
+
+All type classes except `Cassandra\Type` itself have a private constructor. Use the factory methods.

--- a/website/reference/values.md
+++ b/website/reference/values.md
@@ -1,0 +1,271 @@
+# Value classes
+
+Every value class implements `Cassandra\Value`:
+
+```php
+interface Value
+{
+    public function type(): Type;
+}
+```
+
+All of them live directly under `Cassandra\`. See [data types](/guide/data-types) for the CQL
+mapping.
+
+## Numbers
+
+`Cassandra\Bigint`, `Cassandra\Smallint`, `Cassandra\Tinyint`, `Cassandra\Varint`,
+`Cassandra\Decimal`, and `Cassandra\Float` implement `Cassandra\Numeric`:
+
+```php
+interface Numeric
+{
+    public function add(Numeric $num): Numeric;
+    public function sub(Numeric $num): Numeric;
+    public function mul(Numeric $num): Numeric;
+    public function div(Numeric $num): Numeric;
+    public function mod(Numeric $num): Numeric;
+    public function abs(): Numeric;
+    public function neg(): Numeric;
+    public function sqrt(): Numeric;
+    public function toInt(): int;
+    public function toDouble(): float;
+}
+```
+
+Each constructor accepts `int|float|string|<same class>`.
+
+| Class | CQL | `value()` returns | `min()` / `max()` |
+| --- | --- | --- | --- |
+| `Cassandra\Bigint` | `bigint`, `counter` | `string` | yes |
+| `Cassandra\Smallint` | `smallint` | `int` | yes |
+| `Cassandra\Tinyint` | `tinyint` | `int` | yes |
+| `Cassandra\Varint` | `varint` | `string` | no |
+| `Cassandra\Decimal` | `decimal` | `string`, unscaled | no |
+| `Cassandra\Float` | `float` | `float` | yes |
+
+Extra methods:
+
+```php
+$decimal->scale();       // int
+
+$float->isInfinite();    // bool
+$float->isFinite();      // bool
+$float->isNaN();         // bool
+```
+
+Division by zero raises `Cassandra\Exception\DivideByZeroException`.
+
+## `Cassandra\Uuid` and `Cassandra\Timeuuid`
+
+Both implement `Cassandra\UuidInterface`, which extends `Cassandra\Value`:
+
+```php
+interface UuidInterface extends Value
+{
+    public function uuid(): string;
+    public function version(): int;
+}
+```
+
+```php
+final class Uuid implements Value, UuidInterface
+{
+    public function __construct(string $uuid = <random v4>) {}
+
+    public function uuid(): string;
+    public function version(): int;
+    public function type(): Type;
+    public function __toString(): string;
+}
+```
+
+```php
+final class Timeuuid implements Value, UuidInterface
+{
+    public function __construct(string|int $uuid = <now>) {}
+
+    public function time(): int;     // Unix seconds
+    public function uuid(): string;
+    public function version(): int;
+    public function type(): Type;
+    public function __toString(): string;
+}
+```
+
+## Date and time
+
+```php
+final class Timestamp implements Value
+{
+    // Omit both arguments to get the current time.
+    public function __construct(int $seconds = <now>, int $microseconds = <now>) {}
+
+    public static function fromDateTime(\DateTimeInterface $datetime): static;
+    public function toDateTime(): \DateTime;
+    public function time(): int;                                  // seconds
+    public function microtime(bool $get_as_float = false): float|string;
+    public function type(): Type;
+    public function __toString(): string;
+}
+```
+
+```php
+final class Date implements Value
+{
+    public function __construct(int|string $value = <today>) {}
+
+    public static function fromDateTime(\DateTimeInterface $datetime): static;
+    public function toDateTime(?Time $time = null): \DateTime;
+    public function seconds(): int;
+    public function type(): Type;
+    public function __toString(): string;
+}
+```
+
+```php
+final class Time implements Value
+{
+    public function __construct(int|string $nanoseconds = <now>) {}
+
+    public static function fromDateTime(\DateTimeInterface $datetime): static;
+    public function seconds(): int;
+    public function type(): Type;
+    public function __toString(): string;
+}
+```
+
+```php
+final class Duration implements Value
+{
+    public function __construct(
+        int|float|string|Bigint $months,
+        int|float|string|Bigint $days,
+        int|float|string|Bigint $nanos,
+    ) {}
+
+    public function months(): string;
+    public function days(): string;
+    public function nanos(): string;
+    public function type(): Type;
+    public function __toString(): string;   // '1mo15d0ns'
+}
+```
+
+## `Cassandra\Blob`
+
+```php
+final class Blob implements Value
+{
+    public function __construct(string $bytes) {}
+
+    public function bytes(): string;            // raw bytes
+    public function toBinaryString(): string;   // raw bytes
+    public function type(): Type;
+    public function __toString(): string;       // hexadecimal, for display
+}
+```
+
+## `Cassandra\Inet`
+
+```php
+final class Inet implements Value
+{
+    public function __construct(string $address) {}   // IPv4 or IPv6
+
+    public function address(): string;
+    public function type(): Type;
+    public function __toString(): string;
+}
+```
+
+## `Cassandra\Collection`
+
+CQL `list<T>`. Implements `Value`, `Countable`, and `Iterator`.
+
+```php
+public function __construct(Cassandra\Type|string $type) {}
+
+public function add(mixed ...$value): int;      // the new count
+public function get(int $index): mixed;
+public function find(mixed $value): int|null;
+public function remove(int $index): bool;
+public function values(): array;
+public function type(): Type;
+```
+
+## `Cassandra\Set`
+
+CQL `set<T>`. Implements `Value`, `Countable`, and `Iterator`.
+
+```php
+public function __construct(Cassandra\Type|string $type) {}
+
+public function add(mixed $value): bool;        // false when already present
+public function has(mixed $value): bool;
+public function remove(mixed $value): bool;
+public function values(): array;
+public function type(): Type;
+```
+
+## `Cassandra\Map`
+
+CQL `map<K,V>`. Implements `Value`, `Countable`, `Iterator`, and `ArrayAccess`.
+
+```php
+public function __construct(Cassandra\Type|string $keyType, Cassandra\Type|string $valueType) {}
+
+public function set(mixed $key, mixed $value): bool;
+public function get(mixed $key): mixed;
+public function has(mixed $key): bool;
+public function remove(mixed $key): bool;
+public function keys(): array;
+public function values(): array;
+public function type(): Type;
+```
+
+`ArrayAccess` works too: `$map['k'] = $v`, `$map['k']`, `isset($map['k'])`, `unset($map['k'])`.
+
+## `Cassandra\Tuple`
+
+CQL `tuple<...>`. Implements `Value`, `Countable`, and `Iterator`.
+
+```php
+public function __construct(array $types) {}
+
+public function set(int $index, mixed $value): void;
+public function get(int $index): mixed;
+public function values(): array;
+public function type(): Type;
+```
+
+## `Cassandra\UserTypeValue`
+
+A user defined type value. Implements `Value`, `Countable`, and `Iterator`.
+
+```php
+public function __construct(array $types) {}   // ['field' => type, ...]
+
+public function set(string $name, mixed $value): void;
+public function get(string $name): mixed;
+public function values(): array;
+public function type(): Type;
+```
+
+Building it from the schema keeps the field types in step with the cluster:
+
+```php
+$type  = $session->schema()->keyspace('shop')->userType('address');
+$value = $type->create('city', 'Paris', 'country', 'FR');
+```
+
+See [collections and user defined types](/guide/collections).
+
+## Comparison
+
+Value objects define their own comparison, so `==` compares by value:
+
+```php
+new Cassandra\Bigint(42) == new Cassandra\Bigint(42);    // true
+new Cassandra\Bigint(42) === new Cassandra\Bigint(42);   // false
+```


### PR DESCRIPTION
## What

Adds `website/`, a [VitePress](https://vitepress.dev) documentation site (24 pages), plus a workflow that publishes it to GitHub Pages at <https://he4rt.github.io/scylladb-php-driver/>.

The project had no user documentation. `docs/` holds generated PHP class stubs and internal audit notes, so it stays untouched.

## Contents

| Section | Pages |
| --- | --- |
| Getting started | Introduction, installation, quick start |
| Connecting | Clusters and sessions, authentication, TLS and SSL, load balancing and routing, connection pool and timeouts, retry policies |
| Working with data | Queries and statements, results and paging, data types, collections and UDTs, batches, asynchronous queries, schema metadata |
| Operating | Error handling, performance, metrics and logging, troubleshooting |
| Reference | `Cluster\Builder`, cluster and session, statements, rows and futures, value classes, type factory, constants, exceptions |

## How it was written

Content comes from the `*.stub.php` files and the C sources, not from the upstream DataStax documentation. Specifically:

- Every default in the `Cluster\Builder` reference table comes from `php_scylladb_cluster_builder_new` (`src/Cluster/BuilderHandlers.c`).
- The CQL to PHP type table comes from the decode switch in `src/Database/ResultDecoder.c` and the bind switch in `src/DefaultSession.c`.
- The execution option keys come from `src/ExecutionOptions.c`.
- The metrics keys come from `Cassandra_DefaultSession::metrics`.
- The exception tree comes from `src/Exception/exceptions.stub.php`.

## CI

`.github/workflows/docs.yml` builds on every pull request that touches `website/`, and deploys `trunk` to Pages. `ignoreDeadLinks` is `false`, so a broken internal link fails the build.

## Reviewer notes

**Action required before the deploy step works:** set **Settings → Pages → Build and deployment → Source** to **GitHub Actions**.

**The repository root `.gitignore` has `config.*`** for the autotools build, which also matched `website/.vitepress/config.mts`. `website/.gitignore` negates it. Worth a look, since it silently drops any `config.*` file added anywhere in the tree.

**Two source issues found while reading the code for this.** Both are documented as the intended behavior, and separate fixes are in progress:

1. `withConnectionHeartbeatInterval()` and `withTCPKeepalive()` convert seconds to milliseconds through `php_scylladb_set_timeout()`, but `cass_cluster_set_connection_heartbeat_interval` and `cass_cluster_set_tcp_keepalive` take seconds. `withConnectionHeartbeatInterval(30.0)` currently yields 30000 seconds. The constructor defaults are raw seconds, which confirms seconds is the intent. **The docs describe these as seconds, so they are correct only once the fix lands.**
2. `php_scylladb_cluster_builder_properties` exposes `password` in clear text, so `var_dump($builder)` prints it. The docs carry a warning about this, which can be removed once it is redacted.

**One broken script, left out of the docs:** `scripts/run-scylladb-ssl.sh` runs `docker compose -f ./docker/docker-compose.ssl.yml`, and that file does not exist.

## Local development

```bash
cd website
npm ci
npm run dev      # http://localhost:5173/scylladb-php-driver/
npm run build    # fails on a dead internal link
```