### PR TITLE
Narrow mixed types across the stubs, fix two value-constructor crashes, ship IDE stubs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,9 +122,68 @@ jobs:
           retention-days: 5
           overwrite: true
 
+  ide-stubs:
+    name: IDE stubs
+    runs-on: ubuntu-26.04
+    needs: [tag]
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 1
+          submodules: recursive
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y --no-install-recommends \
+            pkg-config build-essential ninja-build libuv1-dev
+
+      - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
+        with:
+          php-version: "8.4"
+          ini-file: production
+          coverage: none
+          tools: none
+
+      - name: Setup CMake
+        uses: jwlawson/actions-setup-cmake@0d6a7d60b009d01c9e7523be22153ff8f19460d3 # v2
+        with:
+          cmake-version: "3.30"
+
+      - uses: ./.github/actions/install-cpp-driver
+        id: driver
+        with:
+          driver: scylladb
+
+      # The generator resolves `@cvalue` constants out of a loaded extension,
+      # so the stubs can only be produced against a real build.
+      - uses: ./.github/actions/build-extension
+        with:
+          driver: scylladb
+          cpp_driver_pkg_config_path: ${{ steps.driver.outputs.pkg_config_path }}
+          build_type: Release
+          enable_lto: OFF
+
+      - name: Generate IDE stubs
+        run: php -d extension=cassandra tools/gen_ide_stubs.php build/ide-stubs
+
+      - name: Package IDE stubs
+        run: |
+          ARTIFACT="ide-stubs-v${{ needs.tag.outputs.version }}"
+          tar czf "${ARTIFACT}.tar.gz" -C build ide-stubs
+          echo "ARTIFACT=${ARTIFACT}" >> "$GITHUB_ENV"
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: ${{ env.ARTIFACT }}
+          path: ${{ env.ARTIFACT }}.tar.gz
+          if-no-files-found: error
+          retention-days: 5
+          overwrite: true
+
   release:
     runs-on: ubuntu-26.04
-    needs: [build, tag]
+    needs: [build, ide-stubs, tag]
     steps:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:

