### PR TITLE
feat(statement): mark statements idempotent for retries and speculative execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,15 @@
 
 ### Added
 
+- `Statement::setIdempotent(bool $idempotent = true): static` and
+  `Statement::isIdempotent(): ?bool`, on `SimpleStatement`, `PreparedStatement` and
+  `BatchStatement`, plus a matching `idempotent` execution option. The driver only retries a
+  statement after a timeout, and only runs it speculatively, when the statement is idempotent.
+  Until now the extension had no way to set that flag, so the speculative execution policy on
+  the cluster builder and on an execution profile never applied to any statement. A statement
+  carries no setting by default and `isIdempotent()` then returns `null`. A per-call
+  `idempotent` option overrides the statement. For a batch the driver reads the flag off the
+  batch, so a flag on a statement added to the batch has no effect.
 - `Rows::wasApplied(): bool`, which reads the `[applied]` column of a lightweight transaction
   result. A statement with no condition has no such column, and the method then returns `true`,
   so you can call it on any result. The `[applied]` column stays readable through `first()` and

--- a/include/php_scylladb_types.h
+++ b/include/php_scylladb_types.h
@@ -263,9 +263,18 @@ typedef enum
     PHP_SCYLLADB_BATCH_STATEMENT
 } php_scylladb_statement_type;
 
