### PR TITLE
feat(duration): build a duration from a native DateInterval

### DIFF
--- a/docs/Cassandra/Duration.php
+++ b/docs/Cassandra/Duration.php
@@ -24,11 +24,25 @@ namespace Cassandra;
 final class Duration implements Value {
 
     /**
-     * @param long|double|string|\Cassandra\Bigint $months Months attribute of the duration.
+     * A \DateInterval must be the only argument. Otherwise all three are required.
+     *
+     * @param long|double|string|\Cassandra\Bigint|\DateInterval $months Months attribute of the duration, or a date interval.
      * @param long|double|string|\Cassandra\Bigint $days Days attribute of the duration.
      * @param long|double|string|\Cassandra\Bigint $nanos Nanos attribute of the duration.
      */
     public function __construct($months, $days, $nanos) { }
+
+    /**
+     * Creates a duration from a native date interval.
+     *
+     * Years fold into months and hours and smaller parts fold into nanoseconds.
+     * An inverted interval gives a negative duration.
+     *
+     * @param \DateInterval $interval The interval to convert
+     *
+     * @return static
+     */
+    public static function fromDateInterval($interval) { }
 
     /**
      * The type of represented by the value.

--- a/src/DateTime/Duration.c
+++ b/src/DateTime/Duration.c
@@ -7,6 +7,7 @@
 #include "Type/TypeFactory.h"
 
 #include <spl/spl_exceptions.h>
+#include <ext/date/php_date.h>
 #include "Duration_arginfo.h"
 
 extern php_scylladb_value_handlers php_scylladb_duration_handlers;
@@ -105,20 +106,106 @@ char *php_scylladb_duration_to_string(php_scylladb_duration *duration)
   return rep;
 }
 
+static php_scylladb_duration *duration_instantiate(zval *object)
+{
+  zval val;
+
+  if (object_init_ex(&val, php_scylladb_duration_ce) != SUCCESS) {
+    return nullptr;
+  }
+
+  ZVAL_OBJ(object, Z_OBJ(val));
+  return php_scylladb_duration_object_fetch(Z_OBJ_P(object));
+}
+
+static cass_int64_t rel_time_field(timelib_sll value)
+{
+  return value == TIMELIB_UNSET ? 0 : (cass_int64_t)value;
+}
+
+static bool duration_from_date_interval(zval *interval, php_scylladb_duration *self)
+{
+  php_interval_obj *obj = Z_PHPINTERVAL_P(interval);
+
+  if (!obj->initialized || obj->diff == nullptr) {
+    zend_throw_exception_ex(php_scylladb_invalid_argument_exception_ce, 0, "%s",
+      "The DateInterval is not initialized");
+    return false;
+  }
+
+  timelib_rel_time *rel = obj->diff;
+
+  cass_int64_t months = 0;
+  cass_int64_t days = rel_time_field(rel->d);
+  cass_int64_t seconds = 0;
+  cass_int64_t nanos = 0;
+  cass_int64_t part = 0;
+
+  bool overflow = __builtin_mul_overflow(rel_time_field(rel->y), (cass_int64_t)12, &months);
+  overflow |= __builtin_add_overflow(months, rel_time_field(rel->m), &months);
+
+  overflow |= __builtin_mul_overflow(rel_time_field(rel->h), (cass_int64_t)3600, &seconds);
+  overflow |= __builtin_mul_overflow(rel_time_field(rel->i), (cass_int64_t)60, &part);
+  overflow |= __builtin_add_overflow(seconds, part, &seconds);
+  overflow |= __builtin_add_overflow(seconds, rel_time_field(rel->s), &seconds);
+
+  overflow |= __builtin_mul_overflow(seconds, (cass_int64_t)1000000000, &nanos);
+  overflow |= __builtin_mul_overflow(rel_time_field(rel->us), (cass_int64_t)1000, &part);
+  overflow |= __builtin_add_overflow(nanos, part, &nanos);
+
+  if (overflow || months > INT32_MAX || months < INT32_MIN || days > INT32_MAX ||
+      days < INT32_MIN || nanos == INT64_MIN) {
+    zend_throw_exception_ex(php_scylladb_invalid_argument_exception_ce, 0, "%s",
+      "The DateInterval is too large for a duration");
+    return false;
+  }
+
+  if (rel->invert) {
+    months = -months;
+    days = -days;
+    nanos = -nanos;
+  }
+
+  self->months = (cass_int32_t)months;
+  self->days = (cass_int32_t)days;
+  self->nanos = nanos;
+  return true;
+}
+
 void
 php_scylladb_duration_init(INTERNAL_FUNCTION_PARAMETERS)
 {
-  zval *months, *days, *nanos;
+  zval *months, *days = nullptr, *nanos = nullptr;
   cass_int64_t param;
   php_scylladb_duration *self = nullptr;
 
-  ZEND_PARSE_PARAMETERS_START(3, 3)
+  ZEND_PARSE_PARAMETERS_START(1, 3)
     Z_PARAM_ZVAL(months)
+    Z_PARAM_OPTIONAL
     Z_PARAM_ZVAL(days)
     Z_PARAM_ZVAL(nanos)
   ZEND_PARSE_PARAMETERS_END();
 
   self = PHP_SCYLLADB_GET_DURATION(getThis());
+
+  if (Z_TYPE_P(months) == IS_OBJECT &&
+      instanceof_function(Z_OBJCE_P(months), php_date_get_interval_ce())) {
+    if (ZEND_NUM_ARGS() != 1) {
+      zend_throw_exception_ex(php_scylladb_invalid_argument_exception_ce, 0, "%s",
+        "A DateInterval must be the only argument");
+      return;
+    }
+
+    duration_from_date_interval(months, self);
+    return;
+  }
+
+  if (ZEND_NUM_ARGS() != 3) {
+    zend_argument_count_error(
+      PHP_SCYLLADB_NAMESPACE "\\Duration::__construct() expects exactly 3 arguments, %d given",
+      ZEND_NUM_ARGS());
+    return;
+  }
 
   if (!get_param(months, "months", INT32_MIN, INT32_MAX, &param  )) {
     return;
@@ -146,6 +233,28 @@ php_scylladb_duration_init(INTERNAL_FUNCTION_PARAMETERS)
 ZEND_METHOD(Cassandra_Duration, __construct)
 {
   php_scylladb_duration_init(INTERNAL_FUNCTION_PARAM_PASSTHRU);
+}
+
+ZEND_METHOD(Cassandra_Duration, fromDateInterval)
+{
+  zval *interval;
+
+  ZEND_PARSE_PARAMETERS_START(1, 1)
+    Z_PARAM_OBJECT_OF_CLASS(interval, php_date_get_interval_ce())
+  ZEND_PARSE_PARAMETERS_END();
+
+  php_scylladb_duration *self = duration_instantiate(return_value);
+
+  if (self == nullptr) {
+    zend_throw_exception(php_scylladb_runtime_exception_ce,
+      "Failed to create " PHP_SCYLLADB_NAMESPACE "\\Duration", 0);
+    RETURN_THROWS();
+  }
+
+  if (!duration_from_date_interval(interval, self)) {
+    zval_ptr_dtor(return_value);
+    RETURN_THROWS();
+  }
 }
 
 ZEND_METHOD(Cassandra_Duration, __toString)

--- a/src/DateTime/Duration.stub.php
+++ b/src/DateTime/Duration.stub.php
@@ -12,7 +12,9 @@ namespace Cassandra {
      * @scylladb-value-handlers
  * @scylladb-struct php_scylladb_duration
  */    final class Duration implements Value {
-        public function __construct(int|float|string|Bigint $months, int|float|string|Bigint $days, int|float|string|Bigint $nanos) {}
+        public function __construct(int|float|string|Bigint|\DateInterval $months, int|float|string|Bigint $days = UNKNOWN, int|float|string|Bigint $nanos = UNKNOWN) {}
+
+        public static function fromDateInterval(\DateInterval $interval): static {}
 
         public function type(): Type {}
         public function months(): string {}

--- a/tests/Unit/DurationTest.php
+++ b/tests/Unit/DurationTest.php
@@ -147,4 +147,86 @@ describe('Cassandra\Duration', function () {
         $props    = get_object_vars($duration);
         expect($props)->toEqual(['months' => 1, 'days' => 2, 'nanos' => 3]);
     });
+
+    describe('DateInterval support', function () {
+        it('converts each part of a DateInterval', function ($spec, $months, $days, $nanos) {
+            $duration = new Duration(new \DateInterval($spec));
+
+            expect($duration->months())->toBe($months)
+                ->and($duration->days())->toBe($days)
+                ->and($duration->nanos())->toBe($nanos);
+        })->with([
+            ['P1M15D', '1', '15', '0'],
+            ['P1Y2M3D', '14', '3', '0'],
+            ['PT4H5M6S', '0', '0', '14706000000000'],
+            ['P0D', '0', '0', '0'],
+        ]);
+
+        it('converts sub-second precision down to nanoseconds', function () {
+            $interval    = new \DateInterval('PT0S');
+            $interval->f = 0.123456;
+
+            expect((new Duration($interval))->nanos())->toBe('123456000');
+        });
+
+        it('accepts an interval built by diff', function () {
+            $interval = (new \DateTime('2020-01-01'))->diff(new \DateTime('2021-03-04 05:06:07'));
+            $duration = new Duration($interval);
+
+            expect($duration->months())->toBe('14')
+                ->and($duration->days())->toBe('3')
+                ->and($duration->nanos())->toBe('18367000000000');
+        });
+
+        it('makes every part negative for an inverted interval', function () {
+            $interval = (new \DateTime('2021-03-04'))->diff(new \DateTime('2020-01-01'));
+            $duration = new Duration($interval);
+
+            expect($duration->months())->toBe('-14')
+                ->and($duration->days())->toBe('-3')
+                ->and((string) $duration)->toBe('-14mo3d0ns');
+        });
+
+        it('accepts an interval built from a date string', function () {
+            expect((new Duration(\DateInterval::createFromDateString('90 minutes')))->nanos())
+                ->toBe('5400000000000');
+        });
+
+        it('accepts a CarbonInterval', function () {
+            expect((string) new Duration(\Carbon\CarbonInterval::days(3)))->toBe('0mo3d0ns');
+        });
+
+        it('matches the three argument constructor', function () {
+            expect(new Duration(new \DateInterval('P1M15D')))->toEqual(new Duration(1, 15, 0));
+        });
+
+        it('builds the same value through fromDateInterval', function () {
+            $interval = new \DateInterval('P1Y2M3DT4H5M6S');
+
+            expect(Duration::fromDateInterval($interval))->toEqual(new Duration($interval));
+        });
+
+        it('rejects extra arguments after a DateInterval', function () {
+            new Duration(new \DateInterval('P1M'), 1, 2);
+        })->throws(InvalidArgumentException::class, 'A DateInterval must be the only argument');
+
+        it('rejects an uninitialized DateInterval', function () {
+            new Duration((new \ReflectionClass(\DateInterval::class))->newInstanceWithoutConstructor());
+        })->throws(InvalidArgumentException::class, 'The DateInterval is not initialized');
+
+        it('rejects an interval that does not fit', function ($spec) {
+            new Duration(\DateInterval::createFromDateString($spec));
+        })->with([
+            ['200000000 years'],
+            ['3000000000 days'],
+            ['3000000000000 seconds'],
+        ])->throws(InvalidArgumentException::class, 'The DateInterval is too large for a duration');
+
+        it('still requires three arguments without a DateInterval', function ($args) {
+            new Duration(...$args);
+        })->with([
+            [[1]],
+            [[1, 2]],
+        ])->throws(\ArgumentCountError::class);
+    });
 });

--- a/website/guide/data-types.md
+++ b/website/guide/data-types.md
@@ -203,6 +203,17 @@ $d->nanos();    // string
 The string form is `Mmo Dd Nns` without spaces. A negative duration leads with a minus sign, so
 `(-3, -2, -1)` prints as `-3mo2d1ns`.
 
+A native `DateInterval` works as the only argument:
+
+```php
+$d = new Cassandra\Duration(new DateInterval('P1M15D'));
+$d = Cassandra\Duration::fromDateInterval((new DateTime('2020-01-01'))->diff(new DateTime()));
+```
+
+Years fold into months, hours and smaller parts fold into nanoseconds, and an inverted interval
+gives a negative duration. The sub-second part of a `DateInterval` holds microseconds, so the
+last three digits of `nanos()` are always zero.
+
 ## UUIDs
 
 ```php

--- a/website/reference/values.md
+++ b/website/reference/values.md
@@ -138,12 +138,14 @@ final class Time implements Value
 ```php
 final class Duration implements Value
 {
+    // A DateInterval must be the only argument. Otherwise all three are required.
     public function __construct(
-        int|float|string|Bigint $months,
+        int|float|string|Bigint|\DateInterval $months,
         int|float|string|Bigint $days,
         int|float|string|Bigint $nanos,
     ) {}
 
+    public static function fromDateInterval(\DateInterval $interval): static;
     public function months(): string;
     public function days(): string;
     public function nanos(): string;


### PR DESCRIPTION
## What

`Cassandra\Duration` now accepts PHP's native `DateInterval`.

```php
$d = new Cassandra\Duration(new DateInterval('P1M15D'));
$d = Cassandra\Duration::fromDateInterval((new DateTime('2020-01-01'))->diff(new DateTime()));
```

## Why

The class took three numeric arguments only. A caller who already had a `DateInterval` — from `DateTime::diff()`, from Carbon, from a config value — had to split it into months, days, and nanoseconds by hand and get the calendar arithmetic right.

Note: PHP has no `Duration` class. `DateInterval` is the native type for this.

## Mapping

| DateInterval | Duration |
| --- | --- |
| `y`, `m` | `months` = `y * 12 + m` |
| `d` | `days` |
| `h`, `i`, `s`, `f` | `nanos` |
| `invert` | negates all three parts |

`f` holds microseconds, so the last three digits of `nanos()` are always zero.

## Rules

- A `DateInterval` must be the only argument. Passing it with `$days`/`$nanos` throws `InvalidArgumentException`, because the other two values would be discarded.
- The numeric form still requires all three arguments. A short call throws `ArgumentCountError`. The stub marks arguments 2 and 3 as optional to allow the one-argument form, so this check moved from arginfo into the constructor.
- An interval outside the CQL range is rejected. `months` and `days` are 32 bit, `nanos` is 64 bit. Every intermediate product is checked for overflow.
- An uninitialized `DateInterval` is rejected.
- `DateInterval` subclasses work, `Carbon\CarbonInterval` included.

## Changes

- `src/DateTime/Duration.stub.php`, `src/DateTime/Duration.c`
- `tests/Unit/DurationTest.php` — 16 new cases
- `docs/Cassandra/Duration.php`, `website/reference/values.md`, `website/guide/data-types.md`

## Test

```
php -d extension=out/DebugPHP8.4NTS/cassandra.dylib ./vendor/bin/pest tests/Unit/
Tests: 1 warning, 28 skipped, 849 passed (12157 assertions)
```

## Not in this change

`toDateInterval()`. The reverse direction loses precision below microseconds and needs its own decision about what to do with the remainder.