### PR TITLE
fix(cluster): redact the Builder password behind cassandra.expose_credentials

### DIFF
--- a/cassandra.ini
+++ b/cassandra.ini
@@ -11,3 +11,8 @@ extension = cassandra
 ;         TRACE
 cassandra.log_level = ERROR
 cassandra.log = /var/log/php-cassandra.log
+
+; Show the real password in the properties of Cassandra\Cluster\Builder, which
+; var_dump(), print_r() and framework debug renderers read. Off by default:
+; the value is shown as "***". Use it only in a development environment.
+cassandra.expose_credentials = Off

--- a/include/php_scylladb_globals.h
+++ b/include/php_scylladb_globals.h
@@ -8,6 +8,7 @@ ZEND_BEGIN_MODULE_GLOBALS(php_scylladb)
   unsigned int  persistent_clusters;
   unsigned int  persistent_sessions;
   unsigned int  persistent_prepared_statements;
+  bool          expose_credentials;
   zval  type_varchar;
   zval  type_text;
   zval  type_blob;

--- a/src/Cluster/BuilderHandlers.c
+++ b/src/Cluster/BuilderHandlers.c
@@ -1,6 +1,7 @@
 #include <php.h>
 
 #include <php_scylladb.h>
+#include <php_scylladb_globals.h>
 #include <php_scylladb_types.h>
 
 #include "BuilderHandlers.h"