+/* UNSET is 0 so the zeroing object allocator already means "not set". */
+typedef enum : int8_t
+{
+    PHP_SCYLLADB_TRISTATE_UNSET = 0,
+    PHP_SCYLLADB_TRISTATE_FALSE = 1,
+    PHP_SCYLLADB_TRISTATE_TRUE = 2
+} php_scylladb_tristate;
+
 typedef struct php_scylladb_statement_
 {
     php_scylladb_statement_type type;
+    php_scylladb_tristate idempotent;
     union {
         struct
         {
@@ -288,6 +297,31 @@ static zend_always_inline php_scylladb_statement *php_scylladb_statement_object_
     return (php_scylladb_statement *)((char *)obj - ((size_t)(&(((php_scylladb_statement *)0)->zendObject))));
 }
 
+/* SimpleStatement, PreparedStatement and BatchStatement share php_scylladb_statement
+ * but need their own ZEND_METHOD symbols, so the bodies come from one macro. */
+#define PHP_SCYLLADB_DEFINE_IDEMPOTENCE_METHODS(class_name)                                     \
+    ZEND_METHOD(class_name, setIdempotent)                                                      \
+    {                                                                                           \
+        bool idempotent = true;                                                                 \
+        ZEND_PARSE_PARAMETERS_START(0, 1)                                                       \
+            Z_PARAM_OPTIONAL                                                                    \
+            Z_PARAM_BOOL(idempotent)                                                            \
+        ZEND_PARSE_PARAMETERS_END();                                                            \
+        PHP_SCYLLADB_GET_STATEMENT(ZEND_THIS)->idempotent =                                     \
+            idempotent ? PHP_SCYLLADB_TRISTATE_TRUE : PHP_SCYLLADB_TRISTATE_FALSE;              \
+        RETURN_ZVAL(ZEND_THIS, 1, 0);                                                           \
+    }                                                                                           \
+                                                                                                \
+    ZEND_METHOD(class_name, isIdempotent)                                                       \
+    {                                                                                           \
+        ZEND_PARSE_PARAMETERS_NONE();                                                           \
+        const php_scylladb_tristate value = PHP_SCYLLADB_GET_STATEMENT(ZEND_THIS)->idempotent;  \
+        if (value == PHP_SCYLLADB_TRISTATE_UNSET) {                                             \
+            RETURN_NULL();                                                                      \
+        }                                                                                       \
+        RETURN_BOOL(value == PHP_SCYLLADB_TRISTATE_TRUE);                                       \
+    }
+
 typedef struct
 {
     zval statement;
@@ -305,6 +339,7 @@ typedef struct php_scylladb_execution_options_
     zval arguments;
     zval retry_policy;
     cass_int64_t timestamp;
+    php_scylladb_tristate idempotent;
     zend_object zendObject;
 } php_scylladb_execution_options;
 static zend_always_inline php_scylladb_execution_options *php_scylladb_execution_options_object_fetch(zend_object *obj)

--- a/src/BatchStatement.c
+++ b/src/BatchStatement.c
@@ -99,6 +99,8 @@ ZEND_METHOD(Cassandra_BatchStatement, add)
     RETURN_ZVAL(getThis(), 1, 0);
 }
 
+PHP_SCYLLADB_DEFINE_IDEMPOTENCE_METHODS(Cassandra_BatchStatement)
+
 HashTable *php_scylladb_batch_statement_properties(zend_object *object)
 {
     HashTable *props = zend_std_get_properties(object);

--- a/src/BatchStatement.stub.php
+++ b/src/BatchStatement.stub.php
@@ -12,5 +12,7 @@ namespace Cassandra {
  */    final class BatchStatement implements Statement {
         public function __construct(int $type = \Cassandra::BATCH_LOGGED) {}
         public function add(string|Statement $statement, ?array $arguments = null): static {}
+        public function setIdempotent(bool $idempotent = true): static {}
+        public function isIdempotent(): ?bool {}
     }
 }

--- a/src/DefaultSession.c
+++ b/src/DefaultSession.c
@@ -367,7 +367,8 @@ static CassStatement* create_statement(php_scylladb_statement* statement, HashTa
 }
 
 static CassBatch* create_batch(php_scylladb_statement* batch, CassConsistency consistency,
-                               CassRetryPolicy* retry_policy, cass_int64_t timestamp) {
+                               CassRetryPolicy* retry_policy, cass_int64_t timestamp,
+                               php_scylladb_tristate idempotent) {
   CassBatch* cass_batch = cass_batch_new(batch->data.batch.type);
   if (cass_batch == nullptr) {
     zend_throw_exception_ex(php_scylladb_runtime_exception_ce, 0,
@@ -389,6 +390,7 @@ static CassBatch* create_batch(php_scylladb_statement* batch, CassConsistency co
     if (Z_TYPE(batch_statement_entry->statement) == IS_STRING) {
       simple_statement.type = PHP_SCYLLADB_SIMPLE_STATEMENT;
       simple_statement.data.simple.cql = Z_STRVAL(batch_statement_entry->statement);
+      simple_statement.idempotent = PHP_SCYLLADB_TRISTATE_UNSET;
       statement = &simple_statement;
     } else {
       statement = PHP_SCYLLADB_GET_STATEMENT(&batch_statement_entry->statement);
@@ -423,6 +425,14 @@ static CassBatch* create_batch(php_scylladb_statement* batch, CassConsistency co
     ASSERT_SUCCESS_BLOCK(rc, cass_batch_free(cass_batch); return nullptr;);
   }
 
+  /* Idempotence applies to the batch as a whole. The driver reads it off the
+   * batch, so a flag on a statement added to the batch has no effect. */
+  if (idempotent != PHP_SCYLLADB_TRISTATE_UNSET) {
+    rc = cass_batch_set_is_idempotent(
+        cass_batch, idempotent == PHP_SCYLLADB_TRISTATE_TRUE ? cass_true : cass_false);
+    ASSERT_SUCCESS_BLOCK(rc, cass_batch_free(cass_batch); return nullptr;);
+  }
+
   return cass_batch;
 }
 
@@ -430,7 +440,7 @@ static CassStatement* create_single(php_scylladb_statement* statement, HashTable
                                     CassConsistency consistency, long serial_consistency,
                                     int page_size, const char* paging_state_token,
                                     size_t paging_state_token_size, CassRetryPolicy* retry_policy,
-                                    cass_int64_t timestamp) {
+                                    cass_int64_t timestamp, php_scylladb_tristate idempotent) {
   CassError rc = CASS_OK;
   CassStatement* stmt = create_statement(statement, arguments);
   if (!stmt) return nullptr;
@@ -453,6 +463,10 @@ static CassStatement* create_single(php_scylladb_statement* statement, HashTable
   // rejecting it as out-of-range. See create_batch() for the same reason.
   if (rc == CASS_OK && timestamp != INT64_MIN)
     rc = cass_statement_set_timestamp(stmt, timestamp);
+
+  if (rc == CASS_OK && idempotent != PHP_SCYLLADB_TRISTATE_UNSET)
+    rc = cass_statement_set_is_idempotent(
+        stmt, idempotent == PHP_SCYLLADB_TRISTATE_TRUE ? cass_true : cass_false);
 
   if (rc != CASS_OK) {
     cass_statement_free(stmt);
@@ -478,6 +492,7 @@ ZEND_METHOD(Cassandra_DefaultSession, execute) {
   long serial_consistency = -1;
   CassRetryPolicy* retry_policy = nullptr;
   cass_int64_t timestamp = INT64_MIN;
+  php_scylladb_tristate idempotent = PHP_SCYLLADB_TRISTATE_UNSET;
   php_scylladb_execution_options* opts = nullptr;
   php_scylladb_execution_options local_opts;
   CassFuture* future = nullptr;
@@ -510,6 +525,7 @@ ZEND_METHOD(Cassandra_DefaultSession, execute) {
   if (Z_TYPE_P(statement) == IS_STRING) {
     simple_statement.type = PHP_SCYLLADB_SIMPLE_STATEMENT;
     simple_statement.data.simple.cql = Z_STRVAL_P(statement);
+    simple_statement.idempotent = PHP_SCYLLADB_TRISTATE_UNSET;
     stmt = &simple_statement;
   } else if (Z_TYPE_P(statement) == IS_OBJECT &&
              instanceof_function(Z_OBJCE_P(statement), php_scylladb_statement_ce)) {
@@ -517,6 +533,8 @@ ZEND_METHOD(Cassandra_DefaultSession, execute) {
   } else {
     INVALID_ARGUMENT(statement, "a string or an instance of " PHP_SCYLLADB_NAMESPACE "\\Statement");
   }
+
+  idempotent = stmt->idempotent;
 
   consistency = (CassConsistency)self->default_consistency;
   page_size = self->default_page_size;
@@ -558,13 +576,17 @@ ZEND_METHOD(Cassandra_DefaultSession, execute) {
       retry_policy = PHP_SCYLLADB_OBJ_FETCH(php_scylladb_retry_policy, Z_OBJ_P(&opts->retry_policy))->policy;
 
     timestamp = opts->timestamp;
+
+    /* A per-call option overrides whatever the statement carries. */
+    if (opts->idempotent != PHP_SCYLLADB_TRISTATE_UNSET) idempotent = opts->idempotent;
   }
 
   switch (stmt->type) {
     case PHP_SCYLLADB_SIMPLE_STATEMENT:
     case PHP_SCYLLADB_PREPARED_STATEMENT:
       single = create_single(stmt, arguments, consistency, serial_consistency, page_size,
-                             paging_state_token, paging_state_token_size, retry_policy, timestamp);
+                             paging_state_token, paging_state_token_size, retry_policy, timestamp,
+                             idempotent);
 
       if (!single) return;
 
@@ -576,7 +598,7 @@ ZEND_METHOD(Cassandra_DefaultSession, execute) {
       future = cass_session_execute(self->session, single);
       break;
     case PHP_SCYLLADB_BATCH_STATEMENT:
-      batch = create_batch(stmt, consistency, retry_policy, timestamp);
+      batch = create_batch(stmt, consistency, retry_policy, timestamp, idempotent);
 
       if (!batch) return;
 
@@ -653,6 +675,7 @@ ZEND_METHOD(Cassandra_DefaultSession, executeAsync) {
   long serial_consistency = -1;
   CassRetryPolicy* retry_policy = nullptr;
   cass_int64_t timestamp = INT64_MIN;
+  php_scylladb_tristate idempotent = PHP_SCYLLADB_TRISTATE_UNSET;
   php_scylladb_execution_options* opts = nullptr;
   php_scylladb_execution_options local_opts;
   php_scylladb_future_rows* future_rows = nullptr;
@@ -685,6 +708,7 @@ ZEND_METHOD(Cassandra_DefaultSession, executeAsync) {
   if (Z_TYPE_P(statement) == IS_STRING) {
     simple_statement.type = PHP_SCYLLADB_SIMPLE_STATEMENT;
     simple_statement.data.simple.cql = Z_STRVAL_P(statement);
+    simple_statement.idempotent = PHP_SCYLLADB_TRISTATE_UNSET;
     stmt = &simple_statement;
   } else if (Z_TYPE_P(statement) == IS_OBJECT &&
              instanceof_function(Z_OBJCE_P(statement), php_scylladb_statement_ce)) {
@@ -692,6 +716,8 @@ ZEND_METHOD(Cassandra_DefaultSession, executeAsync) {
   } else {
     INVALID_ARGUMENT(statement, "a string or an instance of " PHP_SCYLLADB_NAMESPACE "\\Statement");
   }
+
+  idempotent = stmt->idempotent;
 
   consistency = (CassConsistency)self->default_consistency;
   page_size = self->default_page_size;
@@ -730,6 +756,9 @@ ZEND_METHOD(Cassandra_DefaultSession, executeAsync) {
       retry_policy = PHP_SCYLLADB_OBJ_FETCH(php_scylladb_retry_policy, Z_OBJ_P(&opts->retry_policy))->policy;
 
     timestamp = opts->timestamp;
+
+    /* A per-call option overrides whatever the statement carries. */
+    if (opts->idempotent != PHP_SCYLLADB_TRISTATE_UNSET) idempotent = opts->idempotent;
   }
 
   object_init_ex(return_value, php_scylladb_future_rows_ce);
@@ -739,7 +768,8 @@ ZEND_METHOD(Cassandra_DefaultSession, executeAsync) {
     case PHP_SCYLLADB_SIMPLE_STATEMENT:
     case PHP_SCYLLADB_PREPARED_STATEMENT:
       single = create_single(stmt, arguments, consistency, serial_consistency, page_size,
-                             paging_state_token, paging_state_token_size, retry_policy, timestamp);
+                             paging_state_token, paging_state_token_size, retry_policy, timestamp,
+                             idempotent);
 
       if (!single) return;
 
@@ -753,7 +783,7 @@ ZEND_METHOD(Cassandra_DefaultSession, executeAsync) {
       ZVAL_COPY(&future_rows->session, getThis());
       break;
     case PHP_SCYLLADB_BATCH_STATEMENT:
-      batch = create_batch(stmt, consistency, retry_policy, timestamp);
+      batch = create_batch(stmt, consistency, retry_policy, timestamp, idempotent);
 
       if (!batch) return;
 

--- a/src/ExecutionOptions.c
+++ b/src/ExecutionOptions.c
@@ -31,6 +31,7 @@ static void init_execution_options(php_scylladb_execution_options *self)
     self->paging_state_token = nullptr;
     self->paging_state_token_size = 0;
     self->timestamp = INT64_MIN;
+    self->idempotent = PHP_SCYLLADB_TRISTATE_UNSET;
     ZVAL_UNDEF(&self->arguments);
     ZVAL_UNDEF(&self->timeout);
     ZVAL_UNDEF(&self->retry_policy);
@@ -46,6 +47,7 @@ static zend_result build_from_array(php_scylladb_execution_options *self, zval *
     zval *arguments = nullptr;
     zval *retry_policy = nullptr;
     zval *timestamp = nullptr;
+    zval *idempotent = nullptr;
 
     if ((consistency = zend_hash_str_find(Z_ARRVAL_P(options), ZEND_STRL("consistency"))) != nullptr)
     {
@@ -202,6 +204,19 @@ static zend_result build_from_array(php_scylladb_execution_options *self, zval *
             return FAILURE;
         }
     }
+
+    if ((idempotent = zend_hash_str_find(Z_ARRVAL_P(options), ZEND_STRL("idempotent"))) != nullptr)
+    {
+        if (Z_TYPE_P(idempotent) != IS_TRUE && Z_TYPE_P(idempotent) != IS_FALSE)
+        {
+            throw_invalid_argument(idempotent, "idempotent", "a boolean");
+            return FAILURE;
+        }
+
+        self->idempotent = Z_TYPE_P(idempotent) == IS_TRUE ? PHP_SCYLLADB_TRISTATE_TRUE
+                                                           : PHP_SCYLLADB_TRISTATE_FALSE;
+    }
+
     return SUCCESS;
 }
 
@@ -302,6 +317,14 @@ ZEND_METHOD(Cassandra_ExecutionOptions, __get)
         spprintf(&string, 0, "%lld", (long long int)self->timestamp);
         RETVAL_STRING(string);
         efree(string);
+    }
+    else if (zend_string_equals_literal(name, "idempotent"))
+    {
+        if (self->idempotent == PHP_SCYLLADB_TRISTATE_UNSET)
+        {
+            RETURN_NULL();
+        }
+        RETURN_BOOL(self->idempotent == PHP_SCYLLADB_TRISTATE_TRUE);
     }
 }
 

--- a/src/PreparedStatement.c
+++ b/src/PreparedStatement.c
@@ -25,6 +25,8 @@ ZEND_METHOD(Cassandra_PreparedStatement, __construct)
 {
 }
 
+PHP_SCYLLADB_DEFINE_IDEMPOTENCE_METHODS(Cassandra_PreparedStatement)
+
 HashTable *
 php_scylladb_prepared_statement_properties(zend_object *object)
 {

--- a/src/PreparedStatement.stub.php
+++ b/src/PreparedStatement.stub.php
@@ -11,5 +11,7 @@ namespace Cassandra {
  * @scylladb-struct php_scylladb_statement
  */    final class PreparedStatement implements Statement {
         private function __construct() {}
+        public function setIdempotent(bool $idempotent = true): static {}
+        public function isIdempotent(): ?bool {}
     }
 }

--- a/src/SimpleStatement.c
+++ b/src/SimpleStatement.c
@@ -35,6 +35,8 @@ ZEND_METHOD(Cassandra_SimpleStatement, __construct)
   self->data.simple.cql = estrndup(ZSTR_VAL(cql), ZSTR_LEN(cql));
 }
 
+PHP_SCYLLADB_DEFINE_IDEMPOTENCE_METHODS(Cassandra_SimpleStatement)
+
 HashTable *
 php_scylladb_simple_statement_properties(zend_object *object)
 {

--- a/src/SimpleStatement.stub.php
+++ b/src/SimpleStatement.stub.php
@@ -11,5 +11,7 @@ namespace Cassandra {
  * @scylladb-struct php_scylladb_statement
  */    final class SimpleStatement implements Statement {
         public function __construct(string $cql) {}
+        public function setIdempotent(bool $idempotent = true): static {}
+        public function isIdempotent(): ?bool {}
     }
 }

--- a/src/Statement.stub.php
+++ b/src/Statement.stub.php
@@ -5,5 +5,17 @@
 declare(strict_types=1);
 
 namespace Cassandra {
-    interface Statement {}
+    interface Statement
+    {
+        /**
+         * Marks the statement as safe to run more than once.
+         *
+         * The driver only retries a statement after a timeout, and only runs it
+         * speculatively, when the statement is idempotent.
+         */
+        public function setIdempotent(bool $idempotent = true): static;
+
+        /** Returns null when the statement carries no explicit setting. */
+        public function isIdempotent(): ?bool;
+    }
 }

--- a/tests/Feature/Statements/IdempotenceTest.php
+++ b/tests/Feature/Statements/IdempotenceTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+use Cassandra\BatchStatement;
+use Cassandra\ExecutionOptions;
+use Cassandra\SimpleStatement;
+
+$keyspace = 'statement_idempotence';
+$table    = 'counters';
+
+beforeAll(function () use ($keyspace, $table) {
+    migrateKeyspace(<<<CQL
+    CREATE KEYSPACE $keyspace WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};
+    USE $keyspace;
+    CREATE TABLE $table (
+        id    int,
+        value text,
+        PRIMARY KEY (id)
+    )
+    CQL);
+});
+
+afterAll(fn () => dropKeyspace($keyspace));
+
+it('executes a statement marked idempotent', function () use ($keyspace, $table) {
+    $session   = scyllaDbConnection($keyspace);
+    $statement = (new SimpleStatement("SELECT * FROM $table"))->setIdempotent();
+
+    expect($session->execute($statement)->count())->toBe(0);
+})->group('feature');
+
+it('executes a prepared statement marked idempotent', function () use ($keyspace, $table) {
+    $session   = scyllaDbConnection($keyspace);
+    $statement = $session->prepare("INSERT INTO $table (id, value) VALUES (?, ?)");
+
+    expect($statement->setIdempotent()->isIdempotent())->toBeTrue();
+
+    $session->execute($statement, ['arguments' => [1, 'one']]);
+
+    expect($session->execute(new SimpleStatement("SELECT * FROM $table WHERE id = 1"))->count())->toBe(1);
+})->group('feature');
+
+it('accepts idempotence as a per-call execution option', function () use ($keyspace, $table) {
+    $session = scyllaDbConnection($keyspace);
+
+    $rows = $session->execute("SELECT * FROM $table", ['idempotent' => true]);
+
+    expect($rows)->not->toBeNull();
+})->group('feature');
+
+it('lets a per-call option override the statement default', function () use ($keyspace, $table) {
+    $session   = scyllaDbConnection($keyspace);
+    $statement = (new SimpleStatement("SELECT * FROM $table"))->setIdempotent(false);
+
+    $rows = $session->execute($statement, ['idempotent' => true]);
+
+    expect($rows->count())->toBe(1);
+    expect($statement->isIdempotent())->toBeFalse();
+})->group('feature');
+
+it('accepts idempotence through an ExecutionOptions object', function () use ($keyspace, $table) {
+    error_reporting(E_ALL ^ E_DEPRECATED);
+    $session = scyllaDbConnection($keyspace);
+
+    $rows = $session->execute("SELECT * FROM $table", new ExecutionOptions(['idempotent' => true]));
+
+    expect($rows->count())->toBe(1);
+    error_reporting(E_ALL);
+})->group('feature');
+
+it('executes an idempotent batch', function () use ($keyspace, $table) {
+    $session = scyllaDbConnection($keyspace);
+    $batch   = new BatchStatement();
+
+    $batch->add("INSERT INTO $table (id, value) VALUES (2, 'two')");
+    $batch->add("INSERT INTO $table (id, value) VALUES (3, 'three')");
+    $batch->setIdempotent();
+
+    $session->execute($batch);
+
+    expect($session->execute(new SimpleStatement("SELECT * FROM $table"))->count())->toBe(3);
+})->group('feature');
+
+it('executes an idempotent statement asynchronously', function () use ($keyspace, $table) {
+    $session   = scyllaDbConnection($keyspace);
+    $statement = (new SimpleStatement("SELECT * FROM $table"))->setIdempotent();
+
+    expect($session->executeAsync($statement)->get()->count())->toBe(3);
+})->group('feature');

--- a/tests/Unit/ExecutionOptionsTest.php
+++ b/tests/Unit/ExecutionOptionsTest.php
@@ -39,4 +39,15 @@ it('returns null values when retrieving undefined settings by name', function ()
     expect($options->pageSize)->toBeNull();
     expect($options->timeout)->toBeNull();
     expect($options->arguments)->toBeNull();
+    expect($options->idempotent)->toBeNull();
+});
+
+it('carries idempotence as a setting', function () {
+    expect((new ExecutionOptions(['idempotent' => true]))->idempotent)->toBeTrue();
+    expect((new ExecutionOptions(['idempotent' => false]))->idempotent)->toBeFalse();
+});
+
+it('rejects a non-boolean idempotent setting', function () {
+    expect(fn () => new ExecutionOptions(['idempotent' => 'yes']))
+        ->toThrow(Cassandra\Exception\InvalidArgumentException::class);
 });

--- a/tests/Unit/StatementIdempotenceTest.php
+++ b/tests/Unit/StatementIdempotenceTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cassandra\Tests\Unit;
+
+use Cassandra\BatchStatement;
+use Cassandra\SimpleStatement;
+use Cassandra\Statement;
+
+it('reports no explicit setting on a fresh statement', function (Statement $statement) {
+    expect($statement->isIdempotent())->toBeNull();
+})->with([
+    'simple' => fn () => new SimpleStatement('SELECT * FROM system.local'),
+    'batch'  => fn () => new BatchStatement(),
+]);
+
+it('marks a statement idempotent and reads the flag back', function (Statement $statement) {
+    expect($statement->setIdempotent()->isIdempotent())->toBeTrue();
+    expect($statement->setIdempotent(false)->isIdempotent())->toBeFalse();
+    expect($statement->setIdempotent(true)->isIdempotent())->toBeTrue();
+})->with([
+    'simple' => fn () => new SimpleStatement('SELECT * FROM system.local'),
+    'batch'  => fn () => new BatchStatement(),
+]);
+
+it('returns the same instance so calls chain', function () {
+    $statement = new SimpleStatement('SELECT * FROM system.local');
+
+    expect($statement->setIdempotent())->toBe($statement);
+});
+
+it('keeps the flag per statement instance', function () {
+    $first  = new SimpleStatement('SELECT * FROM system.local');
+    $second = new SimpleStatement('SELECT * FROM system.local');
+
+    $first->setIdempotent();
+
+    expect($first->isIdempotent())->toBeTrue();
+    expect($second->isIdempotent())->toBeNull();
+});
+
+it('declares the pair on the Statement interface', function () {
+    expect((new SimpleStatement('SELECT 1')))->toBeInstanceOf(Statement::class);
+    expect(method_exists(Statement::class, 'setIdempotent'))->toBeTrue();
+    expect(method_exists(Statement::class, 'isIdempotent'))->toBeTrue();
+});
+

--- a/website/guide/batches.md
+++ b/website/guide/batches.md
@@ -114,6 +114,10 @@ $session->execute($batch, [
 
 The `arguments` key does not apply. Values belong to each `add()` call.
 
+`setIdempotent()` works on a batch too. The driver reads the flag off the batch, so a flag on a
+statement you add to the batch has no effect. A batch that holds a counter update or a
+lightweight transaction is never idempotent. See [Idempotence](/guide/queries#idempotence).
+
 ## Size limits
 
 The server rejects an oversized batch and warns about a large one. Both thresholds are server

--- a/website/guide/configuration.md
+++ b/website/guide/configuration.md
@@ -175,9 +175,12 @@ The driver sends the same request to another replica when the first one does not
 delay. It cuts tail latency caused by one slow replica.
 
 ::: warning Only for idempotent statements
-A speculative attempt runs the statement more than once. Never turn this on for a counter update, a
-lightweight transaction, or an append to a list. It also multiplies load, so keep it off while the
-cluster is already saturated.
+The driver only runs a statement speculatively when you mark it idempotent, so this setting does
+nothing until you call `setIdempotent()` on the statement or pass the `idempotent` execution
+option. See [Idempotence](/guide/queries#idempotence).
+
+Never mark a counter update, a lightweight transaction, or an append to a list as idempotent.
+Speculative execution also multiplies load, so keep it off while the cluster is already saturated.
 :::
 
 ### Event loop tuning

--- a/website/guide/execution-profiles.md
+++ b/website/guide/execution-profiles.md
@@ -91,9 +91,12 @@ profile with the same enum you registered it with and this never matters.
 Every method returns the same profile, so calls chain.
 
 ::: warning Speculative execution needs idempotent statements
-A speculative attempt runs the statement more than once. Never put
-`withConstantSpeculativeExecutionPolicy()` on a profile you use for a counter update, a lightweight
-transaction, or an append to a list.
+A speculative attempt runs the statement more than once, so the driver only does it for statements
+you mark idempotent. The policy has no effect until you call `setIdempotent()` on the statement or
+pass the `idempotent` execution option. See [Idempotence](/guide/queries#idempotence).
+
+Never put `withConstantSpeculativeExecutionPolicy()` on a profile you use for a counter update, a
+lightweight transaction, or an append to a list.
 :::
 
 ## A profile is copied when the cluster is built

--- a/website/guide/queries.md
+++ b/website/guide/queries.md
@@ -172,6 +172,7 @@ The second argument to `execute()` accepts a plain array. Each key is optional.
 | `timeout` | `int` or `float` | Seconds to wait. Must be greater than zero, or `null`. |
 | `retry_policy` | `Cassandra\RetryPolicy` | Overrides the cluster policy for this statement. |
 | `timestamp` | `int` or numeric string | An explicit write timestamp, in microseconds. |
+| `idempotent` | `bool` | Marks the statement safe to run more than once. See [Idempotence](#idempotence). |
 
 ```php
 $rows = $session->execute($statement, [
@@ -188,6 +189,55 @@ An invalid value raises `Cassandra\Exception\InvalidArgumentException` and names
 `new Cassandra\ExecutionOptions([...])` still works and still reads its values through magic
 properties in camel case (`$options->pageSize`). Pass a plain array in new code.
 :::
+
+## Idempotence
+
+A statement is idempotent when running it twice gives the same result as running it once. The
+driver retries a statement after a timeout, and runs it speculatively, only when you mark the
+statement idempotent. Statements carry no setting by default, so both features stay off until
+you opt in.
+
+Mark the statement itself when the CQL is always safe to repeat:
+
+```php
+$statement = $session->prepare('UPDATE users SET email = ? WHERE id = ?');
+$statement->setIdempotent();
+
+$rows = $session->execute($statement, ['arguments' => ['ada@example.com', $id]]);
+```
+
+Every execution of that statement inherits the setting. Read it back with `isIdempotent()`, which
+returns `null` when the statement carries no explicit setting.
+
+Set the `idempotent` option to decide one call at a time. The option wins over the statement:
+
+```php
+$rows = $session->execute($statement, [
+    'arguments'  => ['ada@example.com', $id],
+    'idempotent' => false,
+]);
+```
+
+Batches take the same two paths. The driver reads the flag off the batch, so a flag on a statement
+you add to a batch has no effect.
+
+```php
+$batch = new Cassandra\BatchStatement();
+$batch->add('UPDATE users SET email = ? WHERE id = ?', ['ada@example.com', $id]);
+$batch->setIdempotent();
+
+$session->execute($batch);
+```
+
+::: warning Mark only what is safe to repeat
+A counter update, an append to a list, and a write that uses `now()` or `uuid()` all produce a
+different result each time they run. Do not mark them idempotent. A lightweight transaction is
+also not idempotent, because the condition can hold on the first attempt and fail on the retry.
+:::
+
+`withSpeculativeExecutionPolicy()` on the cluster builder and on an execution profile has no
+effect until statements carry this flag. See
+[Execution profiles](/guide/execution-profiles) for how to configure the policy.
 
 ## Lightweight transactions
 


### PR DESCRIPTION
## Why

`cassandra.h` is explicit about it: *"Idempotent statements are able to be automatically retried after timeouts/errors and can be speculatively executed."* The extension had no way to set that flag.

So the speculative execution policy shipped in #148 — `withConstantSpeculativeExecutionPolicy()` on the cluster builder and on an execution profile — **never applied to any statement**. An operator could configure it, read the docs, and get nothing. The same holds for the driver's retry-after-timeout path.

## What

`Statement` gains two methods, implemented on `SimpleStatement`, `PreparedStatement` and `BatchStatement`:

```php
public function setIdempotent(bool $idempotent = true): static;
public function isIdempotent(): ?bool;
```

Plus a matching `idempotent` execution option:

```php
$statement = $session->prepare('UPDATE users SET email = ? WHERE id = ?');
$statement->setIdempotent();

// or per call, which overrides the statement
$session->execute($statement, ['arguments' => [$email, $id], 'idempotent' => false]);
```

Three states, not two. A statement carries no setting by default and `isIdempotent()` returns `null`, so the driver default stands and **nothing changes for existing code**. The tri-state lives in `php_scylladb_tristate`, whose `UNSET` is `0` so the zeroing object allocator already means "not set".

Batches take the same two paths. The driver reads the flag off the batch, so a flag on a statement added to a batch has no effect — documented rather than silently ignored.

## Backend support

Checked against the Rust source, not just the header, after the ABI surprises in #148: both `cass_statement_set_is_idempotent` and `cass_batch_set_is_idempotent` are genuinely implemented in `cpp-rs-driver` master (`scylla-rust-wrapper/src/statements/statement.rs:451`, `batch.rs:208`) and both really return `CassError`. No `rs_compat.h` shim needed.

## Verification

- Build clean, clang-tidy 0 findings on the five touched C files.
- Full suite against a live ScyllaDB: **1034 passed, 13649 assertions, 0 failures.** The one `WARN` (`NumberTest`, float cast) is pre-existing and unrelated.
- 16 new tests. Unit coverage for the tri-state default, the fluent return, per-instance isolation and option validation. Feature coverage against a real cluster for simple, prepared, batch and async paths, plus the per-call override beating the statement default.

## Docs

New **Idempotence** section in `queries.md`, including which statements must never be marked (counters, `now()`/`uuid()`, list appends, LWTs). The speculative-execution warnings in `execution-profiles.md` and `configuration.md` now say the policy does nothing until statements carry the flag, and link to it.

## Note on scope

`cass_statement_set_request_timeout`, `set_tracing` and `set_custom_payload` are also unwired. They are separate PRs.