### PR TITLE
fix(memory): release the decimal scratch buffer and the Map keyType reference

### DIFF
--- a/src/Map.c
+++ b/src/Map.c
@@ -204,15 +204,22 @@ PHP_METHOD(Cassandra_Map, __construct)
     return;
   }
 
+  /* From here on we own a reference to key_type — either the one
+   * php_scylladb_type_scalar() handed back or the one we added above. It is
+   * only consumed by php_scylladb_type_map() at the very end, so every early
+   * exit must release it. */
   if (Z_TYPE_P(value_type) == IS_STRING) {
     CassValueType type;
-    if (!php_scylladb_value_type(Z_STRVAL_P(value_type), &type ))
+    if (!php_scylladb_value_type(Z_STRVAL_P(value_type), &type )) {
+      zval_ptr_dtor(key_type);
       return;
+    }
     scalar_value_type = php_scylladb_type_scalar(type );
     value_type = &scalar_value_type;
   } else if (Z_TYPE_P(value_type) == IS_OBJECT &&
              instanceof_function(Z_OBJCE_P(value_type), php_scylladb_type_ce )) {
     if (!php_scylladb_type_validate(value_type, "valueType" )) {
+      zval_ptr_dtor(key_type);
       return;
     }
     Z_ADDREF_P(value_type);

--- a/src/Numbers/NumberParser.c
+++ b/src/Numbers/NumberParser.c
@@ -245,9 +245,11 @@ php_scylladb_parse_decimal(char* in, int in_len, mpz_t* number, long* scale )
   int dot = -1;
   /*
    * out will be storing the string representation of the integer part
-   * of the decimal value
+   * of the decimal value. It is allocated only once the input is known to
+   * be a real decimal — the hex/binary/octal paths below hand off to
+   * php_scylladb_parse_varint() and never touch it.
    */
-  char* out = (char*) ecalloc((in_len + 1), sizeof(char));
+  char* out = nullptr;
   /*  holds length of the formatted integer number */
   int out_len = 0;
 
@@ -336,6 +338,8 @@ php_scylladb_parse_decimal(char* in, int in_len, mpz_t* number, long* scale )
     return php_scylladb_parse_varint(in, in_len, number );
   }
 
+  out = (char*) ecalloc((in_len + 1), sizeof(char));
+
   /* Prepend a negative sign if necessary. */
   if (negative)
     out[0] = '-';
@@ -362,6 +366,7 @@ php_scylladb_parse_decimal(char* in, int in_len, mpz_t* number, long* scale )
 
   if (out_len == 0) {
     zend_throw_exception_ex(php_scylladb_invalid_argument_exception_ce, 0 , "No digits seen in value: '%s'", in);
+    efree(out);
     return 0;
   }
 

--- a/tools/gen_descriptor/gen_class_descriptor.php
+++ b/tools/gen_descriptor/gen_class_descriptor.php
@@ -439,9 +439,24 @@ function emit_class_descriptor(array $cls): array
     // Without this, offset stays 0 and Zend efrees/derefs the wrong
     // address → zend_mm_heap corrupted at runtime.
     $handlerWiring = "  memcpy(&$handlersVar$stdAccess, zend_get_std_object_handlers(), sizeof(zend_object_handlers));\n";