@@ -84,10 +85,18 @@ HashTable *php_scylladb_cluster_builder_properties(zend_object *object)
     if (self->username)
     {
         ZVAL_STR_COPY(&username, self->username);
-        /* Never put the credential itself in the properties table: it would be
-         * printed by var_dump/print_r/(array) and by every framework debug
-         * renderer, defeating the #[\SensitiveParameter] on withCredentials(). */
-        ZVAL_STRINGL(&password, "***", 3);
+        /* The credential reaches var_dump/print_r/(array) and every framework
+         * debug renderer from here, which would defeat the
+         * #[\SensitiveParameter] on withCredentials(). Redact unless the
+         * operator asked for the real value with cassandra.expose_credentials. */
+        if (PHP_SCYLLADB_G(expose_credentials))
+        {
+            ZVAL_STR_COPY(&password, self->password);
+        }
+        else
+        {
+            ZVAL_STRINGL(&password, "***", 3);
+        }
     }
     else
     {

--- a/src/Cluster/BuilderHandlers.c
+++ b/src/Cluster/BuilderHandlers.c
@@ -84,7 +84,10 @@ HashTable *php_scylladb_cluster_builder_properties(zend_object *object)
     if (self->username)
     {
         ZVAL_STR_COPY(&username, self->username);
-        ZVAL_STR_COPY(&password, self->password);
+        /* Never put the credential itself in the properties table: it would be
+         * printed by var_dump/print_r/(array) and by every framework debug
+         * renderer, defeating the #[\SensitiveParameter] on withCredentials(). */
+        ZVAL_STRINGL(&password, "***", 3);
     }
     else
     {

--- a/src/php_scylladb.c
+++ b/src/php_scylladb.c
@@ -120,6 +120,10 @@ ZEND_DLEXPORT zend_module_entry *get_module(void) { return &php_scylladb_module_
 PHP_INI_BEGIN()
   PHP_INI_ENTRY(PHP_SCYLLADB_NAME ".log", PHP_SCYLLADB_DEFAULT_LOG, PHP_INI_SYSTEM, OnUpdateLog)
   PHP_INI_ENTRY(PHP_SCYLLADB_NAME ".log_level", PHP_SCYLLADB_DEFAULT_LOG_LEVEL, PHP_INI_SYSTEM, OnUpdateLogLevel)
+  /* PHP_INI_SYSTEM, so no ini_set() in a request can flip it: turning it on is
+   * an operator decision, not something a library or a debug handler can do. */
+  STD_PHP_INI_BOOLEAN(PHP_SCYLLADB_NAME ".expose_credentials", "0", PHP_INI_SYSTEM, OnUpdateBool,
+                      expose_credentials, zend_php_scylladb_globals, php_scylladb_globals)
 PHP_INI_END()
 // clang-format on
 
@@ -425,6 +429,7 @@ static PHP_GINIT_FUNCTION(php_scylladb) {
   php_scylladb_globals->persistent_clusters = 0;
   php_scylladb_globals->persistent_sessions = 0;
   php_scylladb_globals->persistent_prepared_statements = 0;
+  php_scylladb_globals->expose_credentials = false;
   ZVAL_UNDEF(&php_scylladb_globals->type_varchar);
   ZVAL_UNDEF(&php_scylladb_globals->type_text);
   ZVAL_UNDEF(&php_scylladb_globals->type_blob);

--- a/tests/Unit/ClusterBuilderCredentialsTest.php
+++ b/tests/Unit/ClusterBuilderCredentialsTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cassandra\Tests\Unit;
+
+use Cassandra;
+
+describe('Cassandra\Cluster\Builder credentials', function () {
+
+    it('does not expose the password through object properties', function () {
+        $builder = Cassandra::cluster()->withCredentials('bob', 'hunter2');
+
+        $props = (array) $builder;
+
+        expect($props)->toHaveKey('password');
+        expect($props['password'])->toBe('***');
+        expect($props['username'])->toBe('bob');
+    });
+
+    it('does not expose the password through print_r or var_export', function () {
+        $builder = Cassandra::cluster()->withCredentials('bob', 'hunter2');
+
+        expect(print_r($builder, true))->not->toContain('hunter2');
+        expect(var_export($builder, true))->not->toContain('hunter2');
+    });
+
+    it('keeps password null when no credentials are set', function () {
+        $props = (array) Cassandra::cluster();
+
+        expect($props['username'])->toBeNull();
+        expect($props['password'])->toBeNull();
+    });
+});

--- a/tests/Unit/ClusterBuilderCredentialsTest.php
+++ b/tests/Unit/ClusterBuilderCredentialsTest.php
@@ -6,6 +6,37 @@ namespace Cassandra\Tests\Unit;
 
 use Cassandra;
 
+/**
+ * cassandra.expose_credentials is PHP_INI_SYSTEM, so the "on" state can only be
+ * observed in a fresh process. Returns null when the child cannot load the same
+ * extension binary as the parent — set SCYLLADB_EXTENSION_PATH to the built
+ * module when it is not in extension_dir.
+ */
+function childPhpWithIni(string $snippet, array $ini): ?string
+{
+    $args = ['-n', '-d', 'extension=' . (getenv('SCYLLADB_EXTENSION_PATH') ?: 'cassandra')];
+    foreach ($ini as $key => $value) {
+        $args[] = '-d';
+        $args[] = "$key=$value";
+    }
+    $args[] = '-r';
+    $args[] = $snippet;
+
+    $cmd = implode(' ', array_map('escapeshellarg', [PHP_BINARY, ...$args]));
+
+    $pipes = [];
+    $proc  = proc_open($cmd, [1 => ['pipe', 'w'], 2 => ['pipe', 'w']], $pipes);
+    if (!is_resource($proc)) {
+        return null;
+    }
+
+    $stdout = stream_get_contents($pipes[1]);
+    fclose($pipes[1]);
+    fclose($pipes[2]);
+
+    return proc_close($proc) === 0 ? $stdout : null;
+}
+
 describe('Cassandra\Cluster\Builder credentials', function () {
 
     it('does not expose the password through object properties', function () {
@@ -30,5 +61,28 @@ describe('Cassandra\Cluster\Builder credentials', function () {
 
         expect($props['username'])->toBeNull();
         expect($props['password'])->toBeNull();
+    });
+
+    it('defaults cassandra.expose_credentials to off', function () {
+        expect(ini_get('cassandra.expose_credentials'))->toBe('0');
+    });
+
+    it('refuses to let ini_set turn the redaction off at runtime', function () {
+        expect(@ini_set('cassandra.expose_credentials', '1'))->toBeFalse();
+
+        $props = (array) Cassandra::cluster()->withCredentials('bob', 'hunter2');
+        expect($props['password'])->toBe('***');
+    });
+
+    it('shows the real password when cassandra.expose_credentials is on', function () {
+        $snippet = '$p = (array) Cassandra::cluster()->withCredentials("bob", "hunter2"); echo $p["password"];';
+
+        $redacted = childPhpWithIni($snippet, []);
+        if ($redacted === null) {
+            $this->markTestSkipped('child PHP cannot load the extension under test');
+        }
+
+        expect($redacted)->toBe('***');
+        expect(childPhpWithIni($snippet, ['cassandra.expose_credentials' => '1']))->toBe('hunter2');
     });
 });


### PR DESCRIPTION
## Problem

`php_scylladb_cluster_builder_properties` copied the stored password into the object properties table in clear text (`src/Cluster/BuilderHandlers.c`). Every operation that reads object properties printed it:

- `var_dump($builder)`
- `print_r($builder)`
- `get_object_vars($builder)`
- `(array) $builder`
- the debug panel or exception renderer of any framework that dumps objects

This defeated the `#[\SensitiveParameter]` attribute on `Cassandra\Cluster\Builder::withCredentials()`. That attribute only redacts the value in stack traces.

## Fix

The properties table now holds `"***"` instead of the credential. The `password` key stays present and the `null`-when-unset branch does not change, so the shape of a dump is the same as before.

The real value is still reachable for debugging, behind a new INI setting:

```ini
cassandra.expose_credentials = On
```

Off by default, so redaction is the safe default. Turn it on to put the real password back in the properties table.

The setting is `PHP_INI_SYSTEM`. A request cannot call `ini_set()` to turn the redaction off, so a library, a template, or a debug handler cannot unredact the value. Only the operator can, through `php.ini` or `php -d cassandra.expose_credentials=1`.

## Scope

- `src/SSLOptions/` registers no `get_properties` handler at all, so the private key passphrase never reached a properties table. No change was needed there.
- No test asserted on the `password` property. `tests/Support/helpers.php` only calls `withCredentials()`, it never reads the value back.
- The Cluster builder was the only `get_properties` in the tree that touched a secret.

## Tests

New file `tests/Unit/ClusterBuilderCredentialsTest.php` with 6 cases:

1. `(array) $builder` keeps the `password` key and returns `"***"`.
2. `print_r()` and `var_export()` do not contain the credential.
3. `username` and `password` are both `null` when no credentials are set.
4. `cassandra.expose_credentials` defaults to off.
5. `ini_set()` on the setting returns `false` and the value stays redacted.
6. A child process started with `-d cassandra.expose_credentials=1` prints the real password, and the same child without the flag prints `***`.

Case 6 needs a fresh process, because a `PHP_INI_SYSTEM` setting cannot change inside a request. The helper reads `SCYLLADB_EXTENSION_PATH` to find the module to load, and marks the test skipped if the child cannot load it. Both paths were checked:

```bash
SCYLLADB_EXTENSION_PATH=$PWD/out/DebugPHP8.5NTS/cassandra.dylib \
  php -n -d extension=$PWD/out/DebugPHP8.5NTS/cassandra.dylib ./vendor/bin/pest --testsuite=Unit
```

With the variable set: 6 passed. Without it: 5 passed, 1 skipped.

Full Unit suite: 809 passed, 1 failed. The failure is the pre-existing `UuidTest` case at `tests/Unit/Uuid/UuidTest.php:112`. It spawns a child with `-d extension=cassandra`, which resolves through `extension_dir` and therefore loads an installed build instead of the build under test. It is unrelated to this change.

## Also changed

`cassandra.ini` documents the new setting.