### PR TITLE
feat(rows): add Rows::wasApplied() for lightweight transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Added
 
+- `Rows::wasApplied(): bool`, which reads the `[applied]` column of a lightweight transaction
+  result. A statement with no condition has no such column, and the method then returns `true`,
+  so you can call it on any result. The `[applied]` column stays readable through `first()` and
+  array access.
 - Experimental support for [scylladb/cpp-rs-driver](https://github.com/scylladb/cpp-rs-driver)
   as a third backend, selectable at build time via the new `PHP_DRIVER_BACKEND` CMake
   cache variable (`cassandra | scylla-cpp | scylla-rust`). Install the Rust-backed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ The project is **migrating from C++ to pure C23**. New code must be C23; existin
 ```
 src/MyModule/
 ├── MyClass.stub.php          # PHP interface/class definition — source of truth
-├── MyClass_arginfo.h         # AUTO-GENERATED from stub (never edit manually)
+├── MyClass_arginfo.h         # GENERATED at build time — gitignored, never edit, never commit
 ├── MyClass.c                 # C implementation of ZEND_METHOD()s
 ├── MyClassHandlers.h         # Handler declarations
 ├── MyClassHandlers.c         # Object handlers (new/free/gc/properties/compare)
@@ -39,11 +39,18 @@ src/MyModule/
    }
    ```
 
-2. **Generate arginfo** — run from the PHP source tree:
+2. **Generate arginfo** — the build does this for you. `cmake/GenStubs.cmake` runs
+   `tools/gen_stub/gen_arginfo.sh` on every stub, so a plain `cmake --build` regenerates
+   `MyClass_arginfo.h` whenever the stub changes. Commit the stub only — `_arginfo.h` is
+   gitignored (`.gitignore`: `src/**/*_arginfo.h`).
+
+   To run it by hand, call the wrapper, not `gen_stub.php` directly:
    ```bash
-   php php/8.x-debug-nts/src/build/gen_stub.php src/MyModule/MyClass.stub.php
+   tools/gen_stub/gen_arginfo.sh src/MyModule/MyClass.stub.php php path/to/build/gen_stub.php
    ```
-   This produces `MyClass_arginfo.h`. Commit both stub and generated file.
+   The wrapper strips `declare(strict_types=1);` before parsing, because upstream `gen_stub.php`
+   fails on it with `Unexpected node Stmt_Declare`. It also casts the emitted
+   `zend_add_*_attribute()` arguments so the output compiles as C++.
 
 3. **Include arginfo in implementation**:
    ```c
@@ -194,11 +201,15 @@ cmake --build out/DebugPHP8.4NTS     # compile
 
 ### Regenerating Arginfo After Stub Changes
 
+Rebuild. `cmake/GenStubs.cmake` regenerates every `*_arginfo.h` whose stub changed:
+
 ```bash
-php php/8.4-debug-nts/src/build/gen_stub.php src/MyModule/MyClass.stub.php
+cmake --build out/DebugPHP8.4NTS
 ```
 
-Always commit both `*.stub.php` and the generated `*_arginfo.h`.
+Commit the `*.stub.php` only. The generated `*_arginfo.h` is gitignored. Do not call
+`gen_stub.php` directly — it fails on `declare(strict_types=1);`. Use
+`tools/gen_stub/gen_arginfo.sh` if you need to run it outside a build.
 
 ### Running Tests
 

--- a/src/Database/Rows.c
+++ b/src/Database/Rows.c
@@ -400,6 +400,26 @@ ZEND_METHOD(Cassandra_Rows, first)
     }
 }
 
+ZEND_METHOD(Cassandra_Rows, wasApplied)
+{
+    ZEND_PARSE_PARAMETERS_NONE();
+
+    auto self = PHP_SCYLLADB_GET_ROWS(getThis());
+
+    /* A non-conditional statement has no "[applied]" column. Match the Java
+       and Python drivers and report true, so a caller can ask this of any
+       result. */
+    zval *row = zend_hash_index_find(Z_ARRVAL(self->rows), 0);
+    if (row == nullptr || Z_TYPE_P(row) != IS_ARRAY)
+    {
+        RETURN_TRUE;
+    }
+
+    zval *applied = zend_hash_str_find(Z_ARRVAL_P(row), "[applied]", sizeof("[applied]") - 1);
+
+    RETURN_BOOL(applied == nullptr || zend_is_true(applied));
+}
+
 HashTable *php_scylladb_rows_properties(zend_object *object)
 {
     HashTable *props = zend_std_get_properties(object);

--- a/src/Database/Rows.stub.php
+++ b/src/Database/Rows.stub.php
@@ -26,5 +26,6 @@ namespace Cassandra {
         public function nextPageAsync(): Future {}
         public function pagingStateToken(): ?string {}
         public function first(): mixed {}
+        public function wasApplied(): bool {}
     }
 }

--- a/tests/Feature/Results/LightweightTransactionTest.php
+++ b/tests/Feature/Results/LightweightTransactionTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+use Cassandra\SimpleStatement;
+
+$keyspace = 'lwt_was_applied';
+$table    = 'users';
+
+beforeAll(function () use ($keyspace, $table) {
+    migrateKeyspace(<<<CQL
+    CREATE KEYSPACE $keyspace WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};
+    USE $keyspace;
+    CREATE TABLE $table (
+        id    int PRIMARY KEY,
+        email text
+    )
+    CQL);
+});
+
+afterAll(fn () => dropKeyspace($keyspace));
+
+it('reports true when a conditional insert succeeds', function () use ($keyspace, $table) {
+    $session = scyllaDbConnection($keyspace);
+
+    $rows = $session->execute(
+        new SimpleStatement("INSERT INTO $table (id, email) VALUES (1, 'ada@example.com') IF NOT EXISTS")
+    );
+
+    expect($rows->wasApplied())->toBeTrue()
+        ->and($rows->first()['[applied]'])->toBeTrue();
+})->group('feature');
+
+it('reports false and exposes the current values when a conditional insert loses', function () use ($keyspace, $table) {
+    $session = scyllaDbConnection($keyspace);
+
+    $session->execute(
+        new SimpleStatement("INSERT INTO $table (id, email) VALUES (2, 'grace@example.com') IF NOT EXISTS")
+    );
+
+    $rows = $session->execute(
+        new SimpleStatement("INSERT INTO $table (id, email) VALUES (2, 'ada@example.com') IF NOT EXISTS")
+    );
+
+    expect($rows->wasApplied())->toBeFalse()
+        ->and($rows->first()['email'])->toBe('grace@example.com');
+})->group('feature');
+
+it('reports false when a conditional update finds no row', function () use ($keyspace, $table) {
+    $session = scyllaDbConnection($keyspace);
+
+    $rows = $session->execute(
+        new SimpleStatement("UPDATE $table SET email = 'nobody@example.com' WHERE id = 999 IF EXISTS")
+    );
+
+    expect($rows->wasApplied())->toBeFalse();
+})->group('feature');
+
+it('reports false when the IF condition does not match', function () use ($keyspace, $table) {
+    $session = scyllaDbConnection($keyspace);
+
+    $session->execute(new SimpleStatement("INSERT INTO $table (id, email) VALUES (3, 'lovelace@example.com')"));
+
+    $rows = $session->execute(
+        new SimpleStatement("UPDATE $table SET email = 'x@example.com' WHERE id = 3 IF email = 'wrong@example.com'")
+    );
+
+    expect($rows->wasApplied())->toBeFalse()
+        ->and($rows->first()['email'])->toBe('lovelace@example.com');
+})->group('feature');
+
+it('reports true for a non-conditional write', function () use ($keyspace, $table) {
+    $session = scyllaDbConnection($keyspace);
+
+    $rows = $session->execute(
+        new SimpleStatement("INSERT INTO $table (id, email) VALUES (4, 'plain@example.com')")
+    );
+
+    expect($rows->count())->toBe(0)
+        ->and($rows->wasApplied())->toBeTrue();
+})->group('feature');
+
+it('reports true for a SELECT that has no [applied] column', function () use ($keyspace, $table) {
+    $session = scyllaDbConnection($keyspace);
+
+    $rows = $session->execute(new SimpleStatement("SELECT * FROM $table WHERE id = 1"));
+
+    expect($rows->count())->toBe(1)
+        ->and($rows->wasApplied())->toBeTrue();
+})->group('feature');
+
+it('is available on a result fetched through executeAsync', function () use ($keyspace, $table) {
+    $session = scyllaDbConnection($keyspace);
+
+    $rows = $session->executeAsync(
+        new SimpleStatement("INSERT INTO $table (id, email) VALUES (5, 'async@example.com') IF NOT EXISTS")
+    )->get();
+
+    expect($rows->wasApplied())->toBeTrue();
+})->group('feature', 'async');

--- a/website/guide/queries.md
+++ b/website/guide/queries.md
@@ -192,6 +192,7 @@ properties in camel case (`$options->pageSize`). Pass a plain array in new code.
 ## Lightweight transactions
 
 A conditional write returns a result set with an `[applied]` column instead of an empty result.
+Read that column with `wasApplied()`.
 
 ```php
 $statement = $session->prepare(
@@ -203,12 +204,22 @@ $rows = $session->execute($statement, [
     'serial_consistency' => Cassandra::CONSISTENCY_LOCAL_SERIAL,
 ]);
 
-$row = $rows->first();
-
-if ($row['[applied]'] === false) {
-    // A row with this key already exists. The other columns hold the current values.
+if (! $rows->wasApplied()) {
+    // The write lost. $rows->first() holds the current values of the row.
+    $current = $rows->first();
 }
 ```
+
+`wasApplied()` reads the `[applied]` column of the first row. A statement with no condition has no
+such column, and the method then returns `true`. You can call it on any result.
+
+::: warning `wasApplied()` is not `exists()`
+`false` means the condition failed, not that the row is present. After `IF NOT EXISTS` a `false`
+tells you the row **is** there. After `IF EXISTS` the same `false` tells you the row **is not**
+there. The meaning comes from your condition.
+:::
+
+The `[applied]` column stays readable through `first()` and array access, so old code keeps working.
 
 Lightweight transactions use Paxos and cost several round trips. Use them where correctness needs
 them, not as a general concurrency tool.

--- a/website/guide/results.md
+++ b/website/guide/results.md
@@ -188,5 +188,5 @@ if ($row === null) {
 ## Writes and schema changes
 
 An `INSERT`, `UPDATE`, `DELETE`, or `CREATE TABLE` also returns a `Rows` object. It is empty, except
-for a lightweight transaction, which returns the `[applied]` column. See
-[lightweight transactions](/guide/queries#lightweight-transactions).
+for a lightweight transaction, which returns the `[applied]` column. Read that column with
+`$rows->wasApplied()`. See [lightweight transactions](/guide/queries#lightweight-transactions).

--- a/website/reference/rows-futures.md
+++ b/website/reference/rows-futures.md
@@ -9,6 +9,7 @@ final class Rows implements \Iterator, \Countable, \ArrayAccess
 {
     public function count(): int;
     public function first(): mixed;
+    public function wasApplied(): bool;
 
     public function isLastPage(): bool;
     public function nextPage(int|float|null $timeout = null): Rows|false;
@@ -34,6 +35,7 @@ final class Rows implements \Iterator, \Countable, \ArrayAccess
 | --- | --- |
 | `count()` | Rows on **this page**, not in the whole result set. Triggers no fetch. |
 | `first()` | The first row of the page, or `null` when the page is empty. |
+| `wasApplied()` | The `[applied]` column of the first row. `true` when the statement had no condition. |
 | `isLastPage()` | `true` when no further page exists. Check it before `nextPage()`. |
 | `nextPage()` | Fetches and returns a new `Rows`. Blocks. `$timeout` is in seconds. |
 | `nextPageAsync()` | Starts the fetch and returns a future at once. |


### PR DESCRIPTION
## What

Adds `Cassandra\Rows::wasApplied(): bool`.

A conditional write returns an `[applied]` column instead of an empty result. Until now the only way to read it was:

```php
if ($rows->first()['[applied]'] === false) { /* ... */ }
```

Now:

```php
if (! $rows->wasApplied()) {
    $current = $rows->first();   // the conflicting values
}
```

## Semantics

`wasApplied()` reads the `[applied]` column of the first row. A statement with no condition has no such column, and the method then returns `true`, so a caller can ask this of any result. This matches `wasApplied()` in the Java driver and `was_applied` in the Python driver.

`false` means the condition failed, not that the row is present:

| Statement | `wasApplied() === false` means |
| --- | --- |
| `IF NOT EXISTS` | The row is already there |
| `IF EXISTS` | The row is not there |
| `IF col = ?` | The current value does not match |

This is why the method is not named `exists()` — the meaning inverts with the condition, which the driver cannot see.

## Implementation

The method reads the already-decoded row array, so it adds no `cass_*` call and no round trip. The `[applied]` column stays readable through `first()` and array access, so old code keeps working.

## Also in this PR

Two stale statements in `CLAUDE.md`:

- It said to commit `*_arginfo.h`. That file is gitignored (`.gitignore`: `src/**/*_arginfo.h`) and generated at build time by `cmake/GenStubs.cmake`.
- It said to run `gen_stub.php` directly. Upstream `gen_stub.php` fails on `declare(strict_types=1);` with `Unexpected node Stmt_Declare`. The build calls `tools/gen_stub/gen_arginfo.sh`, which strips the declare first.

## Tests

New `tests/Feature/Results/LightweightTransactionTest.php`, 7 cases:

- `IF NOT EXISTS` that wins, and one that loses (checks the current values come back)
- `IF EXISTS` against a missing row
- A failed `IF col = ?`
- A write with no condition
- A `SELECT`
- A result fetched through `executeAsync()`

All 13 tests in `tests/Feature/Results` pass against ScyllaDB, built with the `DebugPHP8.4NTS` preset.