-    if (!empty($cls['struct'])) {
+    if (!empty($cls['struct']) && $cls['struct'] !== 'none') {
         $struct = $cls['struct'];
         $handlerWiring .= "  $handlersVar$stdAccess.offset = offsetof($struct, zendObject);\n";
+    } elseif (empty($cls['struct'])) {
+        // No annotation at all. If the module nonetheless supplies a custom
+        // create_object, offset stays 0 and Zend efrees the zend_object
+        // instead of the enclosing struct — a leak at best, a corrupted heap
+        // at worst. The weak symbol is only resolved at link time, so this
+        // has to be a load-time check rather than a static assertion.
+        // `@scylladb-struct none` opts out for classes that really do
+        // allocate a bare zend_object.
+        $handlerWiring .= "  if (&php_scylladb_{$snake}_new) {\n"
+            . "    zend_error_noreturn(E_CORE_ERROR,\n"
+            . "        \"$fqnLit defines php_scylladb_{$snake}_new() but its stub has no \"\n"
+            . "        \"@scylladb-struct annotation, so handlers.offset stays 0. Add \"\n"
+            . "        \"@scylladb-struct <type> to the stub, or @scylladb-struct none \"\n"
+            . "        \"if the class allocates a bare zend_object.\");\n"
+            . "  }\n";
     }
     $handlerWiring .= "  if (&php_scylladb_{$snake}_free)       $handlersVar$stdAccess.free_obj       = php_scylladb_{$snake}_free;\n";
     $handlerWiring .= "  if (&php_scylladb_{$snake}_properties) $handlersVar$stdAccess.get_properties = php_scylladb_{$snake}_properties;\n";


### PR DESCRIPTION
## Problem

A PHP debug build reports 10 memory leaks at shutdown when the Pest suite runs:

```
php/8.6-debug-nts/bin/php -d extension=$PWD/out/DebugPHP8.6NTS/cassandra.dylib \
  ./vendor/bin/pest --compact --exclude-group=async
```

```
src/Numbers/NumberParser.c(250) : Freeing … (16 bytes)   [× 8]
include/php_scylladb_object.h(49) : Freeing … (128 bytes) [× 2]
=== Total 10 memory leaks detected ===
```

Both sites are version independent. PHP 8.5.6 and PHP 8.6.0alpha3 leak the same 10 allocations.

## Fixes

### 1. `php_scylladb_parse_decimal()` scratch buffer

`out` was allocated at the top of the function but only freed on the two paths that reach `mpz_set_str()`. Every early exit leaked it:

- hex / binary handoff to `php_scylladb_parse_varint()`
- octal handoff to `php_scylladb_parse_varint()`
- "Multiple '.' (dots) in the number"
- "Unrecognized character"
- "No digits seen in value"

The allocation moves down to the point where `out` is first written, which is after all four pre-use exits. The varint handoff paths now allocate nothing at all. The "no digits seen" path gets the missing `efree()`.

### 2. `Cassandra\Map::__construct` keyType reference

The constructor takes ownership of a `Cassandra\Type` reference for `keyType` — either the one `php_scylladb_type_scalar()` returns, or the one it adds to the argument object. `php_scylladb_type_map()` consumes that reference at the very end. The two error paths in the `valueType` block returned without releasing it.

Reproduces with:

```php
new Map('varchar', 'custom type');
new Map(Type::varchar(), new UnsupportedType());
```

The leaked 128 bytes is the `php_scylladb_type` object.

### 3. Generator guard for a missing `@scylladb-struct`

Not the cause of the second leak — all 17 classes that define `php_scylladb_<snake>_new` already carry the annotation — but the failure mode is bad enough to guard.

A class with a custom `create_object` and no `@scylladb-struct` keeps `handlers.offset = 0`, so Zend frees the embedded `zend_object` instead of the struct around it. That leaks at best and corrupts the heap at worst.

The `_new` symbol is weak and resolves at link time, so neither the generator nor `_Static_assert` can see it. The check therefore runs at module load and aborts with `E_CORE_ERROR`:

```
Cassandra\Rows defines php_scylladb_rows_new() but its stub has no
@scylladb-struct annotation, so handlers.offset stays 0. Add
@scylladb-struct <type> to the stub, or @scylladb-struct none if the
class allocates a bare zend_object.
```

`@scylladb-struct none` opts out for a class that really does allocate a bare `zend_object`.

## Verification

Extension rebuilt from this branch against both debug PHP builds.

| PHP | before | after |
|---|---|---|
| 8.6.0alpha3 | 10 leaks | 0 |
| 8.5.6 | 10 leaks | 0 |

860 passed / 27 skipped on both, unchanged. The single failure (`tests/Unit/Uuid/UuidTest.php:112`, "UUID child exited with 255") is present before and after — it is the known cross-process environment quirk and is not touched here.

The generator guard was checked by temporarily removing the annotation from `Rows.stub.php` and confirming the module refuses to load.

## Notes

The same reference leak is latent in `src/Tuple.c` and `src/UserTypeValue.c`: the `php_scylladb_type_scalar()` reference leaks if `..._add()` returns 0. That path is unreachable today, because `cass_data_type_add_sub_type` only fails on a mismatched data type, so it is left out of this change.