--- a/src/Collection.stub.php
+++ b/src/Collection.stub.php
@@ -15,16 +15,16 @@ namespace Cassandra {
 
         public function type(): Type {}
         public function values(): array {}
-        public function add(mixed ...$value): int {}
-        public function get(int $index): mixed {}
-        public function find(mixed $value): int|null {}
+        public function add(Value|string|int|float|bool|null ...$value): int {}
+        public function get(int $index): Value|string|int|float|bool|null {}
+        public function find(Value|string|int|float|bool|null $value): int|null {}
         public function remove(int $index): bool {}
 
         /* Countable */
         public function count(): int {}
 
         /* Iterator */
-        public function current(): mixed {}
+        public function current(): Value|string|int|float|bool|null {}
         public function key(): int {}
         public function next(): void {}
         public function valid(): bool {}

--- a/src/Custom.stub.php
+++ b/src/Custom.stub.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * Declaration-only stub.
+ *
+ * src/Custom.c registers Cassandra\Custom by hand, so this file is NOT passed
+ * to php_scylladb_generate_arginfo() and produces no Custom_arginfo.h. It
+ * exists so the class appears in the generated IDE stubs and so the port to
+ * the canonical stub pattern has a starting point. Keep it in step with
+ * php_scylladb_register_custom().
+ */
+
+declare(strict_types=1);
+
+namespace Cassandra {
+    abstract class Custom implements Value
+    {
+    }
+}

--- a/src/Database/Aggregate.stub.php
+++ b/src/Database/Aggregate.stub.php
@@ -19,8 +19,7 @@ namespace Cassandra {
         /** @return \Cassandra\Function_|null */
         public function stateFunction(): ?\Cassandra\Function_;
 
-        /** @return mixed */
-        public function initialCondition(): mixed;
+        public function initialCondition(): Value|string|int|float|bool|null;
 
         /** @return \Cassandra\Type|null */
         public function returnType(): ?\Cassandra\Type;

--- a/src/Database/DefaultAggregate.stub.php
+++ b/src/Database/DefaultAggregate.stub.php
@@ -23,8 +23,7 @@ namespace Cassandra {
         /** @return \Cassandra\Function_|null */
         public function stateFunction(): ?\Cassandra\Function_ {}
 
-        /** @return mixed */
-        public function initialCondition(): mixed {}
+        public function initialCondition(): Value|string|int|float|bool|null {}
 
         /** @return \Cassandra\Type|null */
         public function returnType(): ?\Cassandra\Type {}

--- a/src/Database/DefaultIndex.stub.php
+++ b/src/Database/DefaultIndex.stub.php
@@ -16,8 +16,7 @@ namespace Cassandra {
 
         public function target(): string {}
 
-        /** @return mixed */
-        public function option(string $name): mixed {}
+        public function option(string $name): Value|string|int|float|bool|null {}
 
         /** @return array<string, string> */
         public function options(): array {}

--- a/src/Database/DefaultKeyspace.stub.php
+++ b/src/Database/DefaultKeyspace.stub.php
@@ -38,13 +38,13 @@ namespace Cassandra {
         public function materializedViews(): array {}
 
         /** @return \Cassandra\Function_|false */
-        public function function(string $name, mixed ...$types): \Cassandra\Function_|false {}
+        public function function(string $name, string|\Cassandra\Type ...$types): \Cassandra\Function_|false {}
 
         /** @return array<string, \Cassandra\Function_> */
         public function functions(): array {}
 
         /** @return Aggregate|false */
-        public function aggregate(string $name, mixed ...$types): Aggregate|false {}
+        public function aggregate(string $name, string|\Cassandra\Type ...$types): Aggregate|false {}
 
         /** @return array<string, Aggregate> */
         public function aggregates(): array {}

--- a/src/Database/DefaultMaterializedView.stub.php
+++ b/src/Database/DefaultMaterializedView.stub.php
@@ -12,8 +12,7 @@ namespace Cassandra {
  */    final class DefaultMaterializedView extends \Cassandra\MaterializedView {
         public function name(): string {}
 
-        /** @return mixed */
-        public function option(string $name): mixed {}
+        public function option(string $name): Value|string|int|float|bool|null {}
 
         /** @return array<string, mixed> */
         public function options(): array {}
@@ -57,11 +56,9 @@ namespace Cassandra {
         /** @return array<string, mixed>|false */
         public function compressionParameters(): array|false {}
 
-        /** @return bool|false */
-        public function populateIOCacheOnFlush(): bool|false {}
+        public function populateIOCacheOnFlush(): bool {}
 
-        /** @return bool|false */
-        public function replicateOnWrite(): bool|false {}
+        public function replicateOnWrite(): bool {}
 
         /** @return int|false */
         public function maxIndexInterval(): int|false {}

--- a/src/Database/DefaultTable.stub.php
+++ b/src/Database/DefaultTable.stub.php
@@ -12,8 +12,7 @@ namespace Cassandra {
  */    final class DefaultTable implements \Cassandra\Table {
         public function name(): string {}
 
-        /** @return mixed */
-        public function option(string $name): mixed {}
+        public function option(string $name): Value|string|int|float|bool|null {}
 
         /** @return array<string, mixed> */
         public function options(): array {}
@@ -57,11 +56,9 @@ namespace Cassandra {
         /** @return array<string, mixed>|false */
         public function compressionParameters(): array|false {}
 
-        /** @return bool|false */
-        public function populateIOCacheOnFlush(): bool|false {}
+        public function populateIOCacheOnFlush(): bool {}
 
-        /** @return bool|false */
-        public function replicateOnWrite(): bool|false {}
+        public function replicateOnWrite(): bool {}
 
         /** @return int|false */
         public function maxIndexInterval(): int|false {}

--- a/src/Database/Index.stub.php
+++ b/src/Database/Index.stub.php
@@ -12,8 +12,7 @@ namespace Cassandra {
 
         public function target(): string;
 
-        /** @return mixed */
-        public function option(string $name): mixed;
+        public function option(string $name): Value|string|int|float|bool|null;
 
         /** @return array<string, string> */
         public function options(): array;

--- a/src/Database/Keyspace.stub.php
+++ b/src/Database/Keyspace.stub.php
@@ -34,13 +34,13 @@ namespace Cassandra {
         public function materializedViews(): array;
 
         /** @return \Cassandra\Function_|false */
-        public function function(string $name, mixed ...$types): \Cassandra\Function_|false;
+        public function function(string $name, string|\Cassandra\Type ...$types): \Cassandra\Function_|false;
 
         /** @return array<string, \Cassandra\Function_> */
         public function functions(): array;
 
         /** @return Aggregate|false */
-        public function aggregate(string $name, mixed ...$types): Aggregate|false;
+        public function aggregate(string $name, string|\Cassandra\Type ...$types): Aggregate|false;
 
         /** @return array<string, Aggregate> */
         public function aggregates(): array;

--- a/src/Database/Rows.stub.php
+++ b/src/Database/Rows.stub.php
@@ -13,19 +13,19 @@ namespace Cassandra {
         public function __construct() {}
         public function count(): int {}
         public function rewind(): void {}
-        public function current(): mixed {}
-        public function key(): mixed {}
+        public function current(): ?array {}
+        public function key(): ?int {}
         public function next(): void {}
         public function valid(): bool {}
         public function offsetExists(mixed $offset): bool {}
-        public function offsetGet(mixed $offset): mixed {}
+        public function offsetGet(mixed $offset): ?array {}
         public function offsetSet(mixed $offset, mixed $value): void {}
         public function offsetUnset(mixed $offset): void {}
         public function isLastPage(): bool {}
         public function nextPage(int|float|null $timeout = null): Rows|false {}
         public function nextPageAsync(): Future {}
         public function pagingStateToken(): ?string {}
-        public function first(): mixed {}
+        public function first(): ?array {}
         public function wasApplied(): bool {}
     }
 }

--- a/src/Database/Table.stub.php
+++ b/src/Database/Table.stub.php
@@ -8,8 +8,7 @@ namespace Cassandra {
     interface Table {
         public function name(): string;
 
-        /** @return mixed */
-        public function option(string $name): mixed;
+        public function option(string $name): Value|string|int|float|bool|null;
 
         /** @return array<string, mixed> */
         public function options(): array;
@@ -53,11 +52,9 @@ namespace Cassandra {
         /** @return array<string, mixed>|false */
         public function compressionParameters(): array|false;
 
-        /** @return bool|false */
-        public function populateIOCacheOnFlush(): bool|false;
+        public function populateIOCacheOnFlush(): bool;
 
-        /** @return bool|false */
-        public function replicateOnWrite(): bool|false;
+        public function replicateOnWrite(): bool;
 
         /** @return int|false */
         public function maxIndexInterval(): int|false;

--- a/src/DateTime/Duration.c
+++ b/src/DateTime/Duration.c
@@ -186,7 +186,16 @@ php_scylladb_duration_init(INTERNAL_FUNCTION_PARAMETERS)
     Z_PARAM_ZVAL(nanos)
   ZEND_PARSE_PARAMETERS_END();
 
-  self = PHP_SCYLLADB_GET_DURATION(getThis());
+  /* Reached both as Duration::__construct (ZEND_THIS is the Duration being
+     built) and as Type\Scalar::create (ZEND_THIS is the Scalar type object).
+     Fetching a duration out of the Scalar is a type-confused write. */
+  if (ZEND_THIS && Z_TYPE_P(ZEND_THIS) == IS_OBJECT &&
+      instanceof_function(Z_OBJCE_P(ZEND_THIS), php_scylladb_duration_ce)) {
+    self = PHP_SCYLLADB_GET_DURATION(ZEND_THIS);
+  } else {
+    object_init_ex(return_value, php_scylladb_duration_ce);
+    self = PHP_SCYLLADB_GET_DURATION(return_value);
+  }
 
   if (Z_TYPE_P(months) == IS_OBJECT &&
       instanceof_function(Z_OBJCE_P(months), php_date_get_interval_ce())) {

--- a/src/DateTime/Timeuuid.c
+++ b/src/DateTime/Timeuuid.c
@@ -32,7 +32,10 @@ zend_result php_scylladb_timeuuid_init(zval *returnValue, zend_string *str, zend
     return FAILURE;
   }
 
-  if (Z_TYPE_P(returnValue) == IS_UNDEF) {
+  /* __construct passes an existing Timeuuid; Type\Scalar::create passes the
+     VM's return_value, which is IS_NULL rather than IS_UNDEF. Testing only for
+     IS_UNDEF let the null through to Z_OBJ_P below. */
+  if (Z_TYPE_P(returnValue) != IS_OBJECT) {
     zval val;
     object_init_ex(&val, php_scylladb_timeuuid_ce);
     ZVAL_OBJ(returnValue, Z_OBJ(val));

--- a/src/ExecutionOptions.stub.php
+++ b/src/ExecutionOptions.stub.php
@@ -12,6 +12,6 @@ namespace Cassandra {
  */    final class ExecutionOptions {
         /** @deprecated */
         public function __construct(array $options) {}
-        public function __get(string $name): mixed {}
+        public function __get(string $name): int|float|string|array|RetryPolicy|null {}
     }
 }

--- a/src/FutureClose.stub.php
+++ b/src/FutureClose.stub.php
@@ -10,7 +10,7 @@ namespace Cassandra {
      * @not-serializable
  * @scylladb-struct php_scylladb_future_close
  */    final class FutureClose implements Future {
-        public function get(int|float|null $timeout = null): mixed {}
+        public function get(int|float|null $timeout = null): null {}
 
         /** @return resource */
         public function getResource(): mixed {}

--- a/src/FuturePreparedStatement.stub.php
+++ b/src/FuturePreparedStatement.stub.php
@@ -10,7 +10,7 @@ namespace Cassandra {
      * @not-serializable
  * @scylladb-struct php_scylladb_future_prepared_statement
  */    final class FuturePreparedStatement implements Future {
-        public function get(int|float|null $timeout = null): mixed {}
+        public function get(int|float|null $timeout = null): ?PreparedStatement {}
 
         /** @return resource */
         public function getResource(): mixed {}

--- a/src/FutureRows.stub.php
+++ b/src/FutureRows.stub.php
@@ -10,7 +10,7 @@ namespace Cassandra {
      * @not-serializable
  * @scylladb-struct php_scylladb_future_rows
  */    final class FutureRows implements Future {
-        public function get(int|float|null $timeout = null): mixed {}
+        public function get(int|float|null $timeout = null): ?Rows {}
 
         /** @return resource */
         public function getResource(): mixed {}

--- a/src/FutureSession.stub.php
+++ b/src/FutureSession.stub.php
@@ -10,7 +10,7 @@ namespace Cassandra {
      * @not-serializable
  * @scylladb-struct php_scylladb_future_session
  */    final class FutureSession implements Future {
-        public function get(int|float|null $timeout = null): mixed {}
+        public function get(int|float|null $timeout = null): ?Session {}
 
         /** @return resource */
         public function getResource(): mixed {}

--- a/src/FutureValue.stub.php
+++ b/src/FutureValue.stub.php
@@ -10,7 +10,7 @@ namespace Cassandra {
      * @not-serializable
  * @scylladb-struct php_scylladb_future_value
  */    final class FutureValue implements Future {
-        public function get(int|float|null $timeout = null): mixed {}
+        public function get(int|float|null $timeout = null): Value|string|int|float|bool|null {}
 
         /** @return resource */
         public function getResource(): mixed {}

--- a/src/Map.stub.php
+++ b/src/Map.stub.php
@@ -16,24 +16,24 @@ namespace Cassandra {
         public function type(): Type {}
         public function keys(): array {}
         public function values(): array {}
-        public function set(mixed $key, mixed $value): bool {}
-        public function get(mixed $key): mixed {}
-        public function remove(mixed $key): bool {}
-        public function has(mixed $key): bool {}
+        public function set(Value|string|int|float|bool|null $key, Value|string|int|float|bool|null $value): bool {}
+        public function get(Value|string|int|float|bool|null $key): Value|string|int|float|bool|null {}
+        public function remove(Value|string|int|float|bool|null $key): bool {}
+        public function has(Value|string|int|float|bool|null $key): bool {}
 
         /* Countable */
         public function count(): int {}
 
         /* Iterator */
-        public function current(): mixed {}
-        public function key(): mixed {}
+        public function current(): Value|string|int|float|bool|null {}
+        public function key(): Value|string|int|float|bool|null {}
         public function next(): void {}
         public function valid(): bool {}
         public function rewind(): void {}
 
         /* ArrayAccess */
         public function offsetSet(mixed $offset, mixed $value): void {}
-        public function offsetGet(mixed $offset): mixed {}
+        public function offsetGet(mixed $offset): Value|string|int|float|bool|null {}
         public function offsetUnset(mixed $offset): void {}
         public function offsetExists(mixed $offset): bool {}
     }

--- a/src/Set.stub.php
+++ b/src/Set.stub.php
@@ -15,15 +15,15 @@ namespace Cassandra {
 
         public function type(): Type {}
         public function values(): array {}
-        public function add(mixed $value): bool {}
-        public function has(mixed $value): bool {}
-        public function remove(mixed $value): bool {}
+        public function add(Value|string|int|float|bool|null $value): bool {}
+        public function has(Value|string|int|float|bool|null $value): bool {}
+        public function remove(Value|string|int|float|bool|null $value): bool {}
 
         /* Countable */
         public function count(): int {}
 
         /* Iterator */
-        public function current(): mixed {}
+        public function current(): Value|string|int|float|bool|null {}
         public function key(): int {}
         public function next(): void {}
         public function valid(): bool {}

--- a/src/Tuple.stub.php
+++ b/src/Tuple.stub.php
@@ -15,14 +15,14 @@ namespace Cassandra {
 
         public function type(): Type {}
         public function values(): array {}
-        public function set(int $index, mixed $value): void {}
-        public function get(int $index): mixed {}
+        public function set(int $index, Value|string|int|float|bool|null $value): void {}
+        public function get(int $index): Value|string|int|float|bool|null {}
 
         /* Countable */
         public function count(): int {}
 
         /* Iterator */
-        public function current(): mixed {}
+        public function current(): Value|string|int|float|bool|null {}
         public function key(): int {}
         public function next(): void {}
         public function valid(): bool {}

--- a/src/Type/Collection.stub.php
+++ b/src/Type/Collection.stub.php
@@ -15,6 +15,6 @@ namespace Cassandra\Type {
         public function name(): string {}
         public function valueType(): \Cassandra\Type {}
         public function __toString(): string {}
-        public function create(mixed ...$value): \Cassandra\Collection {}
+        public function create(\Cassandra\Value|string|int|float|bool|null ...$value): \Cassandra\Collection {}
     }
 }

--- a/src/Type/Custom.stub.php
+++ b/src/Type/Custom.stub.php
@@ -14,6 +14,6 @@ namespace Cassandra\Type {
 
         public function name(): string {}
         public function __toString(): string {}
-        public function create(mixed $value = null): never {}
+        public function create(\Cassandra\Value|string|int|float|bool|null ...$args): never {}
     }
 }

--- a/src/Type/Map.stub.php
+++ b/src/Type/Map.stub.php
@@ -16,6 +16,6 @@ namespace Cassandra\Type {
         public function keyType(): \Cassandra\Type {}
         public function valueType(): \Cassandra\Type {}
         public function __toString(): string {}
-        public function create(mixed ...$value): \Cassandra\Map {}
+        public function create(\Cassandra\Value|string|int|float|bool|null ...$value): \Cassandra\Map {}
     }
 }

--- a/src/Type/Scalar.stub.php
+++ b/src/Type/Scalar.stub.php
@@ -14,6 +14,6 @@ namespace Cassandra\Type {
 
         public function name(): string {}
         public function __toString(): string {}
-        public function create(mixed $value = null): mixed {}
+        public function create(\Cassandra\Value|string|int|float|bool|null ...$args): \Cassandra\Value|string|int|float|bool|null {}
     }
 }

--- a/src/Type/Set.stub.php
+++ b/src/Type/Set.stub.php
@@ -15,6 +15,6 @@ namespace Cassandra\Type {
         public function name(): string {}
         public function valueType(): \Cassandra\Type {}
         public function __toString(): string {}
-        public function create(mixed ...$value): \Cassandra\Set {}
+        public function create(\Cassandra\Value|string|int|float|bool|null ...$value): \Cassandra\Set {}
     }
 }

--- a/src/Type/Tuple.stub.php
+++ b/src/Type/Tuple.stub.php
@@ -15,6 +15,6 @@ namespace Cassandra\Type {
         public function name(): string {}
         public function __toString(): string {}
         public function types(): array {}
-        public function create(mixed ...$values): \Cassandra\Tuple {}
+        public function create(\Cassandra\Value|string|int|float|bool|null ...$values): \Cassandra\Tuple {}
     }
 }

--- a/src/Type/Type.stub.php
+++ b/src/Type/Type.stub.php
@@ -36,6 +36,6 @@ namespace Cassandra {
         final public static function set(Type $type): \Cassandra\Type\Set {}
         final public static function map(Type $keyType, Type $valueType): \Cassandra\Type\Map {}
         final public static function tuple(Type ...$types): \Cassandra\Type\Tuple {}
-        final public static function userType(mixed ...$types): \Cassandra\Type\UserType {}
+        final public static function userType(string|Type ...$types): \Cassandra\Type\UserType {}
     }
 }

--- a/src/Type/UserType.stub.php
+++ b/src/Type/UserType.stub.php
@@ -18,6 +18,6 @@ namespace Cassandra\Type {
         public function keyspace(): ?string {}
         public function __toString(): string {}
         public function types(): array {}
-        public function create(mixed ...$value): \Cassandra\UserTypeValue {}
+        public function create(\Cassandra\Value|string|int|float|bool|null ...$value): \Cassandra\UserTypeValue {}
     }
 }

--- a/src/UserTypeValue.stub.php
+++ b/src/UserTypeValue.stub.php
@@ -15,14 +15,14 @@ namespace Cassandra {
 
         public function type(): Type {}
         public function values(): array {}
-        public function set(string $name, mixed $value): void {}
-        public function get(string $name): mixed {}
+        public function set(string $name, Value|string|int|float|bool|null $value): void {}
+        public function get(string $name): Value|string|int|float|bool|null {}
 
         /* Countable */
         public function count(): int {}
 
         /* Iterator */
-        public function current(): mixed {}
+        public function current(): Value|string|int|float|bool|null {}
         public function key(): string {}
         public function next(): void {}
         public function valid(): bool {}

--- a/tools/gen_ide_stubs.php
+++ b/tools/gen_ide_stubs.php
@@ -1,0 +1,391 @@
+<?php
+
+/**
+ * Generate IDE stubs from the src/**\/*.stub.php sources.
+ *
+ * The .stub.php files are the source of truth for the extension's PHP-visible
+ * API, but they are not usable as IDE stubs directly:
+ *
+ *   - `@cvalue` constants are declared as `= UNKNOWN`; the real values live in
+ *     cassandra.h and are only known to a loaded extension.
+ *   - `@generate-class-entries`, `@strict-properties`, `@scylladb-struct` and
+ *     friends are build-time directives that mean nothing to an IDE.
+ *
+ * This tool resolves the constants against the loaded extension and strips the
+ * build-time annotations, so PhpStorm and VS Code see the same signatures the
+ * engine registers.
+ *
+ * Usage: php -d extension=cassandra tools/gen_ide_stubs.php [output-dir]
+ */
+
+declare(strict_types=1);
+
+namespace ScyllaDB\Tools\IdeStubs;
+
+use PhpParser\Node;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitorAbstract;
+use PhpParser\ParserFactory;
+use PhpParser\PrettyPrinter;
+
+const EXTENSION = 'cassandra';
+
+require_once autoloader(dirname(__DIR__));
+
+/** Build-time annotations that carry no meaning for an IDE. */
+const INTERNAL_ANNOTATIONS = [
+    'generate-class-entries',
+    'strict-properties',
+    'not-serializable',
+    'scylladb-struct',
+    'scylladb-value-handlers',
+    'cvalue',
+    'undocumentable',
+];
+
+function main(array $argv): int
+{
+    $root = dirname(__DIR__);
+    $outDir = $argv[1] ?? $root . '/build/ide-stubs';
+
+    if (!extension_loaded(EXTENSION)) {
+        fwrite(STDERR, "gen_ide_stubs: the '" . EXTENSION . "' extension must be loaded.\n");
+        fwrite(STDERR, "Run: php -d extension=cassandra tools/gen_ide_stubs.php\n");
+
+        return 1;
+    }
+
+    $version = (string) phpversion(EXTENSION);
+    $parser = (new ParserFactory())->createForNewestSupportedVersion();
+    $printer = new PrettyPrinter\Standard(['shortArraySyntax' => true]);
+
+    $stubs = findStubs($root . '/src');
+    if ($stubs === []) {
+        fwrite(STDERR, "gen_ide_stubs: no .stub.php files found under src/.\n");
+
+        return 1;
+    }
+
+    removeTree($outDir);
+    @mkdir($outDir, 0o777, true);
+
+    $written = 0;
+    $unresolved = [];
+
+    foreach ($stubs as $stub) {
+        $ast = $parser->parse((string) file_get_contents($stub));
+        if ($ast === null) {
+            fwrite(STDERR, "gen_ide_stubs: failed to parse $stub\n");
+
+            return 1;
+        }
+
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor($visitor = new StubVisitor());
+        $ast = $traverser->traverse($ast);
+
+        $unresolved = [...$unresolved, ...$visitor->unresolved];
+
+        $relative = substr($stub, strlen($root . '/src/'));
+        $target = $outDir . '/' . preg_replace('/\.stub\.php$/', '.php', $relative);
+
+        @mkdir(dirname($target), 0o777, true);
+        file_put_contents($target, header() . ltrim(substr($printer->prettyPrintFile($ast), 5)));
+        $written++;
+    }
+
+    writePackaging($outDir, $version);
+
+    printf("gen_ide_stubs: wrote %d files to %s\n", $written, $outDir);
+
+    if ($unresolved !== []) {
+        fwrite(STDERR, "gen_ide_stubs: could not resolve " . count($unresolved) . " constant(s):\n");
+        foreach ($unresolved as $name) {
+            fwrite(STDERR, "  - $name\n");
+        }
+
+        return 1;
+    }
+
+    return verify($outDir, $parser) ? 0 : 1;
+}
+
+// ─── nodes ───────────────────────────────────────────────────────────────────
+
+final class StubVisitor extends NodeVisitorAbstract
+{
+    /** @var list<string> */
+    public array $unresolved = [];
+
+    private ?string $namespace = null;
+    private ?string $class = null;
+
+    public function enterNode(Node $node): null
+    {
+        if ($node instanceof Node\Stmt\Namespace_) {
+            $this->namespace = $node->name?->toString();
+        }
+        if ($node instanceof Node\Stmt\ClassLike && $node->name !== null) {
+            $this->class = $node->name->toString();
+        }
+
+        return null;
+    }
+
+    public function leaveNode(Node $node): null|int|Node
+    {
+        $this->stripAnnotations($node);
+
+        // `declare(strict_types=1)` has no effect in a file that never runs.
+        if ($node instanceof Node\Stmt\Declare_ && $node->stmts === null) {
+            return NodeTraverser::REMOVE_NODE;
+        }
+
+        if ($node instanceof Node\Stmt\ClassConst) {
+            $this->resolveConstants($node);
+        }
+
+        return null;
+    }
+
+    /** Replace `= UNKNOWN` placeholders with the value the extension registered. */
+    private function resolveConstants(Node\Stmt\ClassConst $node): void
+    {
+        foreach ($node->consts as $const) {
+            if (!$const->value instanceof Node\Expr\ConstFetch) {
+                continue;
+            }
+            if ($const->value->name->toString() !== 'UNKNOWN') {
+                continue;
+            }
+
+            $fqcn = $this->namespace === null || $this->namespace === ''
+                ? (string) $this->class
+                : $this->namespace . '\\' . $this->class;
+            $name = $fqcn . '::' . $const->name->toString();
+
+            if (!defined($name)) {
+                $this->unresolved[] = $name;
+                continue;
+            }
+
+            $const->value = literal(constant($name));
+        }
+    }
+
+    private function stripAnnotations(Node $node): void
+    {
+        $doc = $node->getDocComment();
+        if ($doc === null) {
+            return;
+        }
+
+        $kept = [];
+        foreach (explode("\n", $doc->getText()) as $line) {
+            if (preg_match('/@(' . implode('|', INTERNAL_ANNOTATIONS) . ')\b/', $line)) {
+                continue;
+            }
+            $kept[] = $line;
+        }
+
+        // Everything but the `/**`, the `*/` and blank `*` lines went away.
+        $meaningful = array_filter(
+            $kept,
+            static fn(string $l): bool => preg_match('#^\s*(/\*\*|\*/|\*\s*)$#', $l) !== 1,
+        );
+
+        if ($meaningful === []) {
+            $node->setAttribute('comments', []);
+
+            return;
+        }
+
+        $node->setDocComment(new \PhpParser\Comment\Doc(implode("\n", $kept)));
+    }
+}
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+function literal(mixed $value): Node\Expr
+{
+    return match (true) {
+        is_int($value) => $value < 0
+            ? new Node\Expr\UnaryMinus(new Node\Scalar\Int_(-$value))
+            : new Node\Scalar\Int_($value),
+        is_float($value) => new Node\Scalar\Float_($value),
+        is_bool($value) => new Node\Expr\ConstFetch(new Node\Name($value ? 'true' : 'false')),
+        $value === null => new Node\Expr\ConstFetch(new Node\Name('null')),
+        default => new Node\Scalar\String_((string) $value),
+    };
+}
+
+function header(): string
+{
+    return "<?php\n\n"
+        . "/**\n"
+        . " * IDE stubs for the ScyllaDB PHP driver (ext-" . EXTENSION . ").\n"
+        . " *\n"
+        . " * Generated from the extension's .stub.php sources by tools/gen_ide_stubs.php.\n"
+        . " * Do not edit. These declarations exist for editor completion only; the real\n"
+        . " * implementations live in the compiled extension.\n"
+        . " */\n\n";
+}
+
+/** @return list<string> */
+function findStubs(string $dir): array
+{
+    $found = [];
+    $it = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($dir));
+    foreach ($it as $file) {
+        if ($file->isFile() && str_ends_with($file->getFilename(), '.stub.php')) {
+            $found[] = $file->getPathname();
+        }
+    }
+    sort($found);
+
+    return $found;
+}
+
+function autoloader(string $root): string
+{
+    $vendored = $root . '/tools/gen_stub/PHP-Parser-5.6.1/lib/PhpParser/Internal/TokenStream.php';
+    if (file_exists($vendored)) {
+        spl_autoload_register(static function (string $class) use ($root): void {
+            if (!str_starts_with($class, 'PhpParser\\')) {
+                return;
+            }
+            $path = $root . '/tools/gen_stub/PHP-Parser-5.6.1/lib/'
+                . str_replace('\\', '/', $class) . '.php';
+            if (file_exists($path)) {
+                require_once $path;
+            }
+        });
+
+        return $root . '/tools/gen_ide_stubs.php';
+    }
+
+    return $root . '/vendor/autoload.php';
+}
+
+function removeTree(string $dir): void
+{
+    if (!is_dir($dir)) {
+        return;
+    }
+    $it = new \RecursiveIteratorIterator(
+        new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+        \RecursiveIteratorIterator::CHILD_FIRST,
+    );
+    foreach ($it as $file) {
+        $file->isDir() ? @rmdir($file->getPathname()) : @unlink($file->getPathname());
+    }
+    @rmdir($dir);
+}
+
+function writePackaging(string $outDir, string $version): void
+{
+    $composer = [
+        'name' => 'scylladb/php-driver-stubs',
+        'description' => 'IDE stubs for the ScyllaDB PHP driver (ext-cassandra).',
+        'license' => 'Apache-2.0',
+        'type' => 'library',
+        'keywords' => ['scylladb', 'cassandra', 'stubs', 'ide', 'phpstorm', 'static analysis'],
+        'require' => ['php' => '>=8.3'],
+    ];
+
+    file_put_contents(
+        $outDir . '/composer.json',
+        json_encode($composer, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n",
+    );
+
+    $readme = <<<MD
+        # ScyllaDB PHP driver — IDE stubs
+
+        Editor completion and static-analysis data for `ext-cassandra` version {$version}.
+        The files declare the extension's classes, methods and constants. They contain
+        no implementation — load the real extension to run code.
+
+        ## Install with Composer
+
+            composer require --dev scylladb/php-driver-stubs
+
+        The package declares no autoloader, so it cannot shadow the real extension at
+        runtime. PhpStorm and VS Code index `vendor/` and pick the stubs up on their own.
+
+        ## Install by hand
+
+        Unpack the archive somewhere in your project and point your editor at it.
+
+        - **PhpStorm** — *Settings → PHP → Include Path*, then add the directory.
+        - **VS Code (Intelephense)** — add the directory to `intelephense.environment.includePaths`.
+
+        ## Static analysis
+
+        PHPStan and Psalm read the stubs through Composer. To point them at an unpacked
+        copy instead, add the directory to `scanDirectories` (PHPStan) or `<stubs>`
+        (Psalm).
+
+        Generated from the extension's `.stub.php` sources. Do not edit by hand.
+        MD;
+
+    file_put_contents($outDir . '/README.md', $readme . "\n");
+}
+
+/**
+ * Compare what the loaded extension registers against what the stubs declare.
+ * A gap means the stubs drifted from the C sources.
+ */
+function verify(string $outDir, \PhpParser\Parser $parser): bool
+{
+    $declared = [];
+    $it = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($outDir));
+    foreach ($it as $file) {
+        if (!$file->isFile() || $file->getExtension() !== 'php') {
+            continue;
+        }
+        $ast = $parser->parse((string) file_get_contents($file->getPathname())) ?? [];
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor($collector = new class extends NodeVisitorAbstract {
+            /** @var list<string> */
+            public array $names = [];
+            private string $ns = '';
+
+            public function enterNode(Node $node): null
+            {
+                if ($node instanceof Node\Stmt\Namespace_) {
+                    $this->ns = $node->name?->toString() ?? '';
+                }
+                if ($node instanceof Node\Stmt\ClassLike && $node->name !== null) {
+                    $this->names[] = ltrim($this->ns . '\\' . $node->name->toString(), '\\');
+                }
+
+                return null;
+            }
+        });
+        $traverser->traverse($ast);
+        $declared = [...$declared, ...$collector->names];
+    }
+
+    $declaredLower = array_map(strtolower(...), $declared);
+    $actual = (new \ReflectionExtension(EXTENSION))->getClassNames();
+
+    $missing = array_values(array_filter(
+        $actual,
+        static fn(string $c): bool => !in_array(strtolower($c), $declaredLower, true),
+    ));
+
+    if ($missing !== []) {
+        fwrite(STDERR, "gen_ide_stubs: " . count($missing) . " class(es) exposed by the extension but absent from the stubs:\n");
+        foreach ($missing as $class) {
+            fwrite(STDERR, "  - $class\n");
+        }
+
+        return false;
+    }
+
+    printf("gen_ide_stubs: verified %d classes against the loaded extension\n", count($actual));
+
+    return true;
+}
+
+exit(main($argv));


### PR DESCRIPTION
## What this does

Narrows `mixed` across the stub files, fixes two crashes found while verifying the narrowing, and ships IDE stubs with each release.

## Type narrowing

The stubs were already fully typed — nothing was missing. But 71 declarations were `mixed`, which gives opcache and the JIT nothing to work with. 53 of them are now precise.

The value union is `Value|string|int|float|bool|null`, derived from `ResultDecoder.c`: a decoded Cassandra value is a string, int, bool, float, null, or one of 19 objects, and all 19 implement `Value`.

Highlights:

| Method | Before | After |
|---|---|---|
| `FutureRows::get()` | `mixed` | `?Rows` |
| `FutureSession::get()` | `mixed` | `?Session` |
| `FuturePreparedStatement::get()` | `mixed` | `?PreparedStatement` |
| `FutureClose::get()` | `mixed` | `null` |
| `Rows::current()` / `first()` / `offsetGet()` | `mixed` | `?array` |
| `Rows::key()` | `mixed` | `?int` |
| `Map`/`Set`/`Collection`/`Tuple` accessors | `mixed` | value union |
| `Keyspace::function()` / `aggregate()` `$types` | `mixed` | `string\|Type` |

### Why narrowing input parameters is safe

The engine computes `should_throw` from arginfo *before* the handler runs, then raises a fatal `Arginfo / zpp mismatch` if the handler returns without throwing ([`zend_execute.c`](https://github.com/php/php-src/blob/master/Zend/zend_execute.c), `zend_internal_call_should_throw`). The comment there is explicit: *"In release builds, we trust that arginfo matches what is enforced by zend_parse_parameters."*

This is safe here because `php_scylladb_validate_object` throws on **every** value outside the union and accepts a strict subset of it — so no accepted value can fall outside the declared type, and the check can never fire.

**No BC break.** An `array` or foreign object still raises `Cassandra\Exception\InvalidArgumentException`, not `TypeError`, because the C handler throws before the engine's check. Verified directly.

### What stays `mixed`, and why

18 declarations remain, each one forced:

- **10 `ArrayAccess`/`Iterator` parameters** — parameter types are contravariant, so narrowing is a fatal error at class registration. Confirmed: `Declaration of T::offsetExists(int $o) must be compatible with ArrayAccess::offsetExists(mixed $offset)`.
- **7 `getResource()` / `Reactor::resource()` returns** — PHP has no `resource` type declaration.
- **`Future::get()` on the interface** — its implementations return genuinely different types, so `mixed` is the correct supertype.

## Bug fixes

Both found while verifying the narrowing, and both confirmed pre-existing on `trunk` by stashing these changes and reproducing on a clean build.

1. **`php_scylladb_duration_init` — type-confused write.** It called `PHP_SCYLLADB_GET_DURATION(getThis())` unconditionally, but through `Type\Scalar::create()` `$this` is a `Type\Scalar`, so the macro applied the Duration offset to a Scalar and wrote past the object. `Type::duration()->create(1,2,3)` returned `null`.
2. **`php_scylladb_timeuuid_init` — SIGSEGV.** It allocated only when `return_value` was `IS_UNDEF`, but the VM pre-initializes it to `IS_NULL`, so `Z_OBJ_P` dereferenced a null zval. `Type::timeuuid()->create(1)` crashed with exit 139.

Both now use the same guard `php_scylladb_uuid_init` and `php_scylladb_bigint_init` already use. All 21 scalar types build correctly through `create()`.

Two related corrections:

- **`Type\Scalar::create()` arity.** Arginfo declared 1 parameter while the `duration` branch parses up to 3 and `timestamp` up to 2 — a guaranteed `Arginfo / zpp mismatch` fatal on debug builds. Now variadic, so each branch enforces its own arity.
- **`bool|false`** on three `Table` interfaces. PHP rejects it as a redundant union. The type is `bool`.

## IDE stubs

`tools/gen_ide_stubs.php` generates a stub package from the `.stub.php` sources. It resolves `@cvalue` `UNKNOWN` constants against a loaded extension (a plain copy would ship `CONSISTENCY_ANY = UNKNOWN`), strips build-time annotations, and keeps documentation comments.

It **verifies its output against `ReflectionExtension`** and fails if the extension registers a class no stub declares. That check immediately found `Cassandra\Custom`, registered by hand in `src/Custom.c` with no stub — hence the new declaration-only `src/Custom.stub.php`. All classes now match.

The release workflow gains an `ide-stubs` job that builds the extension once (needed to resolve constants) and attaches `ide-stubs-v<version>.tar.gz`.

## Reviewer notes

- **`Cassandra\Float` cannot be declared in valid PHP.** `float` is reserved as a class name in every namespace, so only C registration can create it, and `Numbers/Float.php` fails `php -l`. PhpStorm, Intelephense, PHPStan and Psalm all parse it, and the package declares no autoloader so it never loads at runtime. This is a permanent wart, not something this PR introduces.
- `*_arginfo.h` is build-generated and gitignored (`.gitignore:65-66`), so nothing regenerated is committed here. **`CLAUDE.md` still says to commit those files** — that instruction is stale and worth correcting separately.

## Testing

`980 passed, 0 failed` (13360 assertions) on PHP 8.5 NTS against a live ScyllaDB container. Also verified by reflection that every narrowed signature is what the engine actually registers, and swept all 21 scalar `create()` paths.

Note the local build is a release build, so the debug-only `Arginfo / zpp mismatch` check does not fire there — the mismatches were identified by reading `zend_execute.c` and confirmed by the arity analysis. CI debug builds will exercise it